### PR TITLE
Add a script to report native Pynter parity pass/fail as a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,16 @@ all. To see just this suite's results, filter by its test-name tag:
 PYNTER_RUNNER_PATH=../pynter/build/runner/runner yarn jest -t "\[pvml/pynter\]"
 ```
 
+Alternatively, `yarn pynter:report` (`scripts/pynter-parity-report.ts`) runs the whole suite and prints
+a Markdown table of pass/attempted counts and pass rate per test file — handy for seeing what to
+work on at a glance, or pasting into a PR description:
+
+```shell
+PYNTER_RUNNER_PATH=../pynter/build/runner/runner yarn pynter:report
+```
+
+Pass `--failures` to also list the full name of every failing test, grouped by suite.
+
 ### Regenerating the AST types and Parser
 
 The AST types need to be regenerated after changing

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jsdoc:clean": "./scripts/jsdoc.sh clean",
     "test": "jest",
     "test-coverage": "jest --coverage",
+    "pynter:report": "tsx scripts/pynter-parity-report.ts",
     "lint": "eslint --concurrency=auto src",
     "format": "prettier --write \"**/*.{ts,tsx,json,js,mjs}\"",
     "format:ci": "prettier --list-different \"**/*.{ts,tsx,json,js,mjs}\"",

--- a/scripts/pynter-parity-report.ts
+++ b/scripts/pynter-parity-report.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env tsx
+/**
+ * Reports pass/fail counts for the native Pynter parity suite
+ * (generateNativePynterTestCases in src/tests/utils.ts), broken down by test
+ * file, as a Markdown table — so it's easy to see what to work on next, and
+ * to paste straight into a PR description.
+ *
+ * Usage:
+ *   PYNTER_RUNNER_PATH=<path to Pynter's runner binary> yarn pynter:report
+ *   PYNTER_RUNNER_PATH=<path> yarn pynter:report --failures   # also list failing tests
+ */
+import { spawnSync } from "child_process";
+import { Command } from "commander";
+
+const TAG = "[pvml/pynter]";
+
+interface AssertionResult {
+  ancestorTitles: string[];
+  fullName: string;
+  status: "passed" | "failed" | "pending" | "skipped" | "todo";
+  failureMessages: string[];
+}
+
+interface JestTestResult {
+  name: string;
+  assertionResults: AssertionResult[];
+}
+
+interface JestJson {
+  testResults: JestTestResult[];
+}
+
+function suiteNameFor(filePath: string): string {
+  return (
+    filePath
+      .split("/")
+      .pop()
+      ?.replace(/\.test\.ts$/, "") ?? filePath
+  );
+}
+
+function runJest(): JestJson {
+  // Deliberately not using jest's own -t filter: it marks non-matching tests
+  // as "pending" rather than excluding them, which would be indistinguishable
+  // from a genuine (e.g. complex-number) skip. Filter by ancestor title below
+  // instead, over the full (unfiltered) result set.
+  const result = spawnSync("npx", ["jest", "--json"], {
+    encoding: "utf-8",
+    maxBuffer: 1024 * 1024 * 100,
+    env: process.env,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    console.error(result.stderr);
+    throw new Error("Failed to parse `jest --json` output (see stderr above).");
+  }
+}
+
+function main() {
+  const program = new Command()
+    .option("--failures", "Also list failing test names, grouped by suite")
+    .parse();
+  const { failures: listFailures } = program.opts<{ failures?: boolean }>();
+
+  if (!process.env.PYNTER_RUNNER_PATH) {
+    console.error(
+      "PYNTER_RUNNER_PATH is not set, so the native Pynter suite would be entirely skipped.\n" +
+        "Build Pynter's `runner` binary (see " +
+        "https://github.com/source-academy/pynter#build-locally) and set PYNTER_RUNNER_PATH to " +
+        "it, e.g.:\n\n" +
+        "  PYNTER_RUNNER_PATH=../pynter/build/runner/runner yarn pynter:report\n",
+    );
+    process.exit(1);
+  }
+
+  const report = runJest();
+
+  type Row = { suite: string; passed: number; failed: number; skipped: number };
+  const rows: Row[] = [];
+  const failuresBySuite = new Map<string, string[]>();
+
+  for (const testResult of report.testResults) {
+    const tagged = testResult.assertionResults.filter(a =>
+      a.ancestorTitles.some(t => t.startsWith(TAG)),
+    );
+    if (tagged.length === 0) continue;
+
+    const suite = suiteNameFor(testResult.name);
+    const passed = tagged.filter(a => a.status === "passed").length;
+    const failed = tagged.filter(a => a.status === "failed").length;
+    const skipped = tagged.length - passed - failed;
+    rows.push({ suite, passed, failed, skipped });
+
+    if (listFailures && failed > 0) {
+      failuresBySuite.set(
+        suite,
+        tagged.filter(a => a.status === "failed").map(a => a.fullName),
+      );
+    }
+  }
+
+  if (rows.length === 0) {
+    console.error(
+      `No tests tagged "${TAG}" ran. Did the build pick up PYNTER_RUNNER_PATH correctly?`,
+    );
+    process.exit(1);
+  }
+
+  rows.sort((a, b) => a.suite.localeCompare(b.suite));
+  const totals = rows.reduce(
+    (acc, r) => ({
+      passed: acc.passed + r.passed,
+      failed: acc.failed + r.failed,
+      skipped: acc.skipped + r.skipped,
+    }),
+    { passed: 0, failed: 0, skipped: 0 },
+  );
+
+  const pct = (passed: number, attempted: number) =>
+    attempted === 0 ? "n/a" : `${Math.round((passed / attempted) * 100)}%`;
+
+  const toRow = (suite: string, passed: number, failed: number, skipped: number) => {
+    const attempted = passed + failed;
+    return [suite, `${passed}/${attempted}`, String(skipped), pct(passed, attempted)];
+  };
+
+  const header = ["Suite", "Pass/Attempted", "Skipped (complex numbers)", "Pass rate"];
+  const body = rows.map(r => toRow(r.suite, r.passed, r.failed, r.skipped));
+  body.push(
+    toRow("**Total**", totals.passed, totals.failed, totals.skipped).map((cell, i) =>
+      i === 0 ? cell : `**${cell}**`,
+    ) as string[],
+  );
+
+  console.log(`| ${header.join(" | ")} |`);
+  console.log(`|${header.map(() => " --- ").join("|")}|`);
+  for (const row of body) {
+    console.log(`| ${row.join(" | ")} |`);
+  }
+
+  if (listFailures && failuresBySuite.size > 0) {
+    console.log("\nFailing tests:\n");
+    for (const [suite, names] of failuresBySuite) {
+      console.log(`${suite}:`);
+      for (const name of names) {
+        console.log(`  - ${name}`);
+      }
+    }
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Following up on #219: adds `scripts/pynter-parity-report.ts` (`yarn pynter:report`), which runs the full test suite and prints a Markdown table of pass/attempted counts, skipped-for-complex-numbers counts, and pass rate per test file — the same table shape that's been assembled by hand in PR descriptions so far, now generated directly from `jest --json` output.

Pass `--failures` to also list every failing test's full name, grouped by suite, for finding concrete cases to work on rather than just counts.

Note: deliberately doesn't use jest's own `-t` filter for this. `-t` marks non-matching tests as `"pending"` rather than excluding them from the JSON output, which would be indistinguishable from a genuine complex-number skip. The script instead filters by ancestor title (the `[pvml/pynter]` describe-block prefix) over the full, unfiltered result set.

This doesn't touch the existing `yarn jest -t "\[pvml/pynter\]"` instructions in the README — the script is documented as an additional option alongside them, not a replacement.

## Test plan

- [x] `yarn tsc --noEmit`
- [x] `yarn lint` / `yarn format:ci`
- [x] `yarn jest` — unaffected: 2401 passed, 1300 skipped, 0 failed
- [x] `PYNTER_RUNNER_PATH=<path> yarn pynter:report` — output matches the numbers from #219's manually-assembled table exactly (492/1072 attempted, 228 skipped, 46% pass rate)
- [x] `PYNTER_RUNNER_PATH=<path> yarn pynter:report --failures` — lists concrete failing test names per suite
- [x] Runs cleanly with a helpful error when `PYNTER_RUNNER_PATH` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)