### PR TITLE
docs: add local frontend testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ In either case, the evaluator is compiled to `dist/<evaluatorName>.js` and `dist
 
 Refer to the [Conductor's Quick Start Guide](https://github.com/source-academy/conductor?tab=readme-ov-file#quick-start-guide)
 
+### Using your py-slang in your local Source Academy
+
+A common issue when developing modifications to py-slang is how to test it using your own local frontend. Unlike [js-slang](https://github.com/source-academy/js-slang), py-slang isn't a build-time npm dependency of the frontend — it's loaded at runtime as a Conductor evaluator bundle, resolved via a URL from the [Language Directory](https://github.com/source-academy/language-directory).
+
+First, build the evaluator you want to test and serve it locally, e.g.:
+
+```shell
+yarn build --evaluator PyCseEvaluator4
+npx http-server dist -p 4001 --cors
+```
+
+This serves the built bundle at `http://localhost:4001/PyCseEvaluator4.js`. Then run your own local copy of the [Language Directory](https://github.com/source-academy/language-directory) with the relevant Python evaluator's `path` pointed at that URL instead of the deployed one, and configure your local frontend to use it — see the Language Directory's [Local testing](https://github.com/source-academy/language-directory#local-testing) instructions for how to wire this up.
+
 ### Running the Wasm evaluator locally
 
 To run the Wasm compiler locally, run

--- a/README.md
+++ b/README.md
@@ -63,10 +63,12 @@ Refer to the [Conductor's Quick Start Guide](https://github.com/source-academy/c
 
 A common issue when developing modifications to py-slang is how to test it using your own local frontend. Unlike [js-slang](https://github.com/source-academy/js-slang), py-slang isn't a build-time npm dependency of the frontend — it's loaded at runtime as a Conductor evaluator bundle, resolved via a URL from the [Language Directory](https://github.com/source-academy/language-directory).
 
-First, build the evaluator you want to test and serve it locally, e.g.:
+First, build the evaluator you want to test (or run it in watch mode using yarn dev) and serve it locally, e.g.:
 
 ```shell
 yarn build --evaluator PyCseEvaluator4
+## OR
+yarn dev --evaluator PyCseEvaluator4
 npx http-server dist -p 4001 --cors
 ```
 


### PR DESCRIPTION
## Summary
- js-slang's README has a "Using your js-slang in your local Source Academy" section explaining how to test local changes against a local frontend. py-slang has no equivalent anywhere.
- Since py-slang is loaded at runtime as a Conductor evaluator bundle (resolved via the [Language Directory](https://github.com/source-academy/language-directory)), rather than being a build-time npm dependency like js-slang, the workflow is necessarily different: build + serve the evaluator bundle locally, then point a local Language Directory at it (see its own "Local testing" section for the frontend-side wiring).
- Adds a "Using your py-slang in your local Source Academy" section under `## Usage`, mirroring js-slang's naming.

## Test plan
- [x] Docs-only change; the referenced commands (`yarn build --evaluator`, `npx http-server`) and the Language Directory's local-testing flag names were verified end-to-end while testing an unrelated CSE machine PR.