### PR TITLE
fix: buffer stdout so multiple print statements all appear

### DIFF
--- a/src/conductor/PyCseEvaluator.ts
+++ b/src/conductor/PyCseEvaluator.ts
@@ -5,9 +5,9 @@ import { Control } from "../engines/cse/control";
 import { evaluate } from "../engines/cse/interpreter";
 import { Stash } from "../engines/cse/stash";
 import {
+  createBufferedOutputStream,
   createErrorStream,
   createInputStream,
-  createOutputStream,
   destroyStreams,
   displayError,
 } from "../engines/cse/streams";
@@ -76,10 +76,11 @@ abstract class PyCseEvaluatorBase extends BasicEvaluator {
   }
 
   async evaluateChunk(chunk: string): Promise<void> {
+    const { context: stdout, flush: flushOutput } = createBufferedOutputStream();
     try {
       this.context.streams = {
         initialised: true,
-        stdout: createOutputStream(this.conductor),
+        stdout,
         stderr: createErrorStream(this.conductor),
         stdin: createInputStream(this.conductor),
       };
@@ -130,11 +131,14 @@ abstract class PyCseEvaluatorBase extends BasicEvaluator {
           script,
           maxSnapshots,
         );
+        flushOutput(this.conductor);
         this.csePlugin.sendSnapshots(snapshots);
       } else {
         await collectSnapshots(this.context, control, stash, 100000, -1, this.variant, script, 0);
+        flushOutput(this.conductor);
       }
     } catch (e) {
+      flushOutput(this.conductor);
       const errors = Array.isArray(e) ? e : [e];
       await Promise.all(
         errors.map(e => {

--- a/src/engines/cse/streams.ts
+++ b/src/engines/cse/streams.ts
@@ -37,7 +37,10 @@ export function createBufferedOutputStream(): {
   return {
     context: { stream, writer },
     flush: (conductor: IRunnerPlugin) => {
-      if (buffer) conductor.sendOutput(buffer);
+      if (buffer !== "") {
+        conductor.sendOutput(buffer);
+        buffer = "";
+      }
     },
   };
 }

--- a/src/engines/cse/streams.ts
+++ b/src/engines/cse/streams.ts
@@ -23,6 +23,25 @@ export function createOutputStream(conductor: IRunnerPlugin): WritableContext<st
   return { stream, writer };
 }
 
+export function createBufferedOutputStream(): {
+  context: WritableContext<string>;
+  flush: (conductor: IRunnerPlugin) => void;
+} {
+  let buffer = "";
+  const stream = new WritableStream<string>({
+    write: chunk => {
+      buffer += chunk;
+    },
+  });
+  const writer = stream.getWriter();
+  return {
+    context: { stream, writer },
+    flush: (conductor: IRunnerPlugin) => {
+      if (buffer) conductor.sendOutput(buffer);
+    },
+  };
+}
+
 export function createErrorStream(conductor: IRunnerPlugin): WritableContext<ConductorError> {
   const stream = new WritableStream<ConductorError>({
     write: chunk => {

--- a/src/tests/streams.test.ts
+++ b/src/tests/streams.test.ts
@@ -1,0 +1,37 @@
+import { createBufferedOutputStream } from "../engines/cse/streams";
+
+describe("createBufferedOutputStream", () => {
+  const makeMockConductor = () => {
+    const calls: string[] = [];
+    return {
+      sendOutput: (msg: string) => calls.push(msg),
+      calls,
+    };
+  };
+
+  it("flushes all written chunks as a single sendOutput call", async () => {
+    const { context, flush } = createBufferedOutputStream();
+    await context.writer.write("hello ");
+    await context.writer.write("world\n");
+    const { sendOutput, calls } = makeMockConductor();
+    flush({ sendOutput } as never);
+    expect(calls).toEqual(["hello world\n"]);
+  });
+
+  it("does not call sendOutput when buffer is empty", () => {
+    const { flush } = createBufferedOutputStream();
+    const { sendOutput, calls } = makeMockConductor();
+    flush({ sendOutput } as never);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("clears buffer after flush so double-flush never duplicates output", async () => {
+    const { context, flush } = createBufferedOutputStream();
+    await context.writer.write("line\n");
+    const { sendOutput, calls } = makeMockConductor();
+    flush({ sendOutput } as never);
+    flush({ sendOutput } as never);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe("line\n");
+  });
+});


### PR DESCRIPTION
Fixes #175

## Root cause

Each `print()` call writes to a `WritableStream` that immediately calls `conductor.sendOutput(chunk)`, posting a separate message to the host for each line.

On the frontend, `handleStdout` (a redux-saga) processes one message per loop iteration via `yield take(outputChan)`. When the program finishes, `handleStatuses` receives STATUS STOPPED and dispatches `beginInterruptExecution`, which causes the parent saga to cancel `stdoutTask`. The saga scheduler can give `handleStatuses` a turn between `handleStdout` iterations, so `stdoutTask` gets cancelled while unprocessed messages are still buffered in `outputChan` — only the first print shows.

## Fix

Replace the streaming `WritableStream` (one `sendOutput` per write) with a local buffer that collects all output during `collectSnapshots`, then flushes the entire buffer as a **single** `sendOutput` call before sending CSE snapshots. One message → one `handleStdout` iteration → no race.

The flush also runs in the `catch` path so output printed before a runtime error is still shown.

## Changes

- **`src/engines/cse/streams.ts`**: add `createBufferedOutputStream()` — a `WritableContext<string>` that collects chunks and returns a `flush(conductor)` function
- **`src/conductor/PyCseEvaluator.ts`**: use `createBufferedOutputStream` instead of `createOutputStream`; call `flushOutput(this.conductor)` in both the success and error paths before cleanup

## Test plan

- [x] All existing tests pass (`yarn test`)
- [ ] Manual: run a Python program with multiple `print()` calls — all lines appear in the REPL output