### PR TITLE
fix(cse): defer environment restoration on return to the ENVIRONMENT instruction

### DIFF
--- a/src/engines/cse/interpreter.ts
+++ b/src/engines/cse/interpreter.ts
@@ -851,12 +851,16 @@ const cmdEvaluators: CmdEvaluators = {
   [InstrType.RESET]: function (
     _code: string,
     _command: ResetInstr,
-    context: Context,
+    _context: Context,
     _control: Control,
     _stash: Stash,
     _isPrelude: boolean,
   ) {
-    popEnvironment(context);
+    // Environment restoration is handled entirely by the paired ENVIRONMENT instruction
+    // (always pushed immediately below this RESET by the APPLICATION handler), whose while
+    // loop pops back to the caller's environment. Popping here too was redundant — it made
+    // the frame transition happen a step early, at the return statement itself, instead of
+    // at the ENVIRONMENT instruction where the CSE machine visualizer animates it.
   },
 
   [InstrType.ASSIGNMENT]: function (

--- a/src/tests/PyCseMachinePlugin.test.ts
+++ b/src/tests/PyCseMachinePlugin.test.ts
@@ -525,4 +525,40 @@ describe("collectSnapshots", () => {
       expect(snap.currentLine).toBeGreaterThan(0);
     }
   });
+
+  it("frame transition on return happens at the ENVIRONMENT instruction, not the return statement itself", async () => {
+    const snapshots = await runAndCollect(
+      `def f():
+    return 1
+
+f()`,
+    );
+
+    // The step where "return" (RESET) is about to execute: the callee frame must still be
+    // the active one — the frame transition must not have happened yet.
+    const returnStepIndex = snapshots.findIndex(s => s.control[0]?.displayText === "return");
+    expect(returnStepIndex).toBeGreaterThan(-1);
+    const returnStep = snapshots[returnStepIndex];
+    const calleeFrame = returnStep.environments.find(e => e.name === "f");
+    expect(calleeFrame).toBeDefined();
+    expect(calleeFrame!.isActive).toBe(true);
+
+    // The very next step: RESET has fired (now a no-op) and is consumed. The callee frame
+    // must still be present and active — nothing should have changed yet.
+    const afterReturn = snapshots[returnStepIndex + 1];
+    const calleeFrameAfterReturn = afterReturn.environments.find(e => e.name === "f");
+    expect(calleeFrameAfterReturn).toBeDefined();
+    expect(calleeFrameAfterReturn!.isActive).toBe(true);
+
+    // Only once the ENVIRONMENT instruction executes does the active frame move back — the
+    // callee frame ("f") must no longer be the active one (it may still be listed, no longer
+    // on the call stack, or pruned entirely).
+    const envStepIndex = snapshots.findIndex(
+      (s, i) => i > returnStepIndex && s.control[0]?.displayText === "ENVIRONMENT",
+    );
+    expect(envStepIndex).toBeGreaterThan(returnStepIndex);
+    const afterEnvStep = snapshots[envStepIndex + 1];
+    const calleeFrameAfterEnv = afterEnvStep.environments.find(e => e.name === "f");
+    expect(calleeFrameAfterEnv?.isActive).not.toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes source-academy/frontend#4073: the CSE machine visualizer's frame transition on function return happened one step early, at the `return` statement itself, instead of at the `ENVIRONMENT` instruction where `EnvironmentAnimation` is meant to animate it.
- Root cause: `[InstrType.RESET]`'s handler called `popEnvironment(context)` directly. This is redundant — `ENVIRONMENT` is always pushed immediately below `RESET` by `APPLICATION` for every function call, and its own `while` loop already fully restores the environment back to the caller. js-slang's real CSE machine never touches the environment in `RESET` for exactly this reason.
- Removed the redundant pop from `RESET`; environment restoration is now handled entirely by `ENVIRONMENT`, matching js-slang's design.

## Test plan
- [x] New regression test: asserts the callee frame is still active immediately after the return step, and only stops being active once the `ENVIRONMENT` instruction's step has run.
- [x] `yarn jest` — 2449/2449 passing (no regressions; `nonlocal.test.ts` and `global-keyword.test.ts` specifically exercise environment-chain correctness and pass unaffected)
- [x] `yarn lint` — no new errors (pre-existing unrelated warnings only)
- [x] `npx prettier --check` — clean