### PR TITLE
Fix CSE machine loop spec compliance (#153)

### DIFF
--- a/src/engines/cse/interpreter.ts
+++ b/src/engines/cse/interpreter.ts
@@ -345,6 +345,7 @@ export async function* generateCSEMachineStateStream(
     yield { stash, control, steps };
   }
 }
+
 function isDeclaredEvaluator(kind: string): kind is keyof CmdEvaluators {
   return kind in cmdEvaluators;
 }
@@ -988,15 +989,23 @@ const cmdEvaluators: CmdEvaluators = {
   },
 
   [InstrType.WHILE]: function (
-    _code: string,
+    code: string,
     instr: WhileInstr,
-    _context: Context,
+    context: Context,
     control: Control,
     stash: Stash,
     _isPrelude: boolean,
   ) {
     const condition = stash.pop();
-    if (condition && !isFalsy(condition)) {
+    if (!condition) return;
+    if (condition.type !== "bool") {
+      handleRuntimeError(
+        context,
+        new error.TypeError(code, instr.srcNode as StmtNS.Stmt, context, condition.type, "bool"),
+      );
+      return;
+    }
+    if (!isFalsy(condition)) {
       control.push(instr);
       control.push(instr.test);
       control.push(instrCreator.continueMarkerInstr(instr.srcNode));
@@ -1029,20 +1038,32 @@ const cmdEvaluators: CmdEvaluators = {
           ),
         );
       }
+      if (step.value === 0n) {
+        handleRuntimeError(
+          context,
+          new error.UserError("ValueError: range() arg 3 must not be zero", node.iter),
+        );
+        return;
+      }
       if (
-        (step.value <= 0 && end.value >= start.value) ||
-        (step.value >= 0 && end.value <= start.value)
+        (step.value < 0 && end.value >= start.value) ||
+        (step.value > 0 && end.value <= start.value)
       ) {
         return;
       }
       control.push(instr);
       const generateBigIntLiteral = (value: bigint): ExprNS.BigIntLiteral => {
-        const token = new Token(TokenType.BIGINT, value.toString(), 0, 0, 0);
+        const token = new Token(TokenType.BIGINT, value.toString(), 0, 0, -1);
         return new ExprNS.BigIntLiteral(token, token, value.toString());
       };
+      const v1Lit = generateBigIntLiteral(start.value);
+      const v3Lit = generateBigIntLiteral(step.value);
+      const plusToken = new Token(TokenType.PLUS, "+", 0, 0, -1);
+      const nextStartExpr = new ExprNS.Binary(plusToken, plusToken, v1Lit, plusToken, v3Lit);
+      Object.assign(nextStartExpr, { syntheticLabel: `${start.value}+${step.value}` });
       control.push(generateBigIntLiteral(step.value));
       control.push(generateBigIntLiteral(end.value));
-      control.push(generateBigIntLiteral(start.value + step.value));
+      control.push(nextStartExpr);
       control.push(instrCreator.continueMarkerInstr(node));
       control.push(...instr.body.slice().reverse());
       control.push(generateForIncrement(node.target.lexeme, start.value));
@@ -1094,6 +1115,8 @@ const cmdEvaluators: CmdEvaluators = {
 
     if (callable?.type == "closure") {
       const closure = callable.closure;
+      const callerEnv = currentEnvironment(context);
+      control.push(instrCreator.envInstr(callerEnv, instr.srcNode));
       control.push(instrCreator.resetInstr(instr.srcNode));
       if (closure.node.kind === "FunctionDef") {
         control.push(instrCreator.endOfFunctionBodyInstr(instr.srcNode));

--- a/src/engines/cse/utils.ts
+++ b/src/engines/cse/utils.ts
@@ -355,9 +355,12 @@ export function scanForAssignments(node: Node | Node[]): Set<string> {
       if (assignNode.target instanceof ExprNS.Variable) {
         assignments.add(assignNode.target.name.lexeme);
       }
-    } else if (nodeType === "FunctionDef" || nodeType === "Lambda") {
-      // detach here, nested functions have their own scope
-      return;
+    } else if (nodeType === "FunctionDef") {
+      // def f(...) creates a binding for the function name in the current scope
+      assignments.add((curNode as StmtNS.FunctionDef).name.lexeme);
+      return; // don't recurse into the nested function's body
+    } else if (nodeType === "Lambda") {
+      return; // lambda is anonymous, no name binding in current scope
     }
 
     // Recurse through all other properties of the node
@@ -502,10 +505,10 @@ export function evaluateForIterator(
 }
 
 export function generateForIncrement(variableName: string, value: bigint): StmtNS.Stmt {
-  const token = new Token(TokenType.NAME, variableName, 0, 0, 0);
+  const token = new Token(TokenType.NAME, variableName, 0, 0, -1);
   const variable = new ExprNS.Variable(token, token, token);
 
-  const literalToken = new Token(TokenType.BIGINT, value.toString(), 0, 0, 0);
+  const literalToken = new Token(TokenType.BIGINT, value.toString(), 0, 0, -1);
   const literal = new ExprNS.BigIntLiteral(literalToken, literalToken, value.toString());
   return new StmtNS.Assign(token, literalToken, variable, literal);
 }

--- a/src/tests/loops.test.ts
+++ b/src/tests/loops.test.ts
@@ -5,6 +5,7 @@ import math from "../stdlib/math";
 import misc from "../stdlib/misc";
 import pairmutator from "../stdlib/pairmutator";
 import stream from "../stdlib/stream";
+import { TypeError, UserError } from "../errors/errors";
 import { FeatureNotSupportedError } from "../validator";
 import { generateTestCases } from "./utils";
 
@@ -20,6 +21,12 @@ describe("Loop Tests", () => {
         ["for i in range(0):\n    print(i)\n3", 3n, []],
         ["for i in range(5):\n    i = 0\n    print(i)\ni", 0n, ["0", "0", "0", "0", "0"]],
         ["x = 3\nfor x in range(x, x + 5):\n    print(x)\nx", 7n, ["3", "4", "5", "6", "7"]],
+        // ValueError: step of zero
+        ["for i in range(1, 10, 0):\n    print(i)", UserError, null],
+        // Empty ranges (start == stop, or start past stop with positive/negative step)
+        ["for i in range(5, 5, 1):\n    print(i)\n3", 3n, []],
+        ["for i in range(5, 3, 1):\n    print(i)\n3", 3n, []],
+        ["for i in range(3, 5, -1):\n    print(i)\n3", 3n, []],
         [
           "for i in range(5):\n    for j in range(3):\n        print(i, j)\ni",
           4n,
@@ -56,6 +63,11 @@ describe("Loop Tests", () => {
           5n,
           ["0", "1", "3", "4"],
         ],
+        // TypeError: condition must be a boolean
+        ["y = 1\nwhile y + 1:\n    y = y + 1", TypeError, null],
+        ["while 1:\n    pass", TypeError, null],
+        ["while 0:\n    pass", TypeError, null],
+        ["while None:\n    pass", TypeError, null],
       ],
       "break and continue": [
         [


### PR DESCRIPTION
## What this fixes

Three behaviours specified in #153 were not yet implemented. This PR addresses all three.

---

### 1. `while` — TypeError for non-boolean condition

The spec says the condition must be a boolean; anything else raises a `TypeError`. Previously `isFalsy()` was used directly, which silently accepted integers, strings, `None` etc. This caused code like `while y+1:` to hang indefinitely instead of erroring.

<img width="1600" height="399" alt="image" src="https://github.com/user-attachments/assets/a8989500-ef60-4788-8ec3-144f021cddd8" />

---

### 2. `for` — ValueError when step is zero

The spec requires `range() arg 3 must not be zero` to be raised as a `ValueError` when the step argument evaluates to `0`. Previously a zero step fell through the empty-range early-exit condition and produced no output and no error. The early-exit condition was also tightened from `<= / >=` to strict `< / >` to make this work correctly.

<img width="953" height="417" alt="image" src="https://github.com/user-attachments/assets/33739103-2cea-4a61-8ad1-6cd0de63a4df" />

---

### 3. `for` — v1+v3 pushed as a Binary expression

The spec says the next start value should be pushed onto the control stack as `v1+v3 (as an operator combination)`, not as a pre-computed literal. The increment is now a `Binary` AST node so it appears as an explicit evaluation step in the CSE visualiser.

<img width="1275" height="710" alt="image" src="https://github.com/user-attachments/assets/d03847b1-88f8-4212-9203-06495d23bd2f" />

---

## Other changes

Removes the stale `forRangeRole` tagging from `evaluateForIterator` in `utils.ts` — these labels were added for an earlier display approach that has since been replaced and nothing reads them anymore. Refer to the specs at #153 for why this was decided. Utils.ts also has changes related to how the env instructions should be pushed onto the control!

## Files changed

- `src/engines/cse/interpreter.ts`
- `src/engines/cse/utils.ts`

Closes #154