### PR TITLE
Adopt Black for the CPython sicp package (python/)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,6 +21,20 @@ defaults:
     working-directory: python
 
 jobs:
+  format:
+    if: github.event_name != 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: python -m pip install --upgrade pip "black==26.5.1"
+      - name: Check formatting with Black
+        run: black --check --diff .
+
   test:
     if: github.event_name != 'release'
     runs-on: ubuntu-latest

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -29,3 +29,7 @@ Homepage = "https://github.com/source-academy/py-slang"
 [tool.setuptools]
 packages = ["sicp"]
 license-files = ["LICENSE"]
+
+[tool.black]
+line-length = 88
+target-version = ["py310", "py311", "py312", "py313"]

--- a/python/sicp/math.py
+++ b/python/sicp/math.py
@@ -64,6 +64,8 @@ math_trunc = _math.trunc
 math_ulp = _math.ulp
 
 # Added to CPython's math module only recently; provide fallbacks.
-math_cbrt = getattr(_math, "cbrt", lambda x: _math.copysign(abs(x) ** (1 / 3), x))  # 3.11+
-math_exp2 = getattr(_math, "exp2", lambda x: 2.0 ** x)  # 3.11+
+math_cbrt = getattr(
+    _math, "cbrt", lambda x: _math.copysign(abs(x) ** (1 / 3), x)
+)  # 3.11+
+math_exp2 = getattr(_math, "exp2", lambda x: 2.0**x)  # 3.11+
 math_fma = getattr(_math, "fma", lambda x, y, z: x * y + z)  # 3.13+

--- a/python/sicp/misc.py
+++ b/python/sicp/misc.py
@@ -25,7 +25,9 @@ def arity(f):
     try:
         sig = _inspect.signature(f)
     except (ValueError, TypeError):
-        error("arity expects a function with an inspectable signature, but encountered", f)
+        error(
+            "arity expects a function with an inspectable signature, but encountered", f
+        )
     params = list(sig.parameters.values())
     for i, p in enumerate(params):
         if p.kind is _inspect.Parameter.VAR_POSITIONAL:

--- a/python/sicp/stream.py
+++ b/python/sicp/stream.py
@@ -64,7 +64,9 @@ def stream_length(xs):
 
 
 def stream_map(f, s):
-    return None if is_none(s) else pair(f(head(s)), lambda: stream_map(f, stream_tail(s)))
+    return (
+        None if is_none(s) else pair(f(head(s)), lambda: stream_map(f, stream_tail(s)))
+    )
 
 
 def build_stream(fun, n):
@@ -93,7 +95,11 @@ def stream_reverse(xs):
 
 
 def stream_append(xs, ys):
-    return ys if is_none(xs) else pair(head(xs), lambda: stream_append(stream_tail(xs), ys))
+    return (
+        ys
+        if is_none(xs)
+        else pair(head(xs), lambda: stream_append(stream_tail(xs), ys))
+    )
 
 
 def stream_member(x, s):
@@ -108,9 +114,11 @@ def stream_remove(v, xs):
     return (
         None
         if is_none(xs)
-        else stream_tail(xs)
-        if v == head(xs)
-        else pair(head(xs), lambda: stream_remove(v, stream_tail(xs)))
+        else (
+            stream_tail(xs)
+            if v == head(xs)
+            else pair(head(xs), lambda: stream_remove(v, stream_tail(xs)))
+        )
     )
 
 

--- a/python/tests/test_sicp.py
+++ b/python/tests/test_sicp.py
@@ -42,7 +42,9 @@ def test_lists_and_equal():
 def test_streams():
     assert eval_stream(integers_from(1), 4) == llist(1, 2, 3, 4)
     assert stream_ref(integers_from(10), 5) == 15
-    assert eval_stream(stream_map(lambda x: x * x, integers_from(1)), 3) == llist(1, 4, 9)
+    assert eval_stream(stream_map(lambda x: x * x, integers_from(1)), 3) == llist(
+        1, 4, 9
+    )
     assert is_stream(enum_stream(1, 3))
 
 
@@ -93,7 +95,9 @@ def test_misc_and_math():
 if __name__ == "__main__":
     import traceback
 
-    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    tests = [
+        v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)
+    ]
     failures = 0
     for t in tests:
         try:


### PR DESCRIPTION
## Summary

Adopt [Black](https://black.readthedocs.io/) as the formatter for the `python/` package (`sourceacademy-sicp`), so style is consistent and stops being a review topic. "Almost no config" is the whole point — the only knob set is `line-length`.

- **`python/pyproject.toml`** — `[tool.black]` with `line-length = 88` and `target-version = ["py310", "py311", "py312", "py313"]` (matches `requires-python` and the test matrix).
- **CI** — a new `format` job in `.github/workflows/python-package.yml` running a **pinned** `black==26.5.1 --check --diff` on Python 3.13, so the check can't drift as Black's stable style evolves year to year.
- **One-time reformat** — `black .` over the package.

No behavior change; the existing suite still passes 7/7.

## Sequencing

Based on **`python-package`** (#195), not `main`, because the `python/` directory only exists in that PR. It will **sit until #195 merges, then rebase onto `main`**.

## Note

Pinning the Black version (rather than tracking latest) is deliberate: an unpinned `black --check` in CI silently breaks on unrelated PRs whenever Black ships a new stable style. Bumping the pin is then a one-line, intentional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)