### PR TITLE
Cleanly skip complex-number test cases in the native Pynter parity harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,34 @@ Ensure that all tests pass before committing.
 yarn test
 ```
 
+#### Running the PVML/Pynter native parity suite
+
+`yarn test` always runs the CSE machine tests. It also includes an opt-in suite —
+`generateNativePynterTestCases()` in `src/tests/utils.ts`, used by the `stdlib`, `global-keyword`,
+`nonlocal`, `loops`, `linked-list`, `pairmutator`, `list`, `stream`, and `parser-stdlib` test files
+— that reruns the same test cases through the PVML compiler and a native
+[Pynter](https://github.com/source-academy/pynter) `runner` binary instead (see "Running the
+standalone CLI (repl)" above for background). It's skipped by default, since it needs a locally
+built Pynter binary that CI doesn't have.
+
+To run it, build `runner` from the Pynter repo (see its
+[build instructions](https://github.com/source-academy/pynter#build-locally)) and point
+`PYNTER_RUNNER_PATH` at the resulting binary:
+
+```shell
+PYNTER_RUNNER_PATH=../pynter/build/runner/runner yarn test
+```
+
+Failures here are expected and informative, not a sign of broken infra: the PVML compiler
+currently only wires up the `misc` and `math` stdlib groups, so anything relying on linked lists,
+streams, or mutable pairs/lists fails at analysis, not at Pynter. Complex-number cases are cleanly
+skipped rather than counted as failures or passes, since Pynter's VM has no complex number type at
+all. To see just this suite's results, filter by its test-name tag:
+
+```shell
+PYNTER_RUNNER_PATH=../pynter/build/runner/runner yarn jest -t "\[pvml/pynter\]"
+```
+
 ### Regenerating the AST types and Parser
 
 The AST types need to be regenerated after changing

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -386,6 +386,19 @@ function expectedToComparable(expected: TestOutputValue): unknown {
 }
 
 /**
+ * Whether a test case involves complex numbers, which Pynter's VM doesn't support
+ * at all (it mirrors Sinter: values are booleans, 32-bit ints, or single-precision
+ * floats only) — py-slang's own PVML compiler rejects complex literals outright
+ * (see PVMLCompiler.visitComplexExpr). Detected via the expected value's type or a
+ * complex-literal regex over the source, since a case can involve complex numbers
+ * as an intermediate value without one being the final `expected` result (e.g. a
+ * comparison, or an error case).
+ */
+function involvesComplexNumbers(code: string, expected: TestExpectedValue): boolean {
+  return expected instanceof PyComplexNumber || /\b\d+(\.\d+)?j\b/.test(code);
+}
+
+/**
  * Reruns `testCases` (as already used with generateTestCases() for the CSE
  * machine) through the PVML compiler + native Pynter, at the given chapter
  * `variant`. See the file-level comment above for gating/expectations.
@@ -396,7 +409,7 @@ export const generateNativePynterTestCases = (testCases: TestCases, variant: num
 
   for (const [funcName, tests] of Object.entries(testCases)) {
     describeBlock(`[pvml/pynter] ${funcName}`, () => {
-      test.each(createInternalTestCases(tests))(`$label`, async ({ code, expected, output }) => {
+      const runTestCase = async ({ code, expected, output }: InternalTestCase) => {
         let result;
         try {
           result = await runCodePvmlDetailed(code, variant, { pynterPath: pynterPath! });
@@ -427,7 +440,27 @@ export const generateNativePynterTestCases = (testCases: TestCases, variant: num
         } else {
           expect(actual).toEqual(wanted);
         }
-      });
+      };
+
+      const internalTestCases = createInternalTestCases(tests);
+      const supported = internalTestCases.filter(
+        ({ code, expected }) => !involvesComplexNumbers(code, expected),
+      );
+      const unsupportedComplex = internalTestCases.filter(({ code, expected }) =>
+        involvesComplexNumbers(code, expected),
+      );
+
+      // test.each throws if given an empty array, rather than registering zero
+      // tests, so only call it for groups that actually have cases in each bucket.
+      if (supported.length > 0) {
+        test.each(supported)(`$label`, runTestCase);
+      }
+      if (unsupportedComplex.length > 0) {
+        test.skip.each(unsupportedComplex)(
+          `$label (Pynter does not support complex numbers)`,
+          runTestCase,
+        );
+      }
     });
   }
 };

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -385,17 +385,28 @@ function expectedToComparable(expected: TestOutputValue): unknown {
   return undefined;
 }
 
+/** Matches a Python imaginary-number literal: 3j, .5j, 1.2j, 1.j, 1e3j, 1e-3j, 1J, etc. */
+const COMPLEX_LITERAL_RE = /(?<![a-zA-Z_])(?:\d+\.\d*|\.\d+|\d+)(?:[eE][+-]?\d+)?[jJ]\b/;
+
+/** Whether `expected` is (or, if an array, contains) a PyComplexNumber. */
+function containsComplexNumber(expected: TestExpectedValue): boolean {
+  if (expected instanceof PyComplexNumber) return true;
+  if (Array.isArray(expected)) return expected.some(containsComplexNumber);
+  return false;
+}
+
 /**
  * Whether a test case involves complex numbers, which Pynter's VM doesn't support
  * at all (it mirrors Sinter: values are booleans, 32-bit ints, or single-precision
  * floats only) — py-slang's own PVML compiler rejects complex literals outright
- * (see PVMLCompiler.visitComplexExpr). Detected via the expected value's type or a
- * complex-literal regex over the source, since a case can involve complex numbers
- * as an intermediate value without one being the final `expected` result (e.g. a
+ * (see PVMLCompiler.visitComplexExpr). Detected via the expected value's type
+ * (recursing into arrays, e.g. a list of complex numbers) or a complex-literal
+ * regex over the source, since a case can involve complex numbers as an
+ * intermediate value without one being the final `expected` result (e.g. a
  * comparison, or an error case).
  */
 function involvesComplexNumbers(code: string, expected: TestExpectedValue): boolean {
-  return expected instanceof PyComplexNumber || /\b\d+(\.\d+)?j\b/.test(code);
+  return containsComplexNumber(expected) || COMPLEX_LITERAL_RE.test(code);
 }
 
 /**


### PR DESCRIPTION
## Summary

Pynter's VM has no complex number type at all (booleans, 32-bit ints, or single-precision floats only — it mirrors Sinter), and py-slang's own PVML compiler rejects complex literals outright (`PVMLCompiler.visitComplexExpr` throws unconditionally). Every native parity test case whose code contains a complex literal was therefore always failing to compile — but that showed up in two different, both-wrong ways:

- For cases expecting a specific value, a genuine failure.
- For cases expecting *some* error class (e.g. `["arity(1+0j)", TypeError, null]`), a **coincidental pass** — any thrown error satisfied the check, including this unrelated compile failure, so the test wasn't actually verifying what it claimed to.

This adds `involvesComplexNumbers()` in `src/tests/utils.ts`, checking either the expected value's type (`PyComplexNumber`) or a complex-literal regex over the source (since complex numbers can appear as an intermediate value without being the final `expected` result). `generateNativePynterTestCases()` now partitions each group into `supported` (runs normally) and `unsupportedComplex` (`test.skip.each`, with a label explaining why), so they show up as clean, individually-visible skips instead of muddying the pass/fail counts.

Also documents how to run this suite: a new "Running the PVML/Pynter native parity suite" subsection under README.md's "Running the test suite".

## Impact

Verified against a local Pynter build:

| Suite | Before | After (attempted / total unchanged) |
|---|---|---|
| stdlib (misc/math) | 504/911 | 408/685 attempted (226 cases skipped: 96 were coincidental passes, 130 genuine failures) |
| parser-stdlib | 12/97 | 12/95 attempted (2 cases skipped) |
| global-keyword, nonlocal, loops, linked-list, pairmutator, list, stream | unchanged | unchanged (no complex-number cases) |

With `PYNTER_RUNNER_PATH` unset, the full suite still reports exactly 1300 skipped (no behavior change when the harness itself is inactive, e.g. in CI).

## Test plan

- [x] `yarn tsc --noEmit`
- [x] `yarn lint` / `yarn format:ci`
- [x] `yarn jest` (no `PYNTER_RUNNER_PATH`) — unchanged: 2401 passed, 1300 skipped, 0 failed
- [x] `PYNTER_RUNNER_PATH=<path> yarn jest` — 228 complex-number cases now cleanly skip; verified per-suite counts above
- [x] Verified `test.each` on an empty array throws rather than registering zero tests (a real bug hit during development — fixed by guarding both `test.each` calls on non-empty arrays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)