### PR TITLE
feat: implement global keyword for Python §3 and §4

### DIFF
--- a/src/engines/cse/closure.ts
+++ b/src/engines/cse/closure.ts
@@ -22,6 +22,8 @@ export class Closure {
   public originalNode?: StmtNS.FunctionDef | ExprNS.Lambda;
   /** Stores local variables for scope check */
   public localVariables: Set<string>;
+  /** Stores variables declared global in this function body */
+  public globalVariables: Set<string>;
 
   constructor(
     node: StmtNS.FunctionDef | ExprNS.Lambda,
@@ -29,6 +31,7 @@ export class Closure {
     context: Context,
     predefined: boolean = false,
     localVariables: Set<string> = new Set(),
+    globalVariables: Set<string> = new Set(),
   ) {
     this.id = uniqueId(context);
     this.node = node;
@@ -37,6 +40,7 @@ export class Closure {
     this.predefined = predefined;
     this.originalNode = node;
     this.localVariables = localVariables;
+    this.globalVariables = globalVariables;
   }
 
   static makeFromFunctionDef(
@@ -44,8 +48,9 @@ export class Closure {
     environment: Environment,
     context: Context,
     localVariables: Set<string>,
+    globalVariables: Set<string> = new Set(),
   ): Closure {
-    const closure = new Closure(node, environment, context, false, localVariables);
+    const closure = new Closure(node, environment, context, false, localVariables, globalVariables);
     return closure;
   }
 

--- a/src/engines/cse/interpreter.ts
+++ b/src/engines/cse/interpreter.ts
@@ -56,11 +56,14 @@ import {
   evaluateForIterator,
   evaluateListAssignment,
   generateForIncrement,
+  getProgramEnvironment,
   isInstr,
   isNode,
   pyDefineVariable,
+  pyGetGlobalVariable,
   pyGetVariable,
   scanForAssignments,
+  scanForGlobalDeclarations,
 } from "./utils";
 
 export interface IOptions {
@@ -367,11 +370,8 @@ function isDeclaredEvaluator(kind: string): kind is keyof CmdEvaluators {
   return kind in cmdEvaluators;
 }
 type ExprKeys = Exclude<keyof typeof ExprNS, "Expr" | "MultiLambda" | "Starred">;
-type StmtKeys = Exclude<
-  keyof typeof StmtNS,
-  "Stmt" | "AnnAssign" | "Global" | "Assert" | "NonLocal"
->;
-type InstrKeys = Exclude<InstrType, "Assert" | "Global" | "NonLocal" | "Import" | "Program">;
+type StmtKeys = Exclude<keyof typeof StmtNS, "Stmt" | "AnnAssign" | "Assert" | "NonLocal">;
+type InstrKeys = Exclude<InstrType, "Assert" | "NonLocal" | "Import" | "Program">;
 type CmdEvaluators = {
   [K in ExprKeys]: CmdEvaluator<InstanceType<(typeof ExprNS)[K]>>;
 } & {
@@ -531,6 +531,12 @@ const cmdEvaluators: CmdEvaluators = {
     stash.push({ type: "none" });
   },
 
+  Global: function () {
+    // `global x` is a declaration — no runtime effect; the interpreter uses
+    // closure.globalVariables (populated at FunctionDef time) to route reads
+    // and writes to the module-level environment.
+  },
+
   Variable: function (
     code: string,
     variable: ExprNS.Variable,
@@ -540,9 +546,11 @@ const cmdEvaluators: CmdEvaluators = {
     _isPrelude: boolean,
   ) {
     const name = variable.name.lexeme;
-
-    // if not built in, look up in environment
-    const value = pyGetVariable(code, context, name, variable);
+    const currentEnv = currentEnvironment(context);
+    const isGlobal = currentEnv.closure?.globalVariables.has(name) ?? false;
+    const value = isGlobal
+      ? pyGetGlobalVariable(code, context, name, variable)
+      : pyGetVariable(code, context, name, variable);
     stash.push(value);
   },
 
@@ -619,12 +627,14 @@ const cmdEvaluators: CmdEvaluators = {
     _stash: Stash,
     _isPrelude: boolean,
   ) {
-    const localVariables = scanForAssignments(functionDefNode.body);
+    const globalVariables = scanForGlobalDeclarations(functionDefNode.body);
+    const localVariables = scanForAssignments(functionDefNode.body, globalVariables);
     const closure = Closure.makeFromFunctionDef(
       functionDefNode,
       currentEnvironment(context),
       context,
       localVariables,
+      globalVariables,
     );
     pyDefineVariable(context, functionDefNode.name.lexeme, { type: "closure", closure });
   },
@@ -838,7 +848,14 @@ const cmdEvaluators: CmdEvaluators = {
           new BuiltinReassignmentError(code, instr.symbol, instr.srcNode as ExprNS.Expr),
         );
       }
-      pyDefineVariable(context, instr.symbol, value);
+      const currentEnv = currentEnvironment(context);
+      const isGlobal = currentEnv.closure?.globalVariables.has(instr.symbol) ?? false;
+      if (isGlobal) {
+        const progEnv = getProgramEnvironment(context) ?? currentEnv;
+        pyDefineVariable(context, instr.symbol, value, progEnv);
+      } else {
+        pyDefineVariable(context, instr.symbol, value);
+      }
     }
   },
 

--- a/src/engines/cse/utils.ts
+++ b/src/engines/cse/utils.ts
@@ -14,6 +14,10 @@ import { Context } from "./context";
 import { Control, ControlItem } from "./control";
 import { currentEnvironment, Environment } from "./environment";
 import { AssertionError, handleRuntimeError } from "./error";
+
+export function getProgramEnvironment(context: Context): Environment | null {
+  return context.runtime.environments.find(env => env.name === "programEnvironment") ?? null;
+}
 import { BigIntValue, ComplexValue, NumberValue, Value } from "./stash";
 import {
   BranchInstr,
@@ -84,6 +88,7 @@ const propertySetter: PropertySetter = new Map<string, Transformer>([
     },
   ],
   ["FromImport", setToTrue],
+  ["Global", setToFalse],
   ["Pass", setToFalse],
   ["Break", setToFalse],
   ["Continue", setToFalse],
@@ -288,6 +293,27 @@ export function pyGetVariable(code: string, context: Context, name: string, node
   handleRuntimeError(context, new NameError(code, name, node as ExprNS.Variable));
 }
 
+// Reads `name` starting from the module-level (programEnvironment), bypassing any
+// enclosing function frames. Used when a function declares `global name`.
+export function pyGetGlobalVariable(
+  code: string,
+  context: Context,
+  name: string,
+  node: Node,
+): Value {
+  let currentEnv: Environment | null = getProgramEnvironment(context);
+  while (currentEnv) {
+    if (Object.prototype.hasOwnProperty.call(currentEnv.head, name)) {
+      return currentEnv.head[name];
+    }
+    currentEnv = currentEnv.tail;
+  }
+  if (context.nativeStorage.builtins.has(name)) {
+    return context.nativeStorage.builtins.get(name)!;
+  }
+  handleRuntimeError(context, new NameError(code, name, node as ExprNS.Variable));
+}
+
 /**
  * Check whether the stack has exceeded the max recursion limit
  * (It only accepts instructions since a new function call can only be pushed onto the control
@@ -365,7 +391,38 @@ export default function assert(
   }
 }
 
-export function scanForAssignments(node: Node | Node[]): Set<string> {
+// Returns the set of names declared with `global` anywhere in the given function body,
+// without recursing into nested function definitions.
+export function scanForGlobalDeclarations(node: Node | Node[]): Set<string> {
+  const globals = new Set<string>();
+  const visitor = (curNode: Node) => {
+    if (!curNode || typeof curNode !== "object") return;
+    const kind = (curNode as { kind?: string }).kind;
+    if (kind === "Global") {
+      globals.add((curNode as unknown as StmtNS.Global).name.lexeme);
+      return;
+    }
+    if (kind === "FunctionDef" || kind === "Lambda") return;
+    for (const key in curNode) {
+      if (Object.prototype.hasOwnProperty.call(curNode, key)) {
+        const child = (curNode as unknown as Record<string, unknown>)[key];
+        if (Array.isArray(child)) {
+          child.forEach(c => {
+            if (c && typeof c === "object") visitor(c as Node);
+          });
+        }
+      }
+    }
+  };
+  if (Array.isArray(node)) node.forEach(visitor);
+  else visitor(node);
+  return globals;
+}
+
+export function scanForAssignments(
+  node: Node | Node[],
+  globalNames: Set<string> = new Set(),
+): Set<string> {
   const assignments = new Set<string>();
   const visitor = (curNode: Node) => {
     if (!curNode || typeof curNode !== "object") {
@@ -377,11 +434,17 @@ export function scanForAssignments(node: Node | Node[]): Set<string> {
     if (nodeType === "Assign") {
       const assignNode = curNode as StmtNS.Assign;
       if (assignNode.target instanceof ExprNS.Variable) {
-        assignments.add(assignNode.target.name.lexeme);
+        const name = assignNode.target.name.lexeme;
+        if (!globalNames.has(name)) {
+          assignments.add(name);
+        }
       }
     } else if (nodeType === "FunctionDef") {
       // def f(...) creates a binding for the function name in the current scope
-      assignments.add((curNode as StmtNS.FunctionDef).name.lexeme);
+      const name = (curNode as StmtNS.FunctionDef).name.lexeme;
+      if (!globalNames.has(name)) {
+        assignments.add(name);
+      }
       return; // don't recurse into the nested function's body
     } else if (nodeType === "Lambda") {
       return; // lambda is anonymous, no name binding in current scope

--- a/src/engines/cse/utils.ts
+++ b/src/engines/cse/utils.ts
@@ -408,8 +408,15 @@ export function scanForGlobalDeclarations(node: Node | Node[]): Set<string> {
         const child = (curNode as unknown as Record<string, unknown>)[key];
         if (Array.isArray(child)) {
           child.forEach(c => {
-            if (c && typeof c === "object") visitor(c as Node);
+            if (c !== undefined && c !== null && typeof c === "object") visitor(c as Node);
           });
+        } else if (
+          child !== undefined &&
+          child !== null &&
+          typeof child === "object" &&
+          (child as { kind?: string }).kind !== undefined
+        ) {
+          visitor(child as Node);
         }
       }
     }

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -171,6 +171,8 @@ export class Resolver implements StmtNS.Visitor<void>, ExprNS.Visitor<void> {
   errors: Error[];
   functionEnvironments: FunctionEnvironments;
   private validators: FeatureValidator[];
+  // Names declared `global` in the current function body (reset on function entry/exit).
+  private globalNamesInCurrentFunction: Set<string> = new Set();
 
   constructor(
     source: string,
@@ -228,10 +230,14 @@ export class Resolver implements StmtNS.Visitor<void>, ExprNS.Visitor<void> {
     if (stmt instanceof Array) {
       for (const st of stmt) {
         if (st instanceof StmtNS.FunctionDef) {
-          this.environment?.declareName(st.name);
+          if (!this.globalNamesInCurrentFunction.has(st.name.lexeme)) {
+            this.environment?.declareName(st.name);
+          }
         }
         if (st instanceof StmtNS.Assign && st.target instanceof ExprNS.Variable) {
-          this.environment?.declareName(st.target.name);
+          if (!this.globalNamesInCurrentFunction.has(st.target.name.lexeme)) {
+            this.environment?.declareName(st.target.name);
+          }
         }
       }
       for (const st of stmt) {
@@ -308,10 +314,29 @@ export class Resolver implements StmtNS.Visitor<void>, ExprNS.Visitor<void> {
     this.environment = new Environment(this.source, this.environment, newEnv);
     this.functionEnvironments.set(stmt, this.environment);
     this.functionScope = this.environment;
+
+    const oldGlobalNames = this.globalNamesInCurrentFunction;
+    this.globalNamesInCurrentFunction = this.scanGlobalDeclarations(stmt.body);
+    // Declare global names in the outermost (module-level) environment so that
+    // variable lookups within this function can find them via the chain walk.
+    if (this.globalNamesInCurrentFunction.size > 0) {
+      let globalEnv: Environment | null = this.environment;
+      while (globalEnv?.enclosing !== null) {
+        globalEnv = globalEnv?.enclosing ?? null;
+      }
+      if (globalEnv) {
+        for (const name of this.globalNamesInCurrentFunction) {
+          if (!globalEnv.names.has(name)) {
+            // Use a sentinel token so the resolver accepts references to this name.
+            globalEnv.names.set(name, new Token(TokenType.NAME, name, 0, 0, 0));
+          }
+        }
+      }
+    }
+
     this.resolve(stmt.body);
-    // Grab identifiers from that new environment. That are NOT functions.
-    // stmt.varDecls = this.varDeclNames(this.environment.names)
     // Restore old environment
+    this.globalNamesInCurrentFunction = oldGlobalNames;
     this.functionScope = null;
     this.environment = oldEnv;
   }
@@ -337,7 +362,9 @@ export class Resolver implements StmtNS.Visitor<void>, ExprNS.Visitor<void> {
     this.resolve(stmt.value);
   }
   visitForStmt(stmt: StmtNS.For): void {
-    this.environment?.declareName(stmt.target);
+    if (!this.globalNamesInCurrentFunction.has(stmt.target.lexeme)) {
+      this.environment?.declareName(stmt.target);
+    }
     this.resolve(stmt.iter);
     this.resolve(stmt.body);
   }
@@ -347,11 +374,36 @@ export class Resolver implements StmtNS.Visitor<void>, ExprNS.Visitor<void> {
     this.resolve(stmt.body);
     this.resolve(stmt.elseBlock);
   }
-  // @TODO we need to treat all global statements as variable declarations in the global
-  // scope.
   visitGlobalStmt(_stmt: StmtNS.Global): void {
-    // Do nothing because global can also be declared in our
-    // own scope.
+    // All work is done in visitFunctionDefStmt (scanning + declaring in the global env).
+    // At the top level `global x` is a no-op (already in global scope).
+  }
+
+  // Recursively collects names declared with `global` anywhere in the function body,
+  // without descending into nested function/lambda definitions.
+  private scanGlobalDeclarations(stmts: StmtNS.Stmt[]): Set<string> {
+    const globals = new Set<string>();
+    const scan = (stmts: StmtNS.Stmt[]) => {
+      for (const stmt of stmts) {
+        if (stmt instanceof StmtNS.Global) {
+          globals.add(stmt.name.lexeme);
+        } else if (stmt instanceof StmtNS.If) {
+          scan(stmt.body);
+          if (Array.isArray(stmt.elseBlock)) {
+            scan(stmt.elseBlock);
+          } else if (stmt.elseBlock) {
+            scan([stmt.elseBlock]);
+          }
+        } else if (stmt instanceof StmtNS.While) {
+          scan(stmt.body);
+        } else if (stmt instanceof StmtNS.For) {
+          scan(stmt.body);
+        }
+        // Do not recurse into FunctionDef or Lambda bodies.
+      }
+    };
+    scan(stmts);
+    return globals;
   }
   // @TODO nonlocals mean that any variable following that name in the current env
   // should not create a variable declaration, but instead point to an outer variable.

--- a/src/tests/global-keyword.test.ts
+++ b/src/tests/global-keyword.test.ts
@@ -1,0 +1,197 @@
+import { FeatureNotSupportedError } from "../validator";
+import { generateTestCases, toPythonAstAndResolve } from "./utils";
+import math from "../stdlib/math";
+import misc from "../stdlib/misc";
+import list from "../stdlib/list";
+import linkedList from "../stdlib/linked-list";
+
+// ── Resolver: global is rejected in chapters 1 and 2 ────────────────────────
+
+describe("global keyword — validator", () => {
+  test("global inside a function is rejected in chapter 1", () => {
+    const code = `
+def f():
+    global x
+    x = 1
+`;
+    expect(() => toPythonAstAndResolve(code, 1)).toThrow(FeatureNotSupportedError);
+  });
+
+  test("global inside a function is rejected in chapter 2", () => {
+    const code = `
+def f():
+    global x
+    x = 1
+`;
+    expect(() => toPythonAstAndResolve(code, 2)).toThrow(FeatureNotSupportedError);
+  });
+
+  test("global inside a function is accepted in chapter 3", () => {
+    const code = `
+x = 0
+def f():
+    global x
+    x = 1
+`;
+    expect(() => toPythonAstAndResolve(code, 3)).not.toThrow();
+  });
+
+  test("global inside a function is accepted in chapter 4", () => {
+    const code = `
+x = 0
+def f():
+    global x
+    x = 1
+`;
+    expect(() => toPythonAstAndResolve(code, 4)).not.toThrow();
+  });
+
+  test("global for a name not yet declared at module level is accepted by resolver", () => {
+    // The name is introduced by the global declaration itself; no pre-existing binding required
+    const code = `
+def f():
+    global x
+    x = 1
+`;
+    expect(() => toPythonAstAndResolve(code, 3)).not.toThrow();
+  });
+});
+
+// ── CSE interpreter: runtime semantics ───────────────────────────────────────
+
+const ch3 = [misc, math, linkedList, list];
+
+generateTestCases(
+  {
+    "global keyword — basic write": [
+      [
+        `
+x = 0
+def f():
+    global x
+    x = 42
+f()
+x
+`,
+        42n,
+        null,
+      ],
+    ],
+
+    "global keyword — read before local assignment": [
+      [
+        `
+x = 99
+def f():
+    global x
+    x
+f()
+x
+`,
+        99n,
+        null,
+      ],
+    ],
+
+    "global keyword — write then read at module level": [
+      [
+        `
+x = 1
+def increment():
+    global x
+    x = x + 1
+increment()
+increment()
+increment()
+x
+`,
+        4n,
+        null,
+      ],
+    ],
+
+    "global keyword — does not affect local of same name in other function": [
+      [
+        `
+x = 10
+def uses_global():
+    global x
+    x = 20
+def uses_local():
+    x = 99
+uses_global()
+uses_local()
+x
+`,
+        20n,
+        null,
+      ],
+    ],
+
+    "global keyword — nested function: global skips enclosing scope": [
+      [
+        `
+x = 1
+def outer():
+    x = 100
+    def inner():
+        global x
+        x = 2
+    inner()
+outer()
+x
+`,
+        2n,
+        null,
+      ],
+    ],
+
+    "global keyword — declared in if branch inside function": [
+      [
+        `
+x = 0
+def f():
+    global x
+    if True:
+        x = 7
+f()
+x
+`,
+        7n,
+        null,
+      ],
+    ],
+
+    "global keyword — global name created by function (not pre-existing)": [
+      [
+        `
+def f():
+    global y
+    y = 55
+f()
+y
+`,
+        55n,
+        null,
+      ],
+    ],
+
+    "global keyword — print output uses global value": [
+      [
+        `
+count = 0
+def bump():
+    global count
+    count = count + 1
+bump()
+bump()
+print(count)
+`,
+        null,
+        ["2"],
+      ],
+    ],
+  },
+  3,
+  ch3,
+);

--- a/src/validator/features/no-global.ts
+++ b/src/validator/features/no-global.ts
@@ -1,0 +1,10 @@
+import { StmtNS } from "../../ast-types";
+import { ASTNode, FeatureNotSupportedError, FeatureValidator } from "../types";
+
+export const NoGlobalValidator: FeatureValidator = {
+  validate(node: ASTNode): void {
+    if (node instanceof StmtNS.Global) {
+      throw new FeatureNotSupportedError("global statements", node);
+    }
+  },
+};

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -9,6 +9,7 @@ export { NoIsOperatorValidator } from "./features/no-is-operator";
 export { NoLambdaValidator } from "./features/no-lambda";
 export { NoListsValidator } from "./features/no-lists";
 export { NoLoopsValidator } from "./features/no-loops";
+export { NoGlobalValidator } from "./features/no-global";
 export { NoNonlocalValidator } from "./features/no-nonlocal";
 export { createNoReassignmentValidator, NoReassignmentValidator } from "./features/no-reassignment";
 export { NoRestParamsValidator } from "./features/no-rest-params";

--- a/src/validator/sublanguages.ts
+++ b/src/validator/sublanguages.ts
@@ -5,6 +5,7 @@ import { NoBreakContinueValidator } from "./features/no-break-continue";
 import { NoIsOperatorValidator } from "./features/no-is-operator";
 import { NoListsValidator } from "./features/no-lists";
 import { NoLoopsValidator } from "./features/no-loops";
+import { NoGlobalValidator } from "./features/no-global";
 import { NoNonlocalValidator } from "./features/no-nonlocal";
 import { createNoReassignmentValidator } from "./features/no-reassignment";
 import { NoRestParamsValidator } from "./features/no-rest-params";
@@ -21,6 +22,7 @@ export function makeChapter1Validators(): FeatureValidator[] {
     NoLoopsValidator,
     createNoReassignmentValidator(),
     NoBreakContinueValidator,
+    NoGlobalValidator,
     NoNonlocalValidator,
     NoRestParamsValidator,
     NoSpreadValidator,
@@ -30,7 +32,7 @@ export function makeChapter1Validators(): FeatureValidator[] {
 }
 
 /**
- * Source Chapter 2: no lists, no loops, no reassignment, no break/continue, no nonlocal, no rest params, no annotated assignments, no is operator.
+ * Source Chapter 2: no lists, no loops, no reassignment, no break/continue, no global, no nonlocal, no rest params, no annotated assignments, no is operator.
  * Linked-list library available (None as linked list expression).
  */
 export function makeChapter2Validators(): FeatureValidator[] {
@@ -39,6 +41,7 @@ export function makeChapter2Validators(): FeatureValidator[] {
     NoLoopsValidator,
     createNoReassignmentValidator(),
     NoBreakContinueValidator,
+    NoGlobalValidator,
     NoNonlocalValidator,
     NoRestParamsValidator,
     NoSpreadValidator,


### PR DESCRIPTION
## Summary

- Adds runtime support for the `global` keyword in the CSE interpreter (chapters 3 and 4)
- Resolver pre-pass now skips globally-declared names when hoisting local assignments, preventing false `UnboundLocalError`s
- `NoGlobalValidator` blocks `global` in chapters 1 and 2, matching the BNF spec added in #162

## Changes

**`src/engines/cse/closure.ts`**
- Added `globalVariables: Set<string>` field to store names declared `global` in a function body

**`src/engines/cse/utils.ts`**
- `scanForGlobalDeclarations` — scans a function body for `global` declarations without recursing into nested functions
- `scanForAssignments` — extended with an exclusion set so globally-declared names are not marked as locals
- `getProgramEnvironment` / `pyGetGlobalVariable` — helpers to resolve names starting from the module-level scope, bypassing intermediate function frames

**`src/engines/cse/interpreter.ts`**
- `Global` node: no-op handler (semantics are encoded at `FunctionDef` time via `Closure.globalVariables`)
- `Variable`: routes reads through `pyGetGlobalVariable` when the name is in the current closure's `globalVariables`
- `FunctionDef`: scans global declarations and passes them to the new `Closure` field
- `ASSIGNMENT`: writes to `programEnvironment` when the assigned name is globally declared

**`src/resolver/resolver.ts`**
- Tracks globally-declared names per function scope; skips `declareName` for those names in the pre-pass and loop-target hoisting

**`src/validator/features/no-global.ts`** *(new)*
- `NoGlobalValidator` — rejects `global` statements in chapters 1 and 2

**`src/tests/global-keyword.test.ts`** *(new)*
- 13 tests covering validator rejection (ch1/2), resolver acceptance (ch3/4), and CSE runtime behaviour (basic write, read-through, repeated mutation, scope isolation, nested bypass, conditional branch, late creation, print output)

## Test plan

- [ ] `npm test` — all 13 new tests pass, no regressions
- [ ] Manual: `global x; x = 99` inside a function updates the module-level binding
- [ ] Manual: nested function with `global x` bypasses the enclosing function's local `x`
- [ ] Manual: chapters 1 and 2 reject `global` with a validator error