### PR TITLE
docs: add Documentation section linking to Python docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ the Python grammar in `python.ne`.
 yarn compile-grammar
 ```
 
+## Documentation
+
+Python is documented here: <https://docs.sourceacademy.org/python/>
+
 ## Prior Reading
 
 These repositories are relevant to `py-slang`, and may be useful if stuck

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ yarn compile-grammar
 
 ## Documentation
 
-Python is documented here: <https://docs.sourceacademy.org/python/>
+SICPPy Python is documented here: <https://docs.sourceacademy.org/python/>
 
 ## Prior Reading
 


### PR DESCRIPTION
## Summary

- Adds a `## Documentation` section to the README, mirroring the equivalent section in [js-slang](https://github.com/source-academy/js-slang#documentation)
- Links to the Python documentation at https://docs.sourceacademy.org/python/

## Test plan

- [ ] Verify the link resolves correctly: https://docs.sourceacademy.org/python/