### PR TITLE
fix(stepper): substitute a binding into the rest of the block on its own step

### DIFF
--- a/src/conductor/stepper/__tests__/getSteps.test.ts
+++ b/src/conductor/stepper/__tests__/getSteps.test.ts
@@ -673,6 +673,78 @@ describe("Python stepper — function values render as mu-terms (not inline bodi
   });
 });
 
+describe("Python stepper — a binding's substitution is visible on its own step, not the next", () => {
+  // A name binding (`VariableDeclaration`/`FunctionDeclaration`) substitutes its value into the rest
+  // of the block on the *same* contraction that declares it — matching how a call expression's
+  // argument substitution is already visible on its own "Substituted ..." step (`contractCall`), rather
+  // than only becoming visible one (unrelated) step later. The declaration itself still lingers one
+  // more step, highlighted green, before actually disappearing — the same "green flash before discard"
+  // `pass` gets — but that lingering must not delay the substitution's effect on the rest of the tree.
+
+  test("a variable's bound value already appears in the rest on its own 'Declared and substituted' step", () => {
+    const s = steps("x = 5\nx + 1");
+    const i = s.findIndex(
+      step =>
+        step.markers?.[0]?.explanation === "Declared and substituted x into the rest of the block",
+    );
+    expect(i).toBeGreaterThan(-1);
+
+    // The declaration is still present (green flash, like `pass`)...
+    expect(findNode(s[i].ast, n => n.type === "VariableDeclaration")).toBeDefined();
+    // ...but the rest's binary expression already has the literal substituted in, not a reference.
+    const bin = findNode(s[i].ast, n => n.type === "BinaryExpression");
+    expect(bin.left).toMatchObject({ type: "Literal", raw: "5" });
+
+    // Only the *next* step is where the declaration is actually gone.
+    expect(findNode(s[i + 1].ast, n => n.type === "VariableDeclaration")).toBeUndefined();
+  });
+
+  test("a def's mu-term already appears in the rest on its own 'Declared and substituted' step", () => {
+    const s = steps("def square(n):\n  return n * n\nsquare(4)");
+    const i = s.findIndex(
+      step =>
+        step.markers?.[0]?.explanation ===
+        "Declared and substituted square into the rest of the block",
+    );
+    expect(i).toBeGreaterThan(-1);
+
+    // The declaration site is still present, in its full (un-named) form...
+    expect(
+      findNode(s[i].ast, n => n.type === "FunctionDeclaration" && n.name === undefined),
+    ).toBeDefined();
+    // ...but the call in the rest already shows `square` substituted as the named mu-term value.
+    const call = findNode(s[i].ast, n => n.type === "CallExpression");
+    expect(call.callee).toMatchObject({ type: "FunctionDeclaration", name: "square" });
+
+    // Only the *next* step is where the declaration site is actually gone (just the mu-term remains).
+    expect(
+      findNode(s[i + 1].ast, n => n.type === "FunctionDeclaration" && n.name === undefined),
+    ).toBeUndefined();
+  });
+
+  test("a local binding inside a function body substitutes into the rest on the same step", () => {
+    // def f(x):
+    //   y = x + 1
+    //   return y
+    // f(1)
+    const s = steps("def f(x):\n  y = x + 1\n  return y\nf(1)");
+    const i = s.findIndex(
+      step =>
+        step.markers?.[0]?.explanation === "Declared and substituted y into the rest of the block",
+    );
+    expect(i).toBeGreaterThan(-1);
+
+    // `y`'s declaration (`y = 2`) still lingers...
+    expect(findNode(s[i].ast, n => n.type === "VariableDeclaration")).toBeDefined();
+    // ...but `return` already shows the substituted value, not a leftover `y` reference.
+    const ret = findNode(s[i].ast, n => n.type === "ReturnStatement");
+    expect(ret.argument).toMatchObject({ type: "Literal", raw: "2" });
+
+    // Only the *next* step is where the declaration is actually gone.
+    expect(findNode(s[i + 1].ast, n => n.type === "VariableDeclaration")).toBeUndefined();
+  });
+});
+
 describe("Python stepper — explanations mirror Source phrasing", () => {
   test("binary expression", () => {
     expect(explanations("1 + 2")).toContain("Evaluated binary expression 1 + 2");

--- a/src/conductor/stepper/reduce.ts
+++ b/src/conductor/stepper/reduce.ts
@@ -53,9 +53,15 @@ export interface ReduceResult {
    * of the program, removing a `pass`, inlining an `if`'s chosen branch — replaces or removes the
    * redex's containing statement outright, so with no override the value would jump straight from
    * "about to be discarded" (red) to "already gone", never appearing "just finished" (green). Such a
-   * contraction sets `postNode` to the *pre*-contraction tree (redex unchanged, marked via `postRedex`)
-   * so the after step shows the value highlighted green one last time before it disappears on the next
+   * contraction sets `postNode` to a tree with the redex still present (marked via `postRedex`) so the
+   * after step shows the value highlighted green one last time before it disappears on the next
    * contraction; `node` (with the statement actually gone) still becomes the next contraction's start.
+   * This is usually exactly the pre-contraction tree — the one exception is a name binding
+   * (`VariableDeclaration`/`FunctionDeclaration` in `stepHead`), where `postNode` already carries the
+   * bound value substituted into the rest of the block, so that substitution is visible from this same
+   * "Declared and substituted" step rather than only from the next one (matching how a call
+   * expression's argument substitution is already visible on its own "Substituted ..." step — see
+   * `contractCall` — rather than one step later).
    * Defaults to `node` — most contractions (binary/unary/logical/conditional/call/`return`/falling off
    * the end of a function — anything whose result is a value that visibly *replaces* the redex in
    * place, rather than removing its containing statement) need no override.
@@ -774,12 +780,17 @@ function stepHead(head: StepNode, rest: StepNode[]): HeadOutcome {
         init.type === "ArrowFunctionExpression" && init.name === undefined
           ? { ...init, name }
           : init;
+      // Substituted eagerly, not deferred to `node` alone: `postNewBody` (the after step's displayed
+      // tree) reuses this same substituted rest, so the substitution is already visible on this step's
+      // "Declared and substituted" (green) tree rather than only on the next, unrelated step — see the
+      // `postNode` doc comment on `ReduceResult` above.
+      const substitutedRest = rest.map(stmt => substitute(stmt, name, boundValue));
       return {
         kind: "step",
-        newBody: rest.map(stmt => substitute(stmt, name, boundValue)),
+        newBody: substitutedRest,
         preRedex: head,
         postRedex: head,
-        postNewBody: [head, ...rest],
+        postNewBody: [head, ...substitutedRest],
         explanation: `Declared and substituted ${name} into the rest of the block`,
         beforeExplanation: `Declaring and substituting ${name} into the rest of the block`,
       };
@@ -792,12 +803,15 @@ function stepHead(head: StepNode, rest: StepNode[]): HeadOutcome {
       const value: StepNode = { ...head, name };
       const params = paramNames(head);
       const paramsJoined = params.join(", ");
+      // See the identical `substitutedRest`/`postNewBody` note in the `VariableDeclaration` case above:
+      // this makes the substitution visible already on this step's after tree, not only the next one.
+      const substitutedRest = rest.map(stmt => substitute(stmt, name, value));
       return {
         kind: "step",
-        newBody: rest.map(stmt => substitute(stmt, name, value)),
+        newBody: substitutedRest,
         preRedex: head,
         postRedex: head,
-        postNewBody: [head, ...rest],
+        postNewBody: [head, ...substitutedRest],
         explanation: `Declared and substituted ${name} into the rest of the block`,
         beforeExplanation: `Declaring and substituting ${name} into the rest of the block`,
       };

--- a/src/conductor/stepper/reduce.ts
+++ b/src/conductor/stepper/reduce.ts
@@ -801,9 +801,7 @@ function stepHead(head: StepNode, rest: StepNode[]): HeadOutcome {
       // mu-term `name` you hover to reveal the body, instead of expanding the body inline. The
       // declaration site keeps its full `def` form (it carries no `name` marker). Mirrors Source.
       const value: StepNode = { ...head, name };
-      const params = paramNames(head);
-      const paramsJoined = params.join(", ");
-      // See the identical `substitutedRest`/`postNewBody` note in the `VariableDeclaration` case above:
+      // See the identical substitutedRest/postNewBody note in the VariableDeclaration case above:
       // this makes the substitution visible already on this step's after tree, not only the next one.
       const substitutedRest = rest.map(stmt => substitute(stmt, name, value));
       return {


### PR DESCRIPTION
## Summary

Consistency fix for the substitution stepper: a name binding's substitution into the rest of the block was visible one step *after* the step that claims to have already performed it.

For:
```python
def f(x):
    y = x + 1
    return y
f(1)
```
the step explained **"Declared and substituted y into the rest of the block"** (past tense — implying it already happened) still showed `return y` — the substitution of `y` only became visible on the *following*, unrelated step. This didn't match how function calls already behave: `f(1)`'s argument substitution is visible immediately on its own **"Substituted 1 into x of f"** step (`contractCall`), not the next one.

## Fix

`stepHead`'s `VariableDeclaration`/`FunctionDeclaration` cases (`reduce.ts`) now compute the substituted rest once and reuse it for both:
- `newBody` — the tree the next contraction starts from (unchanged behaviour), and
- `postNewBody` — the tree *this* step's own after (green) display uses (previously the unsubstituted `rest`).

The declaration itself still lingers, highlighted green, for exactly one more step before disappearing (the same "green flash before discard" `pass` gets) — only the timing of the substitution's effect on the rest of the program moves earlier, to the step whose explanation already claims it happened.

## Testing

Added a test suite ("a binding's substitution is visible on its own step, not the next") covering: a top-level variable binding, a top-level function declaration, and the local-binding-inside-a-function-body case from the report above. Confirmed each new test fails without the `reduce.ts` change (temporarily reverted it to check) before finalizing.

Full py-slang suite: **2451 passed** / 21 suites. `tsc`, ESLint, and Prettier all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
