### PR TITLE
Docs deploy: publish to docs.sourceacademy.org/python

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -32,11 +32,16 @@ jobs:
         run: |
           chmod +x scripts/jsdoc.sh
           ./scripts/jsdoc.sh prepare
-      - name: Deploy to Branch
+      - name: Deploy to docs site (/python)
         uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.DOCS_DEPLOY_SSH_KEY }}
           publish_dir: docs/python
           external_repository: source-academy/docs.sourceacademy.org
-          publish_branch: deploy-py-slang
-          force_orphan: true
+          publish_branch: master
+          # Publish into the /python subfolder so the docs are served at
+          # https://docs.sourceacademy.org/python/ alongside the Source docs.
+          destination_dir: python
+          # Keep the existing Source docs (published to the branch root by
+          # js-slang) intact; only the /python subfolder is updated here.
+          keep_files: true


### PR DESCRIPTION
## What

Publish the generated Python docs into the \`/python\` subfolder of the \`master\` branch of \`source-academy/docs.sourceacademy.org\`, instead of the standalone \`deploy-py-slang\` branch.

- \`publish_branch: deploy-py-slang\` → \`publish_branch: master\`
- add \`destination_dir: python\`
- \`force_orphan: true\` → \`keep_files: true\`

## Why

\`docs.sourceacademy.org\` is served by GitHub Pages from the \`master\` branch only, so the \`deploy-py-slang\` branch was never publicly visible. Publishing into \`master/python/\` makes the docs available at **https://docs.sourceacademy.org/python/**, alongside the Source docs at the root.

- \`destination_dir: python\` scopes the publish to the \`/python\` subfolder.
- \`keep_files: true\` leaves the Source docs (published to the branch root by js-slang) untouched.

This depends on the companion js-slang PR (\`docs-keep-python-subfolder\`), which switches js-slang's deploy to \`keep_files: true\` so it no longer wipes \`/python\` on each Source-docs deploy.

## Follow-up

Once this is merged and confirmed working, the now-unused \`deploy-py-slang\` branch on the docs repo can be deleted.