### PR TITLE
Add tail-call optimisations + General changes

### DIFF
--- a/docs/lib/mce.js
+++ b/docs/lib/mce.js
@@ -1,0 +1,30 @@
+/**
+ * returns the parse tree that results from parsing
+ * the string <CODE>str</CODE> as a Python program. The format
+ * of the parse tree is described in chapter 4 of
+ * the textbook
+ * in <a href="https://sourceacademy.org/sicpjs/">Structure and
+ * Interpretation of Computer Programs, JavaScript Adaptation</a> (SICP).
+ * @param {str} x - given program as a string
+ * @returns {value} parse tree
+ */
+function parse(str) {}
+
+/**
+ * returns the list of tokens that results from lexing the string <CODE>s</CODE>
+ * @param {str} s - given program as a string
+ * @returns {linked_list} linked list of tokens
+ */
+function tokenize(str) {}
+
+/**
+ * calls the function <CODE>f</CODE>
+ * with arguments given in linked list <CODE>xs</CODE>. For example: <PRE><CODE>def times(x, y):
+ *     return x * y
+ * 
+ * apply_in_underlying_python(times, list(2, 3)); # returns 6</CODE></PRE>
+ * @param {function} f - function to be applied
+ * @param {linked_list} xs - arguments given in list
+ * @returns {value} whatever <CODE>f</CODE> returns
+ */
+function apply_in_underlying_python(f, xs) {}

--- a/docs/md/README_3.md
+++ b/docs/md/README_3.md
@@ -19,13 +19,13 @@ these groups:
       <a href="../LINKED LISTS/index.html">LINKED LISTS</a>: Support for linked lists
     </li>
     <li>
-      <a href="../PAIR MUTATOR/index.html">PAIR MUTATOR</a>: Mutating pairs
+      <a href="../PAIR MUTATORS/index.html">PAIR MUTATORS</a>: Mutating pairs
     </li>
     <li>
-      <a href="../LIST/index.html">LIST</a>: Support for lists
+      <a href="../LISTS/index.html">LISTS</a>: Support for lists
     </li>
     <li>
-      <a href="../STREAM/index.html">STREAM</a>: Support for streams
+      <a href="../STREAMS/index.html">STREAMS</a>: Support for streams
     </li>
   </ul>
 

--- a/docs/md/README_4.md
+++ b/docs/md/README_4.md
@@ -19,13 +19,13 @@ these groups:
       <a href="../LINKED LISTS/index.html">LINKED LISTS</a>: Support for linked lists
     </li>
     <li>
-      <a href="../PAIR MUTATOR/index.html">PAIR MUTATOR</a>: Mutating pairs
+      <a href="../PAIR MUTATORS/index.html">PAIR MUTATORS</a>: Mutating pairs
     </li>
     <li>
-      <a href="../LIST/index.html">LIST</a>: Support for lists
+      <a href="../LISTS/index.html">LISTS</a>: Support for lists
     </li>
     <li>
-      <a href="../STREAM/index.html">STREAM</a>: Support for streams
+      <a href="../STREAMS/index.html">STREAM</a>: Support for streams
     </li>
     <li>
       <a href="../MCE/index.html">MCE</a>: Support for the meta-circular evaluator

--- a/docs/specs/python_interpreter.tex
+++ b/docs/specs/python_interpreter.tex
@@ -17,10 +17,10 @@
     of the transformation rules. Implementations are allowed to support more of Python than listed.
 \end{itemize}
 
-In addition, the Source Academy frontend predeclares the name \lstinline{__PROGRAM__} in all Python languages to
+In addition, the Source Academy frontend predeclares the name \lstinline{__program__} in all Python languages to
 refer to the string representation of the entrypoint file of the program in the editor that is being run using ``Run''.
 The entrypoint file is the file containing the code that acts as the entrypoint of the program being run.
-If \lstinline{__PROGRAM__} is used in the REPL, it refers to the string representation of the editor content
+If \lstinline{__program__} is used in the REPL, it refers to the string representation of the editor content
 at the time when ``Run'' was last pressed.
 
 \newpage

--- a/docs/specs/python_interpreter.tex
+++ b/docs/specs/python_interpreter.tex
@@ -8,16 +8,16 @@
         return x * y
     apply_in_underlying_python(times, linked_list(2, 3))  # returns 6
     \end{lstlisting}
-  \item \lstinline{tokenize(x)}: \textit{primitive}, returns the literal list of tokens that results from tokenizing
-    the string \lstinline{x} as a Source program. Each token is a string that contains the characters of
+  \item \lstinline{tokenize(x)}: \textit{primitive}, returns the literal linked list of tokens that results from tokenizing
+    the string \lstinline{x} as a Python program. Each token is a string that contains the characters of
     the token as they appear in the program. Comments are ignored.
   \item \lstinline{parse(x)}: \textit{primitive}, returns the parse tree that results from parsing
-    the string \lstinline{x} as a Source program. The following two pages describe the shape of the parse tree.
-    The tree is represented by the tagged lists on the right; the angle brackets denote recursive application
-    of the transformation rules. Implementations are allowed to support more of JavaScript than listed.
+    the string \lstinline{x} as a Python program. The following two pages describe the shape of the parse tree.
+    The tree is represented by the tagged linked lists on the right; the angle brackets denote recursive application
+    of the transformation rules. Implementations are allowed to support more of Python than listed.
 \end{itemize}
 
