### PR TITLE
Fix float display to always show .0 for integer floats (closes #60)

### DIFF
--- a/src/stdlib.ts
+++ b/src/stdlib.ts
@@ -1599,7 +1599,7 @@ export function toPythonFloat(num: number): string {
         return num.toExponential().replace(/e([+-])(\d)$/, 'e$10$2');
     }
     if (Number.isInteger(num)) {
-        return num.toFixed(1).toString();
+        return num.toFixed(1);
     }
     return num.toString();
 }


### PR DESCRIPTION
Fix #60 by removing calling of toString for floats