### PR TITLE
Nearley dsl

### DIFF
--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -1,5 +1,5 @@
 export { FeatureValidator, FeatureNotSupportedError, ASTNode } from "./types";
-export { traverseAST, runValidators } from "./traverse";
+export { traverseAST } from "./traverse";
 export {
   makeValidatorsForChapter,
   makeChapter1Validators,

--- a/src/validator/traverse.ts
+++ b/src/validator/traverse.ts
@@ -1,5 +1,5 @@
 import { StmtNS, ExprNS } from "../ast-types";
-import { ASTNode, FeatureValidator } from "./types";
+import { ASTNode } from "./types";
 
 /**
  * Walks the AST via instanceof dispatch and calls fn on each node.
@@ -67,21 +67,9 @@ export function traverseAST(node: ASTNode, fn: (node: ASTNode) => void): void {
   } else if (node instanceof ExprNS.Subscript) {
     traverseAST(node.value, fn);
     traverseAST(node.index, fn);
+  } else if (node instanceof ExprNS.Starred) {
+    traverseAST(node.value, fn);
   }
   // Leaf nodes: Literal, Variable, BigIntLiteral, Complex, None, Pass, Break, Continue,
   // FromImport, Global, NonLocal, Indent, Dedent — no children to traverse.
-}
-
-/**
- * Run validators over every AST node. WARNING: does not pass Environment,
- * so scope-aware validators (e.g. no-reassignment) will silently no-op.
- * Use the Resolver's inline validation for production code.
- */
-export function runValidators(ast: ASTNode, validators: FeatureValidator[]): void {
-  if (validators.length === 0) return;
-  traverseAST(ast, node => {
-    for (const v of validators) {
-      v.validate(node);
-    }
-  });
 }


### PR DESCRIPTION
**Summary:**
This pull request (Fixes #68) introduces unified **Nearley + Moo**–based parsing system. It replaces the old, fragmented setup (manual tokenizer, static grammar, separate AST DSL) with a single declarative pipeline that integrates tokenization, grammar rules, and AST generation.

**Key Improvements:**

* Adds a **Moo lexer** for tokens and keywords.
* Defines a **Nearley grammar** aligned with the existing language subset.
* Embeds **AST node generation** within grammar rules.
* Maintains compatibility with `generate-ast.ts`.
* Introduces a **build step** to compile grammar into the parser.

**Benefits:**

* Centralized source of truth for grammar (`grammar.ne` + `lexer.moo`).
* Automatic derivation of `TokenType` enums — no manual syncing.
* Deprecates `tokenizer.ts` and `Grammar.gram`.
* Easier debugging through Nearley’s readable parse trees.

**Next Steps:**

* Expand grammar to support more Python constructs (`+=`, comprehensions, etc.).
* Reassess integration with `generate-ast.ts` -> currently creates ExprNS/StmtNS objects