-In addition, the Source Academy frontend predeclares the name \lstinline{__PROGRAM__} in all Source languages to
+In addition, the Source Academy frontend predeclares the name \lstinline{__PROGRAM__} in all Python languages to
 refer to the string representation of the entrypoint file of the program in the editor that is being run using ``Run''.
 The entrypoint file is the file containing the code that acts as the entrypoint of the program being run.
 If \lstinline{__PROGRAM__} is used in the REPL, it refers to the string representation of the editor content

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,0 @@
-{
-  "watch": ["src"],
-  "ext": ".ts,.js",
-  "ignore": ["src/ast-types.ts", "src/generated-parser.ts"],
-  "exec": "npx ts-node ./src/index.ts"
-}

--- a/scripts/jsdoc.sh
+++ b/scripts/jsdoc.sh
@@ -71,13 +71,21 @@ run() {
   # STREAMS
   run_jsdoc "STREAMS" "README_STREAMS.md" "STREAMS" "$LIB/stream.js" &
 
+  # MCE
+  run_jsdoc "MCE" "README_MCE.md" "MCE" "$LIB/mce.js" &
+  
+
   # Python §1
   run_jsdoc "Python §1" "README_1.md" "python_1" "$LIB/misc.js" "$LIB/math.js" &
   
   # Python §2
   run_jsdoc "Python §2" "README_2.md" "python_2" "$LIB/misc.js" "$LIB/math.js" "$LIB/linked_list.js" &
 
+  # Python §3
   run_jsdoc "Python §3" "README_3.md" "python_3" "$LIB/misc.js" "$LIB/math.js" "$LIB/linked_list.js" "$LIB/pairmutator.js" "$LIB/list.js" "$LIB/stream.js" &
+
+  # Python §4
+  run_jsdoc "Python §4" "README_4.md" "python_4" "$LIB/misc.js" "$LIB/math.js" "$LIB/linked_list.js" "$LIB/pairmutator.js" "$LIB/list.js" "$LIB/stream.js" "$LIB/mce.js" &
 
   wait
 }

--- a/src/engines/cse/context.ts
+++ b/src/engines/cse/context.ts
@@ -30,7 +30,6 @@ export class Context {
   public errors: RuntimeSourceError[] = [];
   public moduleContexts: { [name: string]: ModuleContext };
   public prelude: string | null = null;
-
   runtime: {
     break: boolean;
     debuggerOn: boolean;

--- a/src/engines/cse/control.ts
+++ b/src/engines/cse/control.ts
@@ -10,7 +10,8 @@ export type ControlItem = Node | Instr;
  */
 export class Control extends Stack<ControlItem> {
   private numEnvDependentItems: number;
-  private numFunctionResets: number = 0;
+  private numFunctionResets: number;
+
   public constructor(program?: StmtNS.Stmt) {
     super();
     this.numEnvDependentItems = 0;

--- a/src/engines/cse/control.ts
+++ b/src/engines/cse/control.ts
@@ -1,7 +1,7 @@
 import { StmtNS } from "../../ast-types";
 import { Stack } from "./stack";
-import { Instr, Node } from "./types";
-import { isEnvDependent } from "./utils";
+import { Instr, InstrType, Node } from "./types";
+import { isEnvDependent, isInstr } from "./utils";
 
 export type ControlItem = Node | Instr;
 
@@ -10,9 +10,11 @@ export type ControlItem = Node | Instr;
  */
 export class Control extends Stack<ControlItem> {
   private numEnvDependentItems: number;
+  private numFunctionResets: number = 0;
   public constructor(program?: StmtNS.Stmt) {
     super();
     this.numEnvDependentItems = 0;
+    this.numFunctionResets = 0;
     // Load program into control stack
     if (program) this.push(program);
   }
@@ -26,10 +28,17 @@ export class Control extends Stack<ControlItem> {
     return this.numEnvDependentItems;
   }
 
+  public getNumFunctionResets(): number {
+    return this.numFunctionResets;
+  }
+
   public pop(): ControlItem | undefined {
     const item = super.pop();
     if (item !== undefined && isEnvDependent(item)) {
       this.numEnvDependentItems--;
+    }
+    if (item !== undefined && isInstr(item) && item.instrType === InstrType.RESET) {
+      this.numFunctionResets--;
     }
     return item;
   }
@@ -38,6 +47,9 @@ export class Control extends Stack<ControlItem> {
     items.forEach((item: ControlItem) => {
       if (isEnvDependent(item)) {
         this.numEnvDependentItems++;
+      }
+      if (isInstr(item) && item.instrType === InstrType.RESET) {
+        this.numFunctionResets++;
       }
     });
     super.push(...items);

--- a/src/engines/cse/environment.ts
+++ b/src/engines/cse/environment.ts
@@ -131,7 +131,7 @@ export const createProgramEnvironment = (context: Context, isPrelude: boolean): 
   return createSimpleEnvironment(
     context,
     isPrelude ? "prelude" : "programEnvironment",
-    isPrelude ? null : getPreludeEnvironment(context),
+    isPrelude ? getGlobalEnvironment(context) : (getPreludeEnvironment(context) || getGlobalEnvironment(context)),
   );
 };
 

--- a/src/engines/cse/environment.ts
+++ b/src/engines/cse/environment.ts
@@ -131,7 +131,9 @@ export const createProgramEnvironment = (context: Context, isPrelude: boolean): 
   return createSimpleEnvironment(
     context,
     isPrelude ? "prelude" : "programEnvironment",
-    isPrelude ? getGlobalEnvironment(context) : (getPreludeEnvironment(context) || getGlobalEnvironment(context)),
+    isPrelude
+      ? getGlobalEnvironment(context)
+      : getPreludeEnvironment(context) || getGlobalEnvironment(context),
   );
 };
 

--- a/src/engines/cse/interpreter.ts
+++ b/src/engines/cse/interpreter.ts
@@ -20,6 +20,7 @@ import {
   createEnvironment,
   createProgramEnvironment,
   currentEnvironment,
+  getGlobalEnvironment,
   popEnvironment,
   pushEnvironment,
 } from "./environment";
@@ -271,6 +272,11 @@ export async function* generateCSEMachineStateStream(
     context.runtime.nodes.unshift(command);
   }
 
+  // Define the program 
+  const globalEnvironment = getGlobalEnvironment(context);
+  if (globalEnvironment) {
+    pyDefineVariable(context, "__program__", { type: "string", value: code }, globalEnvironment);
+  }
   while (command) {
     // Return to capture a snapshot of the control and stash after the target step count is reached
     // if (!isPrelude && steps === envSteps) {

--- a/src/engines/cse/interpreter.ts
+++ b/src/engines/cse/interpreter.ts
@@ -1118,7 +1118,9 @@ const cmdEvaluators: CmdEvaluators = {
       }
     } else if (callable?.type === "builtin") {
       const result = await callable.func(args, code, instr.srcNode, context);
-      stash.push(result);
+      if (result) {
+        stash.push(result);
+      } 
     } else {
       handleRuntimeError(
         context,

--- a/src/engines/cse/interpreter.ts
+++ b/src/engines/cse/interpreter.ts
@@ -51,10 +51,12 @@ import {
   WhileInstr,
 } from "./types";
 import {
+  checkStackOverFlow,
   envChanging,
   evaluateForIterator,
   evaluateListAssignment,
   generateForIncrement,
+  isInstr,
   isNode,
   pyDefineVariable,
   pyGetVariable,
@@ -646,7 +648,7 @@ const cmdEvaluators: CmdEvaluators = {
     let head;
     while (true) {
       head = control.pop();
-      if (!head || ("instrType" in head && head.instrType === InstrType.RESET)) {
+      if (!head || (isInstr(head) && head.instrType === InstrType.RESET)) {
         break;
       }
     }
@@ -1063,6 +1065,19 @@ const cmdEvaluators: CmdEvaluators = {
     stash: Stash,
     _isPrelude: boolean,
   ) {
+    checkStackOverFlow(code, instr.srcNode, context, control);
+
+    // Tail-Call Optimisation
+    const topElement = control.peek();
+    if (
+      topElement !== undefined &&
+      isInstr(topElement) &&
+      topElement.instrType === InstrType.RESET
+    ) {
+      control.pop();
+      popEnvironment(context);
+    }
+
     const numOfArgs = instr.numOfArgs;
 
     const rawArgs: Value[] = [];

--- a/src/engines/cse/interpreter.ts
+++ b/src/engines/cse/interpreter.ts
@@ -272,7 +272,7 @@ export async function* generateCSEMachineStateStream(
     context.runtime.nodes.unshift(command);
   }
 
-  // Define the program 
+  // Define the program
   const globalEnvironment = getGlobalEnvironment(context);
   if (globalEnvironment) {
     pyDefineVariable(context, "__program__", { type: "string", value: code }, globalEnvironment);
@@ -1120,7 +1120,7 @@ const cmdEvaluators: CmdEvaluators = {
       const result = await callable.func(args, code, instr.srcNode, context);
       if (result) {
         stash.push(result);
-      } 
+      }
     } else {
       handleRuntimeError(
         context,

--- a/src/engines/cse/interpreter.ts
+++ b/src/engines/cse/interpreter.ts
@@ -69,6 +69,7 @@ export interface IOptions {
   envSteps: number;
   stepLimit: number;
   variant: number;
+  recursionLimit: number;
 }
 
 type CmdEvaluator<T extends ControlItem> = (
@@ -122,6 +123,7 @@ export async function evaluate(
     groups: [],
     envSteps: 100000,
     stepLimit: -1,
+    recursionLimit: 1024,
     variant: 4,
     ...(options as Partial<IOptions>),
   };
@@ -148,6 +150,7 @@ export async function evaluate(
       context.stash,
       opts.envSteps,
       opts.stepLimit,
+      opts.recursionLimit,
       opts.variant,
       opts.isPrelude,
     );
@@ -206,6 +209,7 @@ export async function evaluate(
  * @param stash Points to the current Stash.
  * @param envSteps Number of environment steps to run.
  * @param stepLimit Maximum number of steps to execute.
+ * @param recursionLimit Maximum depth of recursion allowed.
  * @param variant The language variant being executed.
  * @param isPrelude Whether the program is the prelude.
  * @returns The top value of the stash after execution.
@@ -217,6 +221,7 @@ export async function runCSEMachine(
   stash: Stash,
   envSteps: number,
   stepLimit: number,
+  recursionLimit: number,
   variant: number,
   isPrelude: boolean = false,
 ): Promise<Value> {
@@ -227,6 +232,7 @@ export async function runCSEMachine(
     stash,
     envSteps,
     stepLimit,
+    recursionLimit,
     variant,
     isPrelude,
   );
@@ -249,6 +255,7 @@ export async function runCSEMachine(
  * @param stash The stash storage.
  * @param _envSteps Number of environment steps to run.
  * @param stepLimit Maximum number of steps to execute.
+ * @param recursionLimit Maximum depth of recursion allowed.
  * @param variant The language variant being executed.
  * @param isPrelude Whether the program is the prelude.
  * @yields The current state of the stash, control stack, and step count.
@@ -260,6 +267,7 @@ export async function* generateCSEMachineStateStream(
   stash: Stash,
   _envSteps: number,
   stepLimit: number,
+  recursionLimit: number,
   variant: number,
   isPrelude: boolean = false,
 ) {
@@ -341,6 +349,7 @@ export async function* generateCSEMachineStateStream(
         isPrelude,
         variant,
       );
+      checkStackOverFlow(code, command, context, control, recursionLimit);
     }
 
     command = control.peek();
@@ -1065,8 +1074,6 @@ const cmdEvaluators: CmdEvaluators = {
     stash: Stash,
     _isPrelude: boolean,
   ) {
-    checkStackOverFlow(code, instr.srcNode, context, control);
-
     // Tail-Call Optimisation
     const topElement = control.peek();
     if (
@@ -1133,7 +1140,7 @@ const cmdEvaluators: CmdEvaluators = {
       }
     } else if (callable?.type === "builtin") {
       const result = await callable.func(args, code, instr.srcNode, context);
-      if (result) {
+      if (result !== undefined) {
         stash.push(result);
       }
     } else {

--- a/src/engines/cse/stash.ts
+++ b/src/engines/cse/stash.ts
@@ -88,7 +88,12 @@ export interface BuiltinValue {
   name: string;
   func:
     | ((args: Value[], code: string, command: ExprNS.Call, context: Context) => Value | undefined)
-    | ((args: Value[], code: string, command: ExprNS.Call, context: Context) => Promise<Value | undefined>);
+    | ((
+        args: Value[],
+        code: string,
+        command: ExprNS.Call,
+        context: Context,
+      ) => Promise<Value | undefined>);
   minArgs: number;
 }
 

--- a/src/engines/cse/stash.ts
+++ b/src/engines/cse/stash.ts
@@ -87,8 +87,8 @@ export interface BuiltinValue {
   type: "builtin";
   name: string;
   func:
-    | ((args: Value[], code: string, command: ExprNS.Call, context: Context) => Value)
-    | ((args: Value[], code: string, command: ExprNS.Call, context: Context) => Promise<Value>);
+    | ((args: Value[], code: string, command: ExprNS.Call, context: Context) => Value | undefined)
+    | ((args: Value[], code: string, command: ExprNS.Call, context: Context) => Promise<Value | undefined>);
   minArgs: number;
 }
 

--- a/src/engines/cse/utils.ts
+++ b/src/engines/cse/utils.ts
@@ -9,6 +9,7 @@ import {
   UnboundLocalError,
 } from "../../errors/errors";
 import { Token, TokenType } from "../../tokenizer";
+import { isStatementSequence } from "./closure";
 import { Context } from "./context";
 import { Control, ControlItem } from "./control";
 import { currentEnvironment, Environment } from "./environment";
@@ -287,14 +288,29 @@ export function pyGetVariable(code: string, context: Context, name: string, node
   handleRuntimeError(context, new NameError(code, name, node as ExprNS.Variable));
 }
 
+/**
+ * Check whether the stack has exceeded the max recursion limit
+ * (It only accepts instructions since a new function call can only be pushed onto the control
+ *  after the `InstrType.APPLICATION` instruction is pushed)
+ *
+ * It checks the number of `InstrType.RESET` in the control stack, which corresponds to the number of function calls currently on the stack.
+ * If this number exceeds the specified recursion limit, it throws a `RecursionError`.
+ *
+ * @param code The code being executed, used for error reporting
+ * @param instr The executed instruction
+ * @param context The execution context
+ * @param control The control stack
+ * @param recursionLimit The maximum allowed recursion depth before throwing an error
+ */
 export const checkStackOverFlow = (
   code: string,
-  callExpr: ExprNS.Call,
+  instr: Instr,
   context: Context,
   control: Control,
+  recursionLimit: number,
 ) => {
-  if (control.getNumFunctionResets() > 1024) {
-    handleRuntimeError(context, new RecursionError(code, callExpr));
+  if (control.getNumFunctionResets() > recursionLimit && !isStatementSequence(instr.srcNode)) {
+    handleRuntimeError(context, new RecursionError(code, instr.srcNode));
   }
 };
 

--- a/src/engines/cse/utils.ts
+++ b/src/engines/cse/utils.ts
@@ -3,6 +3,7 @@ import {
   IndexError,
   MissingRequiredPositionalError,
   NameError,
+  RecursionError,
   TooManyPositionalArgumentsError,
   TypeError,
   UnboundLocalError,
@@ -242,9 +243,9 @@ export function isEnvDependent(item: ControlItem | null | undefined): boolean {
   return false;
 }
 
-function isInstr(item: ControlItem): item is Instr & { isEnvDependent?: boolean } {
+export const isInstr = (item: ControlItem): item is Instr & { isEnvDependent?: boolean } => {
   return "instrType" in item;
-}
+};
 
 export const envChanging = (command: ControlItem): boolean => {
   return isEnvDependent(command);
@@ -286,8 +287,15 @@ export function pyGetVariable(code: string, context: Context, name: string, node
   handleRuntimeError(context, new NameError(code, name, node as ExprNS.Variable));
 }
 
-export const checkStackOverFlow = (_context: Context, _control: Control) => {
-  // TODO
+export const checkStackOverFlow = (
+  code: string,
+  callExpr: ExprNS.Call,
+  context: Context,
+  control: Control,
+) => {
+  if (control.getNumFunctionResets() > 1024) {
+    handleRuntimeError(context, new RecursionError(code, callExpr));
+  }
 };
 
 export function pythonMod(a: bigint, b: bigint): bigint;

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -408,6 +408,36 @@ export class StepLimitExceededError extends RuntimeSourceError {
   }
 }
 
+export class RecursionError extends RuntimeSourceError {
+  constructor(source: string, node: ExprNS.Expr | StmtNS.Stmt) {
+    super(node);
+    this.type = ErrorType.RUNTIME;
+    const index = node.startToken.indexInSource;
+
+    const { lineIndex, fullLine } = getFullLine(source, index);
+    const snippet = source.substring(
+      node.startToken.indexInSource,
+      node.endToken.indexInSource + node.endToken.lexeme.length,
+    );
+    const offset = fullLine.indexOf(snippet);
+    const adjustedOffset = offset >= 0 ? offset : 0;
+    const errorPos = 0;
+    const indicator = createErrorIndicator(snippet, errorPos);
+
+    const name = "RecursionError";
+    const hint = "The evaluation has exceeded the maximum recursion depth.";
+
+    const msg = [
+      `${name} at line ${lineIndex}`,
+      "",
+      "    " + fullLine,
+      "    " + " ".repeat(adjustedOffset) + indicator,
+      hint,
+    ].join("\n");
+
+    this.message = msg;
+  }
+}
 export class ValueError extends RuntimeSourceError {
   constructor(source: string, node: ExprNS.Expr, context: Context, functionName: string) {
     super(node);

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -213,7 +213,6 @@ export class UnsupportedOperandTypeError extends RuntimeSourceError {
   }
 }
 
-// TODO: fix this class, since it doesn't seem to be functional
 export class MissingRequiredPositionalError extends RuntimeSourceError {
   private functionName: string;
   private missingParamCnt: number;

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -191,8 +191,8 @@ export class Resolver implements StmtNS.Visitor<void>, ExprNS.Visitor<void> {
       source,
       null,
       new Map([
-        // misc library
         ["range", new Token(TokenType.NAME, "range", 0, 0, 0)],
+        ["__program__", new Token(TokenType.NAME, "__program__", 0, 0, 0)],
         ...groups.flatMap(group =>
           Array.from(group.builtins.entries()).map(
             ([name]) => [name, new Token(TokenType.NAME, name, 0, 0, 0)] as const,

--- a/src/stdlib/linked-list.ts
+++ b/src/stdlib/linked-list.ts
@@ -2,14 +2,7 @@ import { ExprNS } from "../ast-types";
 import { Context } from "../engines/cse/context";
 import { ControlItem } from "../engines/cse/control";
 import { handleRuntimeError } from "../engines/cse/error";
-import {
-  BoolValue,
-  BuiltinValue,
-  ListValue,
-  NoneValue,
-  StringValue,
-  Value,
-} from "../engines/cse/stash";
+import { BoolValue, BuiltinValue, ListValue, NoneValue, Value } from "../engines/cse/stash";
 import { displayOutput } from "../engines/cse/streams";
 import { TypeError } from "../errors";
 import linkedListPrelude from "./linked-list.prelude";
@@ -80,10 +73,10 @@ class LinkedListBuiltins {
     source: string,
     command: ExprNS.Call,
     context: Context,
-  ): StringValue {
+  ): string {
     if (!LinkedListBuiltins._is_linked_list(value)) {
       if (!isPair(value)) {
-        return { type: "string", value: toPythonString(value) };
+        return toPythonString(value, true);
       }
       const string1 = LinkedListBuiltins._print_linked_list(
         value.value[0],
@@ -97,19 +90,14 @@ class LinkedListBuiltins {
         command,
         context,
       );
-      return { type: "string", value: "[" + string1.value + ", " + string2.value + "]" };
+      return "[" + string1 + ", " + string2 + "]";
     }
 
     let string = "linked_list(";
     let current = value;
 
     while (current.type == "list" && current.value.length === 2) {
-      string += LinkedListBuiltins._print_linked_list(
-        current.value[0],
-        source,
-        command,
-        context,
-      ).value;
+      string += LinkedListBuiltins._print_linked_list(current.value[0], source, command, context);
       string += ", ";
       current = LinkedListBuiltins.tail([current], source, command, context);
     }
@@ -117,7 +105,7 @@ class LinkedListBuiltins {
       string = string.slice(0, -2);
     }
     string += ")";
-    return { type: "string", value: string };
+    return string;
   }
   @Validate(1, 1, "print_linked_list", true)
   static async print_linked_list(
@@ -127,7 +115,7 @@ class LinkedListBuiltins {
     context: Context,
   ): Promise<NoneValue> {
     const stringValue = LinkedListBuiltins._print_linked_list(args[0], source, command, context);
-    await displayOutput(context, stringValue.value);
+    await displayOutput(context, stringValue);
     return { type: "none" };
   }
 }

--- a/src/stdlib/list.ts
+++ b/src/stdlib/list.ts
@@ -38,13 +38,13 @@ class ListBuiltins {
   @Validate(1, 1, "_gen_list", true)
   static _gen_list(
     args: Value[],
-    _source: string,
-    _command: ExprNS.Call,
-    _context: Context,
+    source: string,
+    command: ExprNS.Call,
+    context: Context,
   ): Value {
     const length = args[0];
     if (length.type !== "bigint") {
-      throw new Error("_gen_list expects a bigint as the first argument");
+      handleRuntimeError(context, new TypeError(source, command, context, length.type, "bigint"));
     }
     const list: Value[] = [];
     for (let i = BigInt(0); i < length.value; i++) {

--- a/src/stdlib/list.ts
+++ b/src/stdlib/list.ts
@@ -36,12 +36,7 @@ class ListBuiltins {
 
   // A helper function to generate a list of a given length
   @Validate(1, 1, "_gen_list", true)
-  static _gen_list(
-    args: Value[],
-    source: string,
-    command: ExprNS.Call,
-    context: Context,
-  ): Value {
+  static _gen_list(args: Value[], source: string, command: ExprNS.Call, context: Context): Value {
     const length = args[0];
     if (length.type !== "bigint") {
       handleRuntimeError(context, new TypeError(source, command, context, length.type, "bigint"));

--- a/src/stdlib/parser.ts
+++ b/src/stdlib/parser.ts
@@ -328,7 +328,7 @@ class ParserBuiltins {
     }
     context.stash.push(func);
     argArray.forEach(arg => context.stash.push(arg));
-    context.control.push(appInstr(argArray.length, command))
+    context.control.push(appInstr(argArray.length, command));
   }
 
   @Validate(1, 1, "tokenize", false)

--- a/src/stdlib/parser.ts
+++ b/src/stdlib/parser.ts
@@ -1,6 +1,7 @@
 import { ExprNS, FunctionParam, StmtNS } from "../ast-types";
 import { Context } from "../engines/cse/context";
 import { handleRuntimeError } from "../engines/cse/error";
+import { appInstr } from "../engines/cse/instrCreator";
 import { BuiltinValue, ListValue, NoneValue, StringValue, Value } from "../engines/cse/stash";
 import { operatorTranslator } from "../engines/cse/types";
 import { TypeError } from "../errors/errors";
@@ -312,7 +313,7 @@ class ParserBuiltins {
     source: string,
     command: ExprNS.Call,
     context: Context,
-  ): Promise<Value> {
+  ): Promise<Value | undefined> {
     const func = args[0];
     const argList = args[1];
     const argArray: Value[] = [];
@@ -325,10 +326,9 @@ class ParserBuiltins {
     if (func.type === "builtin") {
       return func.func(argArray, source, command, context);
     }
-    return handleRuntimeError(
-      context,
-      new TypeError(source, command, context, func.type, "primitive function"),
-    );
+    context.stash.push(func);
+    argArray.forEach(arg => context.stash.push(arg));
+    context.control.push(appInstr(argArray.length, command))
   }
 
   @Validate(1, 1, "tokenize", false)

--- a/src/stdlib/utils.ts
+++ b/src/stdlib/utils.ts
@@ -41,7 +41,7 @@ export type Group = {
 
 export const minArgMap = new Map<string, number>();
 
-export function Validate<T extends Value | Promise<Value>>(
+export function Validate<T extends Value | undefined | Promise<Value | undefined>>(
   minArgs: number | null,
   maxArgs: number | null,
   functionName: string,

--- a/src/tests/linked-list.test.ts
+++ b/src/tests/linked-list.test.ts
@@ -34,6 +34,7 @@ describe("Linked List Tests", () => {
         null,
         ["linked_list(linked_list(1, 2, 3), 4, 5, 6)"],
       ],
+      ["print_linked_list(linked_list('a', 'b'))", null, ["linked_list('a', 'b')"]],
     ],
     "empty list boundaries": [
       ["equal(append_linked_list(None, None), None)", true, null],

--- a/src/tests/parser-stdlib.test.ts
+++ b/src/tests/parser-stdlib.test.ts
@@ -601,10 +601,17 @@ describe("Parser Stdlib Tests", () => {
     ],
     "apply_in_underlying_python — non-primitive functions": [
       ["apply_in_underlying_python(lambda x: x + 1, linked_list(5))", 6n, null],
-      ["def f(x, y, *args):\n    return x + y + (f(*args) if len(args) > 0 else 0)\napply_in_underlying_python(f, linked_list(1, 2, 3, 4))", 10n, null],
-      ["def g(x, y): return x + \" \" + y\napply_in_underlying_python(g, linked_list(\"hello\", \"world\"))", "hello world", null],
+      [
+        "def f(x, y, *args):\n    return x + y + (f(*args) if len(args) > 0 else 0)\napply_in_underlying_python(f, linked_list(1, 2, 3, 4))",
+        10n,
+        null,
+      ],
+      [
+        'def g(x, y): return x + " " + y\napply_in_underlying_python(g, linked_list("hello", "world"))',
+        "hello world",
+        null,
+      ],
     ],
-
   };
 
   generateTestCases(literalTests, 4, groups);

--- a/src/tests/parser-stdlib.test.ts
+++ b/src/tests/parser-stdlib.test.ts
@@ -599,6 +599,12 @@ describe("Parser Stdlib Tests", () => {
       ["apply_in_underlying_python(True, linked_list(1))", TypeError, null],
       ["apply_in_underlying_python(None, linked_list(1))", TypeError, null],
     ],
+    "apply_in_underlying_python — non-primitive functions": [
+      ["apply_in_underlying_python(lambda x: x + 1, linked_list(5))", 6n, null],
+      ["def f(x, y, *args):\n    return x + y + (f(*args) if len(args) > 0 else 0)\napply_in_underlying_python(f, linked_list(1, 2, 3, 4))", 10n, null],
+      ["def g(x, y): return x + \" \" + y\napply_in_underlying_python(g, linked_list(\"hello\", \"world\"))", "hello world", null],
+    ],
+
   };
 
   generateTestCases(literalTests, 4, groups);

--- a/src/tests/stdlib.test.ts
+++ b/src/tests/stdlib.test.ts
@@ -994,9 +994,7 @@ describe("Standard Library Tests", () => {
         ["hello = 'hello'\r\n\r\nhello", "hello", null],
         ["hello = 'hello'\r\n# This is a comment\r\nhello", "hello", null],
       ],
-      "predefined variables": [
-        ["a = 1\n__program__", "a = 1\n__program__", null],
-      ]
+      "predefined variables": [["a = 1\n__program__", "a = 1\n__program__", null]],
     };
 
     generateTestCases(mathTests, 1, [misc, math]);

--- a/src/tests/stdlib.test.ts
+++ b/src/tests/stdlib.test.ts
@@ -1,4 +1,10 @@
-import { TypeError, UnsupportedOperandTypeError, ValueError, ZeroDivisionError } from "../errors";
+import {
+  RecursionError,
+  TypeError,
+  UnsupportedOperandTypeError,
+  ValueError,
+  ZeroDivisionError,
+} from "../errors";
 import linkedList from "../stdlib/linked-list";
 import list from "../stdlib/list";
 import math from "../stdlib/math";
@@ -685,6 +691,8 @@ describe("Standard Library Tests", () => {
         ["a = 18446744073709551616\nrepr(a)", "18446744073709551616", null],
         ["a = 18446744073709551616\nb = 2**64\na == b", true, null],
         ["a = 18446744073709551616\nb = int('18446744073709551615')\na != b", true, null],
+        ["def f(x): return 1 + f(x)\nf(2)", RecursionError, null],
+        ["def f(x): return f(x - 1) if x > 0 else 0\nf(10240)", 0n, null],
       ],
       "is functions": [
         ["is_int(1)", true, null],

--- a/src/tests/stdlib.test.ts
+++ b/src/tests/stdlib.test.ts
@@ -994,6 +994,9 @@ describe("Standard Library Tests", () => {
         ["hello = 'hello'\r\n\r\nhello", "hello", null],
         ["hello = 'hello'\r\n# This is a comment\r\nhello", "hello", null],
       ],
+      "predefined variables": [
+        ["a = 1\n__program__", "a = 1\n__program__", null],
+      ]
     };
 
     generateTestCases(mathTests, 1, [misc, math]);

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -114,7 +114,9 @@ type InternalTestCase = {
 export const createInternalTestCases = (tests: TestCases[string]): InternalTestCase[] => {
   return tests.map(([code, expected, output]) => ({
     label:
-      JSON.stringify(code) + " should " + (expected instanceof Function &&
+      JSON.stringify(code) +
+      " should " +
+      (expected instanceof Function &&
       (expected.prototype instanceof RuntimeSourceError || expected.prototype instanceof Error)
         ? "throw " + expected.name
         : "return " + expected),
@@ -186,78 +188,75 @@ export const generateTestCases = (testCases: TestCases, variant: number, groups:
       afterEach(() => {
         jest.restoreAllMocks(); // Automatically restores all spyOn mocks
       });
-      test.each(createInternalTestCases(tests))(
-        `$label`,
-        async ({ code, expected, output }) => {
-          const spy = jest.spyOn(Stash.prototype, "pop");
-          const context = new Context();
+      test.each(createInternalTestCases(tests))(`$label`, async ({ code, expected, output }) => {
+        const spy = jest.spyOn(Stash.prototype, "pop");
+        const context = new Context();
 
-          const outputLst: OutputType[] = [];
-          generateMockStreams(context, outputLst);
-          const result = await runInContext(code, context, { variant, groups });
-          expect(result.status).toBe("finished");
+        const outputLst: OutputType[] = [];
+        generateMockStreams(context, outputLst);
+        const result = await runInContext(code, context, { variant, groups });
+        expect(result.status).toBe("finished");
 
-          if (typeof expected === "function" && expected.prototype instanceof RuntimeSourceError) {
-            expect(context.errors.length).toBeGreaterThan(0);
-            expect(context.errors[0]).toHaveProperty("constructor", expected);
-            return;
-          }
-          if (typeof expected === "function" && expected.prototype instanceof Error) {
-            expect(result).toHaveProperty("value.message", expect.stringContaining(expected.name));
-            return;
-          }
-          expect(outputLst.filter(item => item.type === "stderr")).toStrictEqual([]);
-
-          expect(result.status).not.toHaveProperty("value.type", "error");
-          if (output !== null) {
-            expect(outputLst).toEqual(output.map(line => ({ type: "stdout", value: line })));
-          }
-
-          const generateExpectedValueAssertion = (expected: TestOutputValue): Value => {
-            if (expected === null) {
-              return { type: "none" };
-            }
-
-            if (typeof expected === "bigint") {
-              return { type: "bigint", value: expected };
-            }
-
-            if (typeof expected === "number") {
-              if (isNaN(expected)) {
-                return { type: "number", value: NaN };
-              }
-              return { type: "number", value: expect.closeTo(expected) };
-            }
-
-            if (typeof expected === "boolean") {
-              return { type: "bool", value: expected };
-            }
-
-            if (expected instanceof PyComplexNumber) {
-              return {
-                type: "complex",
-                value: expect.objectContaining({
-                  real: isNaN(expected.real) ? NaN : expect.closeTo(expected.real),
-                  imag: isNaN(expected.imag) ? NaN : expect.closeTo(expected.imag),
-                }),
-              };
-            }
-
-            if (Array.isArray(expected)) {
-              return {
-                type: "list",
-                value: expected.map(generateExpectedValueAssertion),
-              };
-            }
-
-            return { type: "string", value: expected };
-          };
-          expect(spy).toHaveLastReturnedWith(
-            expect.objectContaining(generateExpectedValueAssertion(expected as TestOutputValue)),
-          );
+        if (typeof expected === "function" && expected.prototype instanceof RuntimeSourceError) {
+          expect(context.errors.length).toBeGreaterThan(0);
+          expect(context.errors[0]).toHaveProperty("constructor", expected);
           return;
-        },
-      );
+        }
+        if (typeof expected === "function" && expected.prototype instanceof Error) {
+          expect(result).toHaveProperty("value.message", expect.stringContaining(expected.name));
+          return;
+        }
+        expect(outputLst.filter(item => item.type === "stderr")).toStrictEqual([]);
+
+        expect(result.status).not.toHaveProperty("value.type", "error");
+        if (output !== null) {
+          expect(outputLst).toEqual(output.map(line => ({ type: "stdout", value: line })));
+        }
+
+        const generateExpectedValueAssertion = (expected: TestOutputValue): Value => {
+          if (expected === null) {
+            return { type: "none" };
+          }
+
+          if (typeof expected === "bigint") {
+            return { type: "bigint", value: expected };
+          }
+
+          if (typeof expected === "number") {
+            if (isNaN(expected)) {
+              return { type: "number", value: NaN };
+            }
+            return { type: "number", value: expect.closeTo(expected) };
+          }
+
+          if (typeof expected === "boolean") {
+            return { type: "bool", value: expected };
+          }
+
+          if (expected instanceof PyComplexNumber) {
+            return {
+              type: "complex",
+              value: expect.objectContaining({
+                real: isNaN(expected.real) ? NaN : expect.closeTo(expected.real),
+                imag: isNaN(expected.imag) ? NaN : expect.closeTo(expected.imag),
+              }),
+            };
+          }
+
+          if (Array.isArray(expected)) {
+            return {
+              type: "list",
+              value: expected.map(generateExpectedValueAssertion),
+            };
+          }
+
+          return { type: "string", value: expected };
+        };
+        expect(spy).toHaveLastReturnedWith(
+          expect.objectContaining(generateExpectedValueAssertion(expected as TestOutputValue)),
+        );
+        return;
+      });
     });
   }
 };

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -61,7 +61,7 @@ async function runInContext(
   }
 
   // Evaluate
-  const result = await evaluate(code, pyAst, context, options as Partial<IOptions>);
+  const result = await evaluate(code, pyAst, context, options);
   return CSEResultPromise(context, result);
 }
 
@@ -114,10 +114,10 @@ type InternalTestCase = {
 export const createInternalTestCases = (tests: TestCases[string]): InternalTestCase[] => {
   return tests.map(([code, expected, output]) => ({
     label:
-      expected instanceof Function &&
+      JSON.stringify(code) + " should " + (expected instanceof Function &&
       (expected.prototype instanceof RuntimeSourceError || expected.prototype instanceof Error)
-        ? expected.name
-        : expected,
+        ? "throw " + expected.name
+        : "return " + expected),
     code,
     expected,
     output,
@@ -187,7 +187,7 @@ export const generateTestCases = (testCases: TestCases, variant: number, groups:
         jest.restoreAllMocks(); // Automatically restores all spyOn mocks
       });
       test.each(createInternalTestCases(tests))(
-        `$code should return $label`,
+        `$label`,
         async ({ code, expected, output }) => {
           const spy = jest.spyOn(Stash.prototype, "pop");
           const context = new Context();
@@ -195,7 +195,6 @@ export const generateTestCases = (testCases: TestCases, variant: number, groups:
           const outputLst: OutputType[] = [];
           generateMockStreams(context, outputLst);
           const result = await runInContext(code, context, { variant, groups });
-          expect(result).toBeDefined();
           expect(result.status).toBe("finished");
 
           if (typeof expected === "function" && expected.prototype instanceof RuntimeSourceError) {
@@ -203,11 +202,11 @@ export const generateTestCases = (testCases: TestCases, variant: number, groups:
             expect(context.errors[0]).toHaveProperty("constructor", expected);
             return;
           }
-
           if (typeof expected === "function" && expected.prototype instanceof Error) {
             expect(result).toHaveProperty("value.message", expect.stringContaining(expected.name));
             return;
           }
+          expect(outputLst.filter(item => item.type === "stderr")).toStrictEqual([]);
 
           expect(result.status).not.toHaveProperty("value.type", "error");
           if (output !== null) {


### PR DESCRIPTION
- Add Python 4 and MCE to the documentation
- Rename `__PROGRAM__` to `__program__` to align with Python's naming scheme
- Add `__program__` which stores the code of the program being evaluated
- Extend `apply_in_underlying_python` to support non-primitive functions
- Add stack overflow checks + tail call optimisations

Fixes #144 