### PR TITLE
PVML: fix compiler bugs, wire native Pynter groups/prelude, correct primitive mappings, add operator sweep

### DIFF
--- a/scripts/pynter-parity-report.ts
+++ b/scripts/pynter-parity-report.ts
@@ -129,7 +129,7 @@ function main() {
     return [suite, `${passed}/${attempted}`, String(skipped), pct(passed, attempted)];
   };
 
-  const header = ["Suite", "Pass/Attempted", "Skipped (complex numbers)", "Pass rate"];
+  const header = ["Suite", "Pass/Attempted", "Skipped (out of scope)", "Pass rate"];
   const body = rows.map(r => toRow(r.suite, r.passed, r.failed, r.skipped));
   body.push(
     toRow("**Total**", totals.passed, totals.failed, totals.skipped).map((cell, i) =>

--- a/src/engines/pvml/PVMLIRBuilder.ts
+++ b/src/engines/pvml/PVMLIRBuilder.ts
@@ -270,7 +270,7 @@ const STACK_EFFECTS = new Int16Array(OPCODE_MAX + 1);
   STACK_EFFECTS[OpCodes.STPB] = -1;
 
   // Array operations
-  STACK_EFFECTS[OpCodes.NEWA] = 0; // Takes size, produces array
+  STACK_EFFECTS[OpCodes.NEWA] = 1; // Takes no operand, produces an empty array (see visitListExpr)
   STACK_EFFECTS[OpCodes.LDAG] = -1;
   STACK_EFFECTS[OpCodes.LDAB] = -1;
   STACK_EFFECTS[OpCodes.LDAF] = -1;

--- a/src/engines/pvml/builtins.ts
+++ b/src/engines/pvml/builtins.ts
@@ -1,27 +1,140 @@
 import type { PVMLBoxType } from "./types";
-import { isPVMLObject } from "./types";
+import { getPVMLType, isPVMLObject, PVMLType } from "./types";
 import { MissingRequiredPositionalError, PVMLInterpreterError } from "./errors";
 
-// Map Python builtin names to PVML primitive opcode indices
+/**
+ * Maps canonical SICPy builtin names (as defined by the CSE machine's stdlib
+ * groups, src/stdlib/misc.ts and src/stdlib/math.ts — see VARIANT_GROUPS[1]
+ * in src/runner.ts) to PVML primitive opcode indices.
+ *
+ * These indices are NOT arbitrary: they must match the position of the
+ * corresponding function in native Pynter's `sivmfn_primitives[]` dispatch
+ * table (pynter/vm/src/primitives.c) exactly, since `CALLP`/`CALLTP` bake
+ * this number into the bytecode and the native VM uses it as a raw array
+ * index (see `sivmfn_primitives[ifn]` in pynter/vm/include/pynter/vm.h). A
+ * name with no native equivalent (e.g. `str`, `input`, complex numbers) is
+ * intentionally left out, so calling it surfaces as a clear
+ * NameNotFoundError at analysis time rather than silently invoking whatever
+ * unrelated native primitive happens to sit at a made-up index.
+ *
+ * `range` is a special case: for-loops compile it away entirely via the
+ * NEWITER opcode (PVMLCompiler.visitForStmt), so this entry only matters for
+ * range() called outside a for-loop, and only for this file's own TS-side
+ * PVMLInterpreter — native Pynter has no primitive for it at all.
+ *
+ * `str`/`repr` point at native Pynter's unimplemented `stringify` stub
+ * (index 90, `sivmfn_prim_unimpl`) rather than being left out: SICPy preludes
+ * (e.g. linked-list.prelude.ts's `llist_to_string`) reference `repr()`, and
+ * PVMLCompiler compiles a whole file eagerly — leaving the name out would
+ * block every function in the prelude from compiling, not just the one that
+ * calls it. Pointing it at the stub lets compilation succeed; it only faults
+ * if actually called at runtime.
+ *
+ * `is_integer`/`is_float`/`is_complex`/`_gen_list` have no Source-standard-
+ * library equivalent (Source's is_number() doesn't distinguish int/float,
+ * Source has no complex numbers, and nothing builds a None-filled array), so
+ * they were added as new native primitives appended to the end of Pynter's
+ * dispatch table (see SIVMFN_PRIMITIVE_COUNT in
+ * pynter/vm/include/pynter/internal_fn.h) rather than reused from an
+ * existing slot.
+ *
+ * `is_list`/`list_length` (list.ts, over Python list literals, which PVML
+ * represents as native's raw arrays) are deliberately mapped to native's
+ * `is_array`/`array_length`, NOT native's own `is_list`(19)/`length`(26) —
+ * those check "is/measure a proper cons-pair chain", which is the concept
+ * py-slang's *linked-list* prelude (`is_llist`/`length`) uses instead.
+ */
 export const PRIMITIVE_FUNCTIONS: Map<string, number> = new Map([
   ["print", 5],
   ["display", 5], // Alias for print
-  ["abs", 10],
-  ["min", 20],
-  ["max", 21],
-  ["pow", 22],
-  ["sqrt", 23],
-  ["floor", 24],
-  ["ceil", 25],
-  ["round", 26],
+  ["_gen_list", 95],
+  ["arity", 96],
+  ["error", 10],
+  ["head", 14],
+  ["is_list", 16], // Python list literal check; see note above.
+  ["is_pair", 22],
+  ["is_function", 18],
+  ["is_boolean", 17],
+  ["is_number", 21],
+  ["is_string", 24],
+  ["is_none", 20],
+  ["len", 2],
+  ["list_length", 2], // Same concept as len() for list.ts; see note above.
+  ["llist", 27], // Native `list(...)` builds an identical null-terminated cons chain.
   ["range", 30],
-  ["len", 31],
+  ["set_head", 74],
+  ["set_tail", 75],
+  ["stream", 76], // Variadic lazy-stream constructor; identical semantics to native's.
+  ["str", 90], // Unimplemented native stub; see comment above.
+  ["repr", 90],
+  ["tail", 89],
+  ["pair", 68],
+  ["is_integer", 92],
+  ["is_float", 93],
+  ["is_complex", 94],
+  ["abs", 32],
+  ["math_acos", 33],
+  ["math_acosh", 34],
+  ["math_asin", 35],
+  ["math_asinh", 36],
+  ["math_atan", 37],
+  ["math_atan2", 38],
+  ["math_atanh", 39],
+  ["math_cbrt", 40],
+  ["math_ceil", 41],
+  ["math_cos", 43],
+  ["math_cosh", 44],
+  ["math_exp", 45],
+  ["math_expm1", 46],
+  ["math_floor", 47],
+  ["math_log", 51],
+  ["math_log1p", 52],
+  ["math_log2", 53],
+  ["math_log10", 54],
+  ["max", 55],
+  ["min", 56],
+  ["math_pow", 57],
+  ["random_random", 58],
+  ["round", 59],
+  ["math_sin", 61],
+  ["math_sinh", 62],
+  ["math_sqrt", 63],
+  ["math_tan", 64],
+  ["math_tanh", 65],
+  ["math_trunc", 66],
 ]);
 
 function assertNumericArgs(args: PVMLBoxType[], fn: string): number[] {
   if (!args.every(a => typeof a === "number"))
     throw new PVMLInterpreterError(`TypeError: ${fn}() requires numeric arguments`);
   return args;
+}
+
+function unaryMath(args: PVMLBoxType[], name: string, fn: (x: number) => number): number {
+  if (args.length !== 1)
+    throw new MissingRequiredPositionalError(`${name}() takes exactly 1 argument`);
+  const [x] = assertNumericArgs(args, name);
+  return fn(x);
+}
+
+function binaryMath(args: PVMLBoxType[], name: string, fn: (a: number, b: number) => number): number {
+  if (args.length !== 2)
+    throw new MissingRequiredPositionalError(`${name}() takes exactly 2 arguments`);
+  const [a, b] = assertNumericArgs(args, name);
+  return fn(a, b);
+}
+
+/** A pair is represented as a 2-element PVMLArray, matching native Pynter's cons-array layout. */
+function pairArray(v: PVMLBoxType, fn: string): Extract<PVMLBoxType, { type: "array" }> {
+  if (!isPVMLObject(v) || v.type !== "array")
+    throw new PVMLInterpreterError(`TypeError: ${fn}() requires a pair argument`);
+  return v;
+}
+
+function pairElement(args: PVMLBoxType[], name: string, index: 0 | 1): PVMLBoxType {
+  if (args.length !== 1)
+    throw new MissingRequiredPositionalError(`${name}() takes exactly 1 argument`);
+  return pairArray(args[0], name).elements[index];
 }
 
 /**
@@ -34,75 +147,108 @@ export function executePrimitive(
   sendOutput: (message: string) => void,
 ): PVMLBoxType {
   switch (primitiveIndex) {
+    case 2: {
+      // len / list_length
+      if (args.length !== 1)
+        throw new MissingRequiredPositionalError("len() takes exactly 1 argument");
+      const v = args[0];
+      if (isPVMLObject(v) && v.type === "array") return v.elements.length;
+      throw new PVMLInterpreterError(`TypeError: object of type '${typeof v}' has no len()`);
+    }
+
     case 5: // print/display
       sendOutput(args.join(" "));
       return undefined;
 
-    case 10: {
-      // abs
-      if (args.length !== 1)
-        throw new MissingRequiredPositionalError("abs() takes exactly 1 argument");
-      const [x] = assertNumericArgs(args, "abs");
-      return Math.abs(x);
-    }
+    case 10: // error
+      throw new PVMLInterpreterError(`Error: ${args.map(String).join(" ")}`);
 
-    case 20: {
-      // min
-      if (args.length < 2)
-        throw new MissingRequiredPositionalError(
-          `min() takes at least 2 arguments (${args.length} given)`,
-        );
-      return Math.min(...assertNumericArgs(args, "min"));
-    }
+    case 14: // head
+      return pairElement(args, "head", 0);
 
-    case 21: {
-      // max
-      if (args.length < 2)
-        throw new MissingRequiredPositionalError(
-          `max() takes at least 2 arguments (${args.length} given)`,
-        );
-      return Math.max(...assertNumericArgs(args, "max"));
-    }
+    case 16: // is_list
+      return isPVMLObject(args[0]) && args[0].type === "array";
 
-    case 22: {
-      // pow
+    case 17: // is_boolean
+      return getPVMLType(args[0]) === PVMLType.BOOLEAN;
+
+    case 18: // is_function
+      return (
+        getPVMLType(args[0]) === PVMLType.CLOSURE || getPVMLType(args[0]) === PVMLType.PRIMITIVE
+      );
+
+    case 20: // is_none
+      return getPVMLType(args[0]) === PVMLType.NULL;
+
+    case 21: // is_number
+      return getPVMLType(args[0]) === PVMLType.NUMBER;
+
+    case 22: // is_pair
+      return isPVMLObject(args[0]) && args[0].type === "array" && args[0].elements.length === 2;
+
+    case 24: // is_string
+      return getPVMLType(args[0]) === PVMLType.STRING;
+
+    case 27: // llist
+      return args.reduceRight<PVMLBoxType>(
+        (acc, x) => ({ type: "array", elements: [x, acc] }),
+        null,
+      );
+
+    case 68: // pair
       if (args.length !== 2)
-        throw new MissingRequiredPositionalError("pow() takes exactly 2 arguments");
-      const [base, exp] = assertNumericArgs(args, "pow");
-      return Math.pow(base, exp);
+        throw new MissingRequiredPositionalError("pair() takes exactly 2 arguments");
+      return { type: "array", elements: [args[0], args[1]] };
+
+    case 74: // set_head
+      if (args.length !== 2)
+        throw new MissingRequiredPositionalError("set_head() takes exactly 2 arguments");
+      pairArray(args[0], "set_head").elements[0] = args[1];
+      return undefined;
+
+    case 75: // set_tail
+      if (args.length !== 2)
+        throw new MissingRequiredPositionalError("set_tail() takes exactly 2 arguments");
+      pairArray(args[0], "set_tail").elements[1] = args[1];
+      return undefined;
+
+    case 89: // tail
+      return pairElement(args, "tail", 1);
+
+    case 90: // str/repr: unimplemented, mirrors native Pynter's stringify stub
+      throw new PVMLInterpreterError(
+        "NotImplementedError: str()/repr() are not yet supported by the PVML/Pynter backend",
+      );
+
+    case 92: // is_integer
+      return typeof args[0] === "number" && Number.isInteger(args[0]);
+
+    case 93: // is_float
+      return typeof args[0] === "number" && !Number.isInteger(args[0]);
+
+    case 94: // is_complex: PVML has no complex number representation
+      return false;
+
+    case 95: {
+      // _gen_list
+      if (args.length !== 1)
+        throw new MissingRequiredPositionalError("_gen_list() takes exactly 1 argument");
+      const [n] = assertNumericArgs(args, "_gen_list");
+      return { type: "array", elements: new Array(n).fill(null) };
     }
 
-    case 23: {
-      // sqrt
-      if (args.length !== 1)
-        throw new MissingRequiredPositionalError("sqrt() takes exactly 1 argument");
-      const [n] = assertNumericArgs(args, "sqrt");
-      return Math.sqrt(n);
-    }
+    case 96: // arity: not implemented here (no access to function IR from this scope)
+      throw new PVMLInterpreterError(
+        "NotImplementedError: arity() is not yet supported by the PVML/Pynter backend",
+      );
 
-    case 24: {
-      // floor
-      if (args.length !== 1)
-        throw new MissingRequiredPositionalError("floor() takes exactly 1 argument");
-      const [n] = assertNumericArgs(args, "floor");
-      return Math.floor(n);
-    }
-
-    case 25: {
-      // ceil
-      if (args.length !== 1)
-        throw new MissingRequiredPositionalError("ceil() takes exactly 1 argument");
-      const [n] = assertNumericArgs(args, "ceil");
-      return Math.ceil(n);
-    }
-
-    case 26: {
-      // round
-      if (args.length !== 1)
-        throw new MissingRequiredPositionalError("round() takes exactly 1 argument");
-      const [n] = assertNumericArgs(args, "round");
-      return Math.round(n);
-    }
+    case 76: // stream: needs a runtime-synthesized continuation closure, which this
+      // TS interpreter can't create (closures reference statically compiled bytecode
+      // functions by index) — native Pynter can, since C continuations are built
+      // dynamically. No existing TS-interpreter-only test exercises this.
+      throw new PVMLInterpreterError(
+        "NotImplementedError: stream() is not yet supported by this TS interpreter",
+      );
 
     case 30: {
       // range
@@ -117,14 +263,89 @@ export function executePrimitive(
       return { type: "iterator", kind: "range", current: start, stop, step };
     }
 
-    case 31: {
-      // len
-      if (args.length !== 1)
-        throw new MissingRequiredPositionalError("len() takes exactly 1 argument");
-      const v = args[0];
-      if (isPVMLObject(v) && v.type === "array") return v.elements.length;
-      throw new PVMLInterpreterError(`TypeError: object of type '${typeof v}' has no len()`);
+    case 32: // abs
+      return unaryMath(args, "abs", Math.abs);
+    case 33: // math_acos
+      return unaryMath(args, "math_acos", Math.acos);
+    case 34: // math_acosh
+      return unaryMath(args, "math_acosh", Math.acosh);
+    case 35: // math_asin
+      return unaryMath(args, "math_asin", Math.asin);
+    case 36: // math_asinh
+      return unaryMath(args, "math_asinh", Math.asinh);
+    case 37: // math_atan
+      return unaryMath(args, "math_atan", Math.atan);
+    case 38: // math_atan2
+      return binaryMath(args, "math_atan2", Math.atan2);
+    case 39: // math_atanh
+      return unaryMath(args, "math_atanh", Math.atanh);
+    case 40: // math_cbrt
+      return unaryMath(args, "math_cbrt", Math.cbrt);
+    case 41: // math_ceil
+      return unaryMath(args, "math_ceil", Math.ceil);
+    case 43: // math_cos
+      return unaryMath(args, "math_cos", Math.cos);
+    case 44: // math_cosh
+      return unaryMath(args, "math_cosh", Math.cosh);
+    case 45: // math_exp
+      return unaryMath(args, "math_exp", Math.exp);
+    case 46: // math_expm1
+      return unaryMath(args, "math_expm1", Math.expm1);
+    case 47: // math_floor
+      return unaryMath(args, "math_floor", Math.floor);
+    case 51: // math_log
+      return unaryMath(args, "math_log", Math.log);
+    case 52: // math_log1p
+      return unaryMath(args, "math_log1p", Math.log1p);
+    case 53: // math_log2
+      return unaryMath(args, "math_log2", Math.log2);
+    case 54: // math_log10
+      return unaryMath(args, "math_log10", Math.log10);
+
+    case 55: {
+      // max
+      if (args.length < 2)
+        throw new MissingRequiredPositionalError(
+          `max() takes at least 2 arguments (${args.length} given)`,
+        );
+      return Math.max(...assertNumericArgs(args, "max"));
     }
+
+    case 56: {
+      // min
+      if (args.length < 2)
+        throw new MissingRequiredPositionalError(
+          `min() takes at least 2 arguments (${args.length} given)`,
+        );
+      return Math.min(...assertNumericArgs(args, "min"));
+    }
+
+    case 57: // math_pow
+      return binaryMath(args, "math_pow", Math.pow);
+
+    case 58: // random_random
+      return Math.random();
+
+    case 59: {
+      // round
+      if (args.length !== 1)
+        throw new MissingRequiredPositionalError("round() takes exactly 1 argument");
+      const [n] = assertNumericArgs(args, "round");
+      return Math.round(n);
+    }
+
+    case 61: // math_sin
+      return unaryMath(args, "math_sin", Math.sin);
+    case 62: // math_sinh
+      return unaryMath(args, "math_sinh", Math.sinh);
+    case 63: // math_sqrt
+      return unaryMath(args, "math_sqrt", Math.sqrt);
+    case 64: // math_tan
+      return unaryMath(args, "math_tan", Math.tan);
+    case 65: // math_tanh
+      return unaryMath(args, "math_tanh", Math.tanh);
+    case 66: // math_trunc
+      return unaryMath(args, "math_trunc", Math.trunc);
 
     default:
       throw new PVMLInterpreterError(`Unknown primitive function index: ${primitiveIndex}`);

--- a/src/engines/pvml/builtins.ts
+++ b/src/engines/pvml/builtins.ts
@@ -117,7 +117,11 @@ function unaryMath(args: PVMLBoxType[], name: string, fn: (x: number) => number)
   return fn(x);
 }
 
-function binaryMath(args: PVMLBoxType[], name: string, fn: (a: number, b: number) => number): number {
+function binaryMath(
+  args: PVMLBoxType[],
+  name: string,
+  fn: (a: number, b: number) => number,
+): number {
   if (args.length !== 2)
     throw new MissingRequiredPositionalError(`${name}() takes exactly 2 arguments`);
   const [a, b] = assertNumericArgs(args, name);

--- a/src/engines/pvml/builtins.ts
+++ b/src/engines/pvml/builtins.ts
@@ -130,7 +130,7 @@ function binaryMath(
 
 /** A pair is represented as a 2-element PVMLArray, matching native Pynter's cons-array layout. */
 function pairArray(v: PVMLBoxType, fn: string): Extract<PVMLBoxType, { type: "array" }> {
-  if (!isPVMLObject(v) || v.type !== "array")
+  if (!isPVMLObject(v) || v.type !== "array" || v.elements.length !== 2)
     throw new PVMLInterpreterError(`TypeError: ${fn}() requires a pair argument`);
   return v;
 }
@@ -157,7 +157,7 @@ export function executePrimitive(
         throw new MissingRequiredPositionalError("len() takes exactly 1 argument");
       const v = args[0];
       if (isPVMLObject(v) && v.type === "array") return v.elements.length;
-      throw new PVMLInterpreterError(`TypeError: object of type '${typeof v}' has no len()`);
+      throw new PVMLInterpreterError(`TypeError: object of type '${getPVMLType(v)}' has no len()`);
     }
 
     case 5: // print/display

--- a/src/engines/pvml/pvml-compiler.ts
+++ b/src/engines/pvml/pvml-compiler.ts
@@ -480,7 +480,9 @@ export class PVMLCompiler
     // Loading it here regardless would push a stray NEWCP value that CALLP
     // never consumes, corrupting the stack for every primitive call.
     const isPrimitiveCallee = this.getTokenAnnotation(callee.name).isPrimitive;
-    const functionStackEffect = isPrimitiveCallee ? 0 : this.emitLoadSymbol(callee.name).maxStackSize;
+    const functionStackEffect = isPrimitiveCallee
+      ? 0
+      : this.emitLoadSymbol(callee.name).maxStackSize;
 
     let maxArgStackSize = 0;
     for (let i = 0; i < expr.args.length; i++) {

--- a/src/engines/pvml/pvml-compiler.ts
+++ b/src/engines/pvml/pvml-compiler.ts
@@ -215,7 +215,7 @@ export class PVMLCompiler
       // to it, mirroring native Pynter's "ifn" nanbox tag. A direct call
       // (`print(x)`) never reaches this branch: emitFunctionCall emits
       // CALLP/CALLTP straight from the primitive index instead.
-      this.builder.emitUnary(OpCodes.NEWCP, annotation.primitiveIndex!);
+      this.builder.emitUnary(OpCodes.NEWCP, annotation.primitiveIndex);
       return { maxStackSize: 1 };
     }
     if (annotation.envLevel === 0) {
@@ -596,7 +596,7 @@ export class PVMLCompiler
 
     const initResult = this.compile(stmt.value);
 
-    this.emitStoreSymbol((stmt.target as ExprNS.Variable).name);
+    this.emitStoreSymbol(stmt.target.name);
 
     this.builder.emitNullary(OpCodes.LGCU);
     return initResult;

--- a/src/engines/pvml/pvml-compiler.ts
+++ b/src/engines/pvml/pvml-compiler.ts
@@ -31,9 +31,11 @@ export class PVMLCompiler
   private functionEnvironments: FunctionEnvironments;
   private isTailCall: boolean;
 
-  private tokenAnnotations = new WeakMap<Token, CompilerAnnotation>();
-  private envSlotCounters = new WeakMap<Environment, number>();
-  private envSlotMaps = new WeakMap<Environment, Map<string, number>>();
+  private tokenAnnotations: WeakMap<Token, CompilerAnnotation>;
+  private envSlotCounters: WeakMap<Environment, number>;
+  private envSlotMaps: WeakMap<Environment, Map<string, number>>;
+  /** The builder whose function scope corresponds to each Environment — see getOrAssignSlot(). */
+  private envBuilders: WeakMap<Environment, PVMLIRBuilder>;
   private tmpCounter = 0;
 
   private loopStack: Array<{
@@ -42,15 +44,35 @@ export class PVMLCompiler
     iteratorOnStack: boolean;
   }> = [];
 
+  /**
+   * `tokenAnnotations`/`envSlotCounters`/`envSlotMaps` default to fresh maps
+   * (the root compiler's case, via fromProgram) but MUST be passed through
+   * from `fromFunctionNode` when creating a child compiler for a nested
+   * function/lambda body. They track slot numbers per Environment object —
+   * if each nested compiler got its own fresh maps, the first time it
+   * resolves a name from an *enclosing* scope (e.g. a function referring to
+   * a sibling or to itself recursively) it would independently assign that
+   * name slot 0 in its own bookkeeping, colliding with whatever slot the
+   * parent compiler already assigned that same environment's other names.
+   */
   constructor(
     currentEnvironment: Environment,
     functionEnvironments: FunctionEnvironments,
     builder: PVMLIRBuilder,
+    tokenAnnotations: WeakMap<Token, CompilerAnnotation> = new WeakMap(),
+    envSlotCounters: WeakMap<Environment, number> = new WeakMap(),
+    envSlotMaps: WeakMap<Environment, Map<string, number>> = new WeakMap(),
+    envBuilders: WeakMap<Environment, PVMLIRBuilder> = new WeakMap(),
   ) {
     this.builder = builder;
     this.currentEnvironment = currentEnvironment;
     this.functionEnvironments = functionEnvironments;
     this.isTailCall = false;
+    this.tokenAnnotations = tokenAnnotations;
+    this.envSlotCounters = envSlotCounters;
+    this.envSlotMaps = envSlotMaps;
+    this.envBuilders = envBuilders;
+    this.envBuilders.set(currentEnvironment, builder);
   }
 
   /**
@@ -85,7 +107,15 @@ export class PVMLCompiler
     const numArgs = node.parameters.length;
     const builder = this.builder.createChildBuilder(numArgs);
 
-    const compiler = new PVMLCompiler(nextEnvironment, this.functionEnvironments, builder);
+    const compiler = new PVMLCompiler(
+      nextEnvironment,
+      this.functionEnvironments,
+      builder,
+      this.tokenAnnotations,
+      this.envSlotCounters,
+      this.envSlotMaps,
+      this.envBuilders,
+    );
 
     const slotMap = new Map<string, number>();
     compiler.envSlotMaps.set(nextEnvironment, slotMap);
@@ -163,7 +193,15 @@ export class PVMLCompiler
       slot = this.envSlotCounters.get(env)!;
       slotMap.set(name, slot);
       this.envSlotCounters.set(env, slot + 1);
-      this.builder.noteSymbolUsed();
+      // Charge the new local slot to whichever builder's function scope `env`
+      // actually is — NOT necessarily `this.builder`, since `env` can be an
+      // *enclosing* scope reached via a cross-scope reference (e.g. a
+      // function calling a sibling, or referring to itself recursively).
+      const owningBuilder = this.envBuilders.get(env);
+      if (!owningBuilder) {
+        throw new Error("No builder registered for environment");
+      }
+      owningBuilder.noteSymbolUsed();
     }
     return slot;
   }
@@ -172,7 +210,13 @@ export class PVMLCompiler
     const annotation = this.getTokenAnnotation(token);
 
     if (annotation.isPrimitive) {
-      return { maxStackSize: 0 };
+      // A primitive referenced as a value rather than called directly (e.g.
+      // `is_function(print)`, `f = abs`) — NEWCP pushes a callable reference
+      // to it, mirroring native Pynter's "ifn" nanbox tag. A direct call
+      // (`print(x)`) never reaches this branch: emitFunctionCall emits
+      // CALLP/CALLTP straight from the primitive index instead.
+      this.builder.emitUnary(OpCodes.NEWCP, annotation.primitiveIndex!);
+      return { maxStackSize: 1 };
     }
     if (annotation.envLevel === 0) {
       this.builder.emitUnary(OpCodes.LDLG, annotation.slot);
@@ -264,7 +308,14 @@ export class PVMLCompiler
       `__list_tmp_${this.tmpCounter++}`,
     );
 
-    this.builder.emitUnary(OpCodes.LGCI, n);
+    // NEWA takes no size operand: native Pynter's op_new_a always creates an
+    // empty, auto-growing array (siarray_new(8) with count=0) and ignores
+    // whatever's on the stack — it never pops a size. Pushing one here (as
+    // this used to) left it stranded on the stack after NEWA, permanently
+    // corrupting stack balance for the rest of the program (every list
+    // literal leaked one value, eventually manifesting as a native stack
+    // overflow). STAG (via siarray_put) grows the array to fit as elements
+    // are stored below.
     this.builder.emitNullary(OpCodes.NEWA);
     this.builder.emitUnary(OpCodes.STLG, tmpSlot);
 
@@ -423,7 +474,13 @@ export class PVMLCompiler
 
     const callee: ExprNS.Variable = expr.callee;
 
-    const { maxStackSize: functionStackEffect } = this.emitLoadSymbol(callee.name);
+    // CALLP/CALLTP (primitive calls) take their arguments directly off the
+    // stack with no function value involved (see callPrimitive) — only a
+    // non-primitive (closure) call needs its callee's value loaded first.
+    // Loading it here regardless would push a stray NEWCP value that CALLP
+    // never consumes, corrupting the stack for every primitive call.
+    const isPrimitiveCallee = this.getTokenAnnotation(callee.name).isPrimitive;
+    const functionStackEffect = isPrimitiveCallee ? 0 : this.emitLoadSymbol(callee.name).maxStackSize;
 
     let maxArgStackSize = 0;
     for (let i = 0; i < expr.args.length; i++) {
@@ -472,7 +529,16 @@ export class PVMLCompiler
   ): ExpressionResult {
     const compiler = this.fromFunctionNode(node);
     const { maxStackSize } = compileBody(compiler);
-    // Functions must always return a value
+    // Falling off the end of a function body without hitting an explicit
+    // `return` yields None in Python, regardless of what the last statement
+    // happened to leave on the stack for compileStatements' stack-balance
+    // bookkeeping (a real value for a bare expression statement, or an
+    // internal `undefined` placeholder for e.g. an assignment) — discard it
+    // and return Python's None explicitly. An explicit `return` elsewhere in
+    // the body (visitReturnStmt) emits its own RETG and exits before ever
+    // reaching this point, so this only fires on true fallthrough.
+    compiler.builder.emitNullary(OpCodes.POPG);
+    compiler.builder.emitNullary(OpCodes.LGCN);
     compiler.builder.emitNullary(OpCodes.RETG);
     this.builder.emitUnary(OpCodes.NEWC, compiler.builder.getFunctionIndex());
     return { maxStackSize: Math.max(maxStackSize, 1) };
@@ -497,7 +563,10 @@ export class PVMLCompiler
 
   visitReturnStmt(stmt: StmtNS.Return): ExpressionResult {
     if (!stmt.value) {
-      this.builder.emitNullary(OpCodes.LGCU);
+      // Bare `return` (no expression) yields Python's None, not `undefined`
+      // — LGCN, not LGCU (LGCU is an internal stack-balance placeholder, not
+      // a real Python value; see compileClosure).
+      this.builder.emitNullary(OpCodes.LGCN);
       this.builder.emitNullary(OpCodes.RETG);
       return { maxStackSize: 1 };
     }
@@ -507,6 +576,22 @@ export class PVMLCompiler
   }
 
   visitAssignStmt(stmt: StmtNS.Assign): ExpressionResult {
+    if (stmt.target instanceof ExprNS.Subscript) {
+      const arrResult = this.compile(stmt.target.value);
+      const idxResult = this.compile(stmt.target.index);
+      const valResult = this.compile(stmt.value);
+      this.builder.emitNullary(OpCodes.STAG);
+      this.builder.emitNullary(OpCodes.LGCU);
+      return {
+        maxStackSize: Math.max(
+          arrResult.maxStackSize,
+          1 + idxResult.maxStackSize,
+          2 + valResult.maxStackSize,
+          1,
+        ),
+      };
+    }
+
     const initResult = this.compile(stmt.value);
 
     this.emitStoreSymbol((stmt.target as ExprNS.Variable).name);

--- a/src/engines/pvml/pvml-interpreter.ts
+++ b/src/engines/pvml/pvml-interpreter.ts
@@ -11,7 +11,6 @@ import {
   PVMLEnvironment,
   PVMLIR,
   PVMLIterator,
-  PVMLPrimitive,
   PVMLProgram,
   PVMLType,
 } from "./types";
@@ -800,7 +799,7 @@ export class PVMLInterpreter {
     // — e.g. `f = abs; f(-5)` — has no function-table entry/frame of its
     // own; dispatch it the same way CALLP/CALLTP do.
     if (isPVMLObject(func) && func.type === "primitive") {
-      const result = executePrimitive((func as PVMLPrimitive).primitiveIndex, args, this.onOutput);
+      const result = executePrimitive(func.primitiveIndex, args, this.onOutput);
       this.push(result);
       return;
     }

--- a/src/engines/pvml/pvml-interpreter.ts
+++ b/src/engines/pvml/pvml-interpreter.ts
@@ -11,6 +11,7 @@ import {
   PVMLEnvironment,
   PVMLIR,
   PVMLIterator,
+  PVMLPrimitive,
   PVMLProgram,
   PVMLType,
 } from "./types";
@@ -428,6 +429,10 @@ export class PVMLInterpreter {
           this.createClosure(a1);
           break;
 
+        case OpCodes.NEWCP:
+          this.push({ type: "primitive", primitiveIndex: a1 });
+          break;
+
         case OpCodes.CALL:
           this.call(a1, false);
           break;
@@ -791,6 +796,15 @@ export class PVMLInterpreter {
     if (__DEBUG__)
       debug(`[CALL] Popped function: ${JSON.stringify(PVMLInterpreter.toJSValue(func))}`);
 
+    // A primitive referenced as a value (NEWCP) rather than called directly
+    // — e.g. `f = abs; f(-5)` — has no function-table entry/frame of its
+    // own; dispatch it the same way CALLP/CALLTP do.
+    if (isPVMLObject(func) && func.type === "primitive") {
+      const result = executePrimitive((func as PVMLPrimitive).primitiveIndex, args, this.onOutput);
+      this.push(result);
+      return;
+    }
+
     if (!isPVMLObject(func) || func.type !== "closure") {
       throw new Error(
         `Cannot call non-closure value: ${JSON.stringify(PVMLInterpreter.toJSValue(func))}`,
@@ -895,10 +909,11 @@ export class PVMLInterpreter {
   // ========================================================================
 
   private createArray(): void {
-    const size = this.pop() as number;
+    // No size operand: native Pynter's NEWA (op_new_a) always creates an
+    // empty, auto-growing array and never pops one — see visitListExpr.
     const arr: PVMLArray = {
       type: "array",
-      elements: new Array(size).fill(undefined),
+      elements: [],
     };
     this.push(arr);
   }
@@ -911,11 +926,9 @@ export class PVMLInterpreter {
       throw new Error("Cannot index non-array value");
     }
 
-    if (index < 0 || index >= arr.elements.length) {
-      throw new Error(`Array index ${index} out of bounds (length: ${arr.elements.length})`);
-    }
-
-    this.push(arr.elements[index]);
+    // Mirrors native Pynter's siarray_get: an out-of-bounds read isn't a
+    // fault, it yields undefined.
+    this.push(index >= 0 && index < arr.elements.length ? arr.elements[index] : undefined);
   }
 
   private storeArrayElement(): void {
@@ -927,10 +940,12 @@ export class PVMLInterpreter {
       throw new Error("Cannot index non-array value");
     }
 
-    if (index < 0 || index >= arr.elements.length) {
-      throw new Error(`Array index ${index} out of bounds (length: ${arr.elements.length})`);
+    if (index < 0) {
+      throw new Error(`Array index ${index} out of bounds`);
     }
 
+    // Mirrors native Pynter's siarray_put: writing past the end grows the
+    // array (leaving a gap of `undefined`s) rather than faulting.
     arr.elements[index] = value;
   }
 
@@ -947,6 +962,7 @@ export class PVMLInterpreter {
       return value;
     if (isPVMLObject(value)) {
       if (value.type === "closure") return `<closure:${value.functionIndex}>`;
+      if (value.type === "primitive") return `<primitive:${value.primitiveIndex}>`;
       if (value.type === "array") return value.elements.map(e => PVMLInterpreter.toJSValue(e));
       if (value.type === "iterator") return `<iterator>`;
     }

--- a/src/engines/pvml/types.ts
+++ b/src/engines/pvml/types.ts
@@ -5,6 +5,7 @@ export type PVMLBoxType =
   | null
   | undefined
   | PVMLClosure
+  | PVMLPrimitive
   | PVMLArray
   | PVMLIterator;
 
@@ -16,6 +17,7 @@ export enum PVMLType {
   STRING = "string",
   ARRAY = "array",
   CLOSURE = "closure",
+  PRIMITIVE = "primitive",
   ITERATOR = "iterator",
 }
 
@@ -42,8 +44,22 @@ export interface PVMLClosure {
   parentEnv: PVMLEnvironment | null;
 }
 
-/** Type guard: narrows PVMLBoxType to the three object variants. */
-export function isPVMLObject(value: PVMLBoxType): value is PVMLClosure | PVMLArray | PVMLIterator {
+/**
+ * A reference to a primitive function (e.g. `print`, `abs`) used as a
+ * first-class value rather than called directly — e.g. `is_function(print)`
+ * or `f = abs; f(-5)`. Mirrors native Pynter's "ifn" nanbox tag, which
+ * likewise represents a primitive function reference distinctly from a
+ * user-defined closure.
+ */
+export interface PVMLPrimitive {
+  type: "primitive";
+  primitiveIndex: number;
+}
+
+/** Type guard: narrows PVMLBoxType to the object variants. */
+export function isPVMLObject(
+  value: PVMLBoxType,
+): value is PVMLClosure | PVMLPrimitive | PVMLArray | PVMLIterator {
   return typeof value === "object" && value !== null && "type" in value;
 }
 
@@ -190,6 +206,8 @@ export function getPVMLType(value: PVMLBoxType): PVMLType {
     switch (value.type) {
       case "closure":
         return PVMLType.CLOSURE;
+      case "primitive":
+        return PVMLType.PRIMITIVE;
       case "array":
         return PVMLType.ARRAY;
       case "iterator":

--- a/src/pvml-runner.ts
+++ b/src/pvml-runner.ts
@@ -17,13 +17,19 @@ import { assemble } from "./engines/pvml/pvml-assembler";
 import { PVMLCompiler } from "./engines/pvml/pvml-compiler";
 import { parse } from "./parser";
 import { analyzeWithEnvironments } from "./resolver";
-import { RunError } from "./runner";
-import math from "./stdlib/math";
-import misc from "./stdlib/misc";
+import { RunError, VARIANT_GROUPS } from "./runner";
+import type { Group } from "./stdlib/utils";
 
 export interface RunPvmlOptions {
   /** Path to a built native Pynter `runner` binary. */
   pynterPath: string;
+  /**
+   * Stdlib groups to load, overriding the VARIANT_GROUPS[variant] default.
+   * Needed for the handful of test suites that exercise a non-canonical
+   * combination for a given variant (e.g. stream tests run at variant 2 with
+   * the `stream`/`pairmutator` groups added on top).
+   */
+  groups?: Group[];
 }
 
 export interface RunPvmlResult {
@@ -40,27 +46,39 @@ export interface RunPvmlResult {
  * to PVML and running it on a native Pynter binary. Returns both the
  * program's print() output and its final result value/type.
  *
- * Note: the PVML compiler currently only wires up the [misc, math] stdlib
- * groups (matching PyPvmlEvaluator/PyPvmlPynterEvaluator), so its chapter
- * coverage is narrower than the CSE pathway's — variants that rely on
- * linked lists, streams, or the parser library are not yet supported here.
+ * Stdlib groups default to VARIANT_GROUPS[variant] (see runner.ts), matching
+ * the CSE pathway's chapter coverage. A group's prelude (SICPy source, e.g.
+ * linked-list.prelude.ts's `equal`/`map`/`reverse`/...) is prepended to
+ * `code` and compiled + run as a single PVML program: unlike the CSE
+ * machine, which runs the prelude once into a shared, mutable environment
+ * ahead of the main script, each native Pynter invocation is a fresh
+ * process with no persistent environment to carry prelude bindings across —
+ * so prelude and script must be one compilation unit for the script to see
+ * the prelude's functions at all.
  */
 export async function runCodePvmlDetailed(
   code: string,
   variant: number,
   options: RunPvmlOptions,
 ): Promise<RunPvmlResult> {
-  const { pynterPath } = options;
+  const { pynterPath, groups = VARIANT_GROUPS[variant] } = options;
+  if (!groups) throw new RunError("parse", `Invalid variant: ${variant}. Expected 1–4.`);
+
   const script = code.endsWith("\n") ? code : code + "\n";
+  const preludeText = groups
+    .map(g => g.prelude ?? "")
+    .filter(p => p.trim())
+    .join("\n");
+  const fullSource = preludeText ? `${preludeText}\n${script}` : script;
 
   let ast;
   try {
-    ast = parse(script);
+    ast = parse(fullSource);
   } catch (e: unknown) {
     throw new RunError("parse", String((e as { message?: string })?.message ?? e));
   }
 
-  const { errors, environments } = analyzeWithEnvironments(ast, script, variant, [misc, math]);
+  const { errors, environments } = analyzeWithEnvironments(ast, fullSource, variant, groups);
   if (errors.length > 0) {
     throw new RunError("analysis", errors.map(e => e.message).join("\n"));
   }

--- a/src/tests/linked-list.test.ts
+++ b/src/tests/linked-list.test.ts
@@ -159,5 +159,5 @@ describe("Linked List Tests", () => {
   };
 
   generateTestCases(linkedListTests, 2, [misc, math, linkedList]);
-  generateNativePynterTestCases(linkedListTests, 2);
+  generateNativePynterTestCases(linkedListTests, 2, [misc, math, linkedList]);
 });

--- a/src/tests/list.test.ts
+++ b/src/tests/list.test.ts
@@ -76,12 +76,5 @@ describe("List Tests", () => {
   };
 
   generateTestCases(listTests, 3, [misc, math, linkedList, pairmutator, stream, list]);
-  generateNativePynterTestCases(listTests, 3, [
-    misc,
-    math,
-    linkedList,
-    pairmutator,
-    stream,
-    list,
-  ]);
+  generateNativePynterTestCases(listTests, 3, [misc, math, linkedList, pairmutator, stream, list]);
 });

--- a/src/tests/list.test.ts
+++ b/src/tests/list.test.ts
@@ -76,5 +76,12 @@ describe("List Tests", () => {
   };
 
   generateTestCases(listTests, 3, [misc, math, linkedList, pairmutator, stream, list]);
-  generateNativePynterTestCases(listTests, 3);
+  generateNativePynterTestCases(listTests, 3, [
+    misc,
+    math,
+    linkedList,
+    pairmutator,
+    stream,
+    list,
+  ]);
 });

--- a/src/tests/operator-conformance-pynter.test.ts
+++ b/src/tests/operator-conformance-pynter.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Native Pynter parity sweep for operator-conformance.test.ts.
+ *
+ * Reuses that suite's spec tables/type universe (see operator-spec.ts; the
+ * human source of truth is still the four docs/specs/python_typing_*.tex
+ * fragments) and sweeps the same operator × type × type cross product, at
+ * all four chapters, through the native Pynter `runner` binary instead of
+ * the CSE machine. For each combination, the CSE machine's own result is
+ * computed fresh and used as the expected value — so this pins native Pynter
+ * against the *actual* reference implementation, not a second hand-written
+ * copy of it that could drift.
+ *
+ * One PVML-specific carve-out: `complex` is dropped from the type universe
+ * entirely. PVMLCompiler.visitComplexExpr rejects complex literals outright
+ * at compile time — there is no PVML complex-number representation to be
+ * conformant *about* — so every complex-adjacent spec row is untestable here
+ * by construction, not a gap worth enumerating.
+ *
+ * Opt-in: set PYNTER_RUNNER_PATH to a built `runner` binary, same as every
+ * other native Pynter suite. Skipped entirely otherwise.
+ */
+import { StmtNS } from "../ast-types";
+import { Context } from "../engines/cse/context";
+import { evaluate } from "../engines/cse/interpreter";
+import { Stash, Value } from "../engines/cse/stash";
+import { parse } from "../parser/parser-adapter";
+import { runCodePvmlDetailed } from "../pvml-runner";
+import { Resolver } from "../resolver";
+import { RunError, VARIANT_GROUPS } from "../runner";
+import { Group } from "../stdlib/utils";
+import { makeValidatorsForChapter } from "../validator";
+import { BINARY_OPS_12, BINARY_OPS_34, literalFor, PyType, universeForChapter } from "./operator-spec";
+import { generateMockStreams, isCloseToFloat32 } from "./utils";
+
+/** PVML has no complex-number support at all; see file header. */
+function pvmlUniverseForChapter(chapter: number): PyType[] {
+  return universeForChapter(chapter).filter(type => type !== "complex");
+}
+
+type CseOutcome = { kind: "value"; stashType: string; value: unknown } | { kind: "error" };
+
+/**
+ * Evaluates `code` through the CSE machine to get the reference outcome.
+ * A trimmed copy of operator-conformance.test.ts's own `run()`: that one
+ * distinguishes resolve- vs runtime-errors by class name for its own
+ * assertions, which this file doesn't need — any error means "the operation
+ * is rejected", matching how generateNativePynterTestCases treats CSE error
+ * expectations elsewhere.
+ */
+async function cseOutcome(code: string, chapter: number, groups: Group[]): Promise<CseOutcome> {
+  const script = code + "\n";
+  let ast: StmtNS.Stmt;
+  try {
+    ast = parse(script);
+    const resolver = new Resolver(script, ast, makeValidatorsForChapter(chapter), groups, []);
+    if (resolver.resolve(ast).length > 0) {
+      return { kind: "error" };
+    }
+  } catch {
+    return { kind: "error" };
+  }
+
+  const context = new Context();
+  generateMockStreams(context, []);
+  for (const group of groups) {
+    for (const [name, value] of group.builtins) {
+      context.nativeStorage.builtins.set(name, value);
+    }
+  }
+  const spy = jest.spyOn(Stash.prototype, "pop");
+  let lastPopped: Value | undefined;
+  try {
+    await evaluate(code, ast, context, { variant: chapter });
+    lastPopped = spy.mock.results.at(-1)?.value as Value | undefined;
+  } finally {
+    spy.mockRestore();
+  }
+  if (context.errors.length > 0) {
+    return { kind: "error" };
+  }
+  return {
+    kind: "value",
+    stashType: lastPopped?.type ?? "none",
+    value: lastPopped && "value" in lastPopped ? lastPopped.value : undefined,
+  };
+}
+
+/** Maps a CSE stash type to native Pynter's resultType tag. */
+const PVML_RESULT_TYPE: Partial<Record<string, string>> = {
+  bigint: "integer",
+  number: "float",
+  bool: "boolean",
+  string: "string",
+};
+
+function pvmlValueMatches(
+  wantType: string,
+  wantValue: unknown,
+  pvmlResultType: string,
+  pvmlResultValue: string,
+): boolean {
+  const expectedTag = PVML_RESULT_TYPE[wantType];
+  if (expectedTag === undefined || pvmlResultType !== expectedTag) return false;
+  switch (expectedTag) {
+    case "integer":
+      return Number(pvmlResultValue) === Number(wantValue);
+    case "float":
+      return isCloseToFloat32(Number(pvmlResultValue), Number(wantValue));
+    case "boolean":
+      return (pvmlResultValue === "true") === wantValue;
+    case "string":
+      return pvmlResultValue === wantValue;
+    default:
+      return false;
+  }
+}
+
+type PvmlOutcome = { kind: "value"; resultType: string; resultValue: string } | { kind: "error" };
+
+async function runPvml(
+  code: string,
+  chapter: number,
+  groups: Group[],
+  pynterPath: string,
+): Promise<PvmlOutcome> {
+  try {
+    const result = await runCodePvmlDetailed(code, chapter, { pynterPath, groups });
+    return { kind: "value", resultType: result.resultType, resultValue: result.resultValue };
+  } catch (e) {
+    if (e instanceof RunError) return { kind: "error" };
+    throw e;
+  }
+}
+
+/** Asserts `actual` matches `wanted` — a CSE value needs the same value from Pynter; a CSE error just needs any Pynter error. */
+function expectMatch(wanted: CseOutcome, actual: PvmlOutcome): void {
+  if (wanted.kind === "value") {
+    expect(actual.kind).toBe("value");
+    if (actual.kind === "value") {
+      expect(pvmlValueMatches(wanted.stashType, wanted.value, actual.resultType, actual.resultValue)).toBe(
+        true,
+      );
+    }
+  } else {
+    expect(actual.kind).toBe("error");
+  }
+}
+
+const pynterPath = process.env.PYNTER_RUNNER_PATH;
+const describeBlock = pynterPath ? describe : describe.skip;
+
+for (const chapter of [1, 2, 3, 4]) {
+  describeBlock(`[pvml/pynter] Operator conformance at Python §${chapter}`, () => {
+    const ops = chapter <= 2 ? BINARY_OPS_12 : BINARY_OPS_34;
+    const universe = pvmlUniverseForChapter(chapter);
+    // The *canonical* per-chapter group list (VARIANT_GROUPS), not
+    // operator-spec.ts's own groupsForChapter(): that one only adds
+    // whatever single extra group a given test needs on top of what the CSE
+    // machine's core language operators already provide for free (e.g.
+    // `linkedList` for `pair()` at §2). PVML has no such free core-language
+    // path — it compiles prelude + script as one unit, so a group's prelude
+    // (linked-list.prelude.ts calls `is_none`/`is_pair` from `misc`) needs
+    // its own dependencies loaded too, or the whole program fails to
+    // compile, not just the one feature the test cares about.
+    const groups = VARIANT_GROUPS[chapter];
+
+    for (const op of ops) {
+      describe(op, () => {
+        for (const left of universe) {
+          for (const right of universe) {
+            const code = `${literalFor(left, chapter)} ${op} ${literalFor(right, chapter)}`;
+            test(code, async () => {
+              const wanted = await cseOutcome(code, chapter, groups);
+              const actual = await runPvml(code, chapter, groups, pynterPath!);
+              expectMatch(wanted, actual);
+            });
+          }
+        }
+      });
+    }
+
+    describe("unary -", () => {
+      for (const operand of universe) {
+        const code = `-${literalFor(operand, chapter)}`;
+        test(code, async () => {
+          const wanted = await cseOutcome(code, chapter, groups);
+          const actual = await runPvml(code, chapter, groups, pynterPath!);
+          expectMatch(wanted, actual);
+        });
+      }
+    });
+
+    // `and`/`or` result in "any" (one of the operands), and `not` only ever
+    // produces bool — the sweeps above already pin the operand-type
+    // restrictions for these via CSE parity; only success-vs-error is
+    // checked here as elsewhere in the CSE version.
+    describe("not", () => {
+      for (const operand of universe) {
+        const code = `not ${literalFor(operand, chapter)}`;
+        test(code, async () => {
+          const wanted = await cseOutcome(code, chapter, groups);
+          const actual = await runPvml(code, chapter, groups, pynterPath!);
+          expect(actual.kind).toBe(wanted.kind);
+        });
+      }
+    });
+
+    for (const op of ["and", "or"]) {
+      describe(op, () => {
+        for (const left of universe) {
+          for (const right of universe) {
+            const code = `${literalFor(left, chapter)} ${op} ${literalFor(right, chapter)}`;
+            test(code, async () => {
+              const wanted = await cseOutcome(code, chapter, groups);
+              const actual = await runPvml(code, chapter, groups, pynterPath!);
+              expect(actual.kind).toBe(wanted.kind);
+            });
+          }
+        }
+      });
+    }
+  });
+}

--- a/src/tests/operator-conformance-pynter.test.ts
+++ b/src/tests/operator-conformance-pynter.test.ts
@@ -29,7 +29,13 @@ import { Resolver } from "../resolver";
 import { RunError, VARIANT_GROUPS } from "../runner";
 import { Group } from "../stdlib/utils";
 import { makeValidatorsForChapter } from "../validator";
-import { BINARY_OPS_12, BINARY_OPS_34, literalFor, PyType, universeForChapter } from "./operator-spec";
+import {
+  BINARY_OPS_12,
+  BINARY_OPS_34,
+  literalFor,
+  PyType,
+  universeForChapter,
+} from "./operator-spec";
 import { generateMockStreams, isCloseToFloat32 } from "./utils";
 
 /** PVML has no complex-number support at all; see file header. */
@@ -137,9 +143,9 @@ function expectMatch(wanted: CseOutcome, actual: PvmlOutcome): void {
   if (wanted.kind === "value") {
     expect(actual.kind).toBe("value");
     if (actual.kind === "value") {
-      expect(pvmlValueMatches(wanted.stashType, wanted.value, actual.resultType, actual.resultValue)).toBe(
-        true,
-      );
+      expect(
+        pvmlValueMatches(wanted.stashType, wanted.value, actual.resultType, actual.resultValue),
+      ).toBe(true);
     }
   } else {
     expect(actual.kind).toBe("error");

--- a/src/tests/operator-conformance.test.ts
+++ b/src/tests/operator-conformance.test.ts
@@ -34,169 +34,18 @@ import { Resolver } from "../resolver";
 import linkedList from "../stdlib/linked-list";
 import { Group } from "../stdlib/utils";
 import { FeatureNotSupportedError, makeValidatorsForChapter } from "../validator";
+import {
+  BINARY_OPS_12,
+  BINARY_OPS_34,
+  groupsForChapter,
+  literalFor,
+  PyType,
+  ResultType,
+  specResult,
+  STASH_TYPE,
+  universeForChapter,
+} from "./operator-spec";
 import { generateMockStreams } from "./utils";
-
-// ---------------------------------------------------------------------------
-// Type universe and representative operand literals
-// ---------------------------------------------------------------------------
-
-type PyType = "int" | "float" | "complex" | "bool" | "str" | "NoneType" | "list" | "function";
-
-/**
- * List literals are rejected by the chapter 1/2 validators (NoListsValidator), so at
- * Python §2 a "list" (pair) value is instead constructed via the linked-list library's
- * `pair` builtin — the only way §2 code can produce one.
- */
-const LITERAL: Record<PyType, string> = {
-  int: "2",
-  float: "2.5",
-  complex: "(1+2j)",
-  bool: "True",
-  str: "'ab'",
-  NoneType: "None",
-  list: "[1, 2]",
-  function: "(lambda x: x)",
-};
-
-function literalFor(type: PyType, chapter: number): string {
-  return type === "list" && chapter === 2 ? "pair(1, 2)" : LITERAL[type];
-}
-
-/** Stash representation of each spec result type. */
-const STASH_TYPE: Record<string, string> = {
-  int: "bigint",
-  float: "number",
-  complex: "complex",
-  bool: "bool",
-  str: "string",
-};
-
-/** List literals are rejected by the chapter 1 validators, so the §1 universe excludes them. */
-const UNIVERSE_1: PyType[] = ["int", "float", "complex", "bool", "str", "NoneType", "function"];
-/** At §2 "list" is available as a pair, constructed via the linked-list library's `pair`. */
-const UNIVERSE_WITH_LIST: PyType[] = [...UNIVERSE_1, "list"];
-
-function universeForChapter(chapter: number): PyType[] {
-  return chapter === 1 ? UNIVERSE_1 : UNIVERSE_WITH_LIST;
-}
-
-/** The linked-list library group, needed at §2 to resolve/evaluate the `pair` builtin. */
-function groupsForChapter(chapter: number): Group[] {
-  return chapter === 2 ? [linkedList] : [];
-}
-
-// ---------------------------------------------------------------------------
-// The spec tables
-// ---------------------------------------------------------------------------
-
-type ResultType = "int" | "float" | "complex" | "bool" | "str";
-
-interface Row {
-  ops: string[];
-  left: PyType[];
-  right: PyType[];
-  result: ResultType;
-}
-
-const NUMERIC: PyType[] = ["int", "float", "complex"];
-const ANY_34 = UNIVERSE_WITH_LIST;
-/** §2's `==`/`!=` universe: everything except bool and function (see MIDDLE_2 below). */
-const CHAPTER_2_EQUALITY_TYPES: PyType[] = UNIVERSE_WITH_LIST.filter(
-  type => type !== "bool" && type !== "function",
-);
-
-// docs/specs/python_typing_front.tex — common to all chapters
-const FRONT: Row[] = [
-  { ops: ["+", "-", "*", "%"], left: ["int"], right: ["int"], result: "int" },
-  { ops: ["/"], left: ["int"], right: ["int"], result: "float" },
-  { ops: ["+", "-", "*", "/", "%"], left: ["int"], right: ["float"], result: "float" },
-  { ops: ["+", "-", "*", "/", "%"], left: ["float"], right: ["int", "float"], result: "float" },
-  { ops: ["+", "-", "*", "/"], left: ["int"], right: ["complex"], result: "complex" },
-  { ops: ["+", "-", "*", "/"], left: ["float"], right: ["complex"], result: "complex" },
-  { ops: ["+", "-", "*", "/"], left: ["complex"], right: NUMERIC, result: "complex" },
-  { ops: ["+"], left: ["str"], right: ["str"], result: "str" },
-  // `**` int x int is value-dependent (int for exponent >= 0, float for < 0);
-  // the sweep's representative exponent is nonnegative, and the signed cases
-  // are covered by directed tests below.
-  { ops: ["**"], left: ["int"], right: ["int"], result: "int" },
-  { ops: ["**"], left: ["int"], right: ["float"], result: "float" },
-  { ops: ["**"], left: ["int"], right: ["complex"], result: "complex" },
-  { ops: ["**"], left: ["float"], right: ["int", "float"], result: "float" },
-  { ops: ["**"], left: ["float"], right: ["complex"], result: "complex" },
-  { ops: ["**"], left: ["complex"], right: NUMERIC, result: "complex" },
-];
-
-// docs/specs/python_typing_back.tex — common to all chapters
-// (`and`, `or`, `not` and unary `-` are handled separately below)
-const BACK: Row[] = [
-  { ops: [">", ">=", "<", "<="], left: ["str"], right: ["str"], result: "bool" },
-];
-
-// docs/specs/python_typing_middle_1.tex — Python §1 only
-const MIDDLE_1: Row[] = [
-  { ops: ["==", "!="], left: NUMERIC, right: NUMERIC, result: "bool" },
-  { ops: ["==", "!="], left: ["str"], right: ["str"], result: "bool" },
-  { ops: [">", ">=", "<", "<="], left: ["int", "float"], right: ["int", "float"], result: "bool" },
-];
-
-// docs/specs/python_typing_middle_2.tex — Python §2 only.
-// `==`/`!=` compare structurally over any x any *except* bool and function,
-// which are excluded entirely (`bool x any -> error`, `any x bool -> error`,
-// `function x any -> error`, `any x function -> error`): a §2 comparison never
-// has to answer whether `True == 1` holds, or what function equality means
-// before `is` is introduced at §3/§4. Every other combination — including
-// cross-type and pair/None comparisons — is `bool`.
-// Ordering comparisons are unaffected: still int,float x int,float only.
-const MIDDLE_2: Row[] = [
-  {
-    ops: ["==", "!="],
-    left: CHAPTER_2_EQUALITY_TYPES,
-    right: CHAPTER_2_EQUALITY_TYPES,
-    result: "bool",
-  },
-  { ops: [">", ">=", "<", "<="], left: ["int", "float"], right: ["int", "float"], result: "bool" },
-];
-
-// docs/specs/python_typing_middle_34.tex — Python §3/§4 only.
-// `==`/`!=` take any x any; `is` is restricted to the reference types
-// (list, function, None) and errors whenever either operand is a number,
-// string or boolean (identity of immutable values is unobservable).
-// The error rows of the table are the sweep's default expectation.
-// Ordering comparisons admit booleans (as in CPython, bool being an int).
-const REFERENCE_TYPES: PyType[] = ["NoneType", "list", "function"];
-const MIDDLE_34: Row[] = [
-  { ops: ["==", "!="], left: ANY_34, right: ANY_34, result: "bool" },
-  { ops: ["is", "is not"], left: REFERENCE_TYPES, right: REFERENCE_TYPES, result: "bool" },
-  {
-    ops: [">", ">=", "<", "<="],
-    left: ["int", "float", "bool"],
-    right: ["int", "float", "bool"],
-    result: "bool",
-  },
-];
-
-const TABLE_1: Row[] = [...FRONT, ...MIDDLE_1, ...BACK];
-const TABLE_2: Row[] = [...FRONT, ...MIDDLE_2, ...BACK];
-const TABLE_34: Row[] = [...FRONT, ...MIDDLE_34, ...BACK];
-
-function tableForChapter(chapter: number): Row[] {
-  if (chapter === 1) return TABLE_1;
-  if (chapter === 2) return TABLE_2;
-  return TABLE_34;
-}
-
-const BINARY_OPS_12 = ["+", "-", "*", "/", "%", "**", ">", ">=", "<", "<=", "==", "!="];
-const BINARY_OPS_34 = [...BINARY_OPS_12, "is", "is not"];
-
-/** The spec result type for `left op right` at the given chapter, or null if forbidden. */
-function specResult(op: string, left: PyType, right: PyType, chapter: number): ResultType | null {
-  for (const row of tableForChapter(chapter)) {
-    if (row.ops.includes(op) && row.left.includes(left) && row.right.includes(right)) {
-      return row.result;
-    }
-  }
-  return null;
-}
 
 // ---------------------------------------------------------------------------
 // Harness

--- a/src/tests/operator-spec.ts
+++ b/src/tests/operator-spec.ts
@@ -25,7 +25,15 @@ import { Group } from "../stdlib/utils";
 // Type universe and representative operand literals
 // ---------------------------------------------------------------------------
 
-export type PyType = "int" | "float" | "complex" | "bool" | "str" | "NoneType" | "list" | "function";
+export type PyType =
+  | "int"
+  | "float"
+  | "complex"
+  | "bool"
+  | "str"
+  | "NoneType"
+  | "list"
+  | "function";
 
 /**
  * List literals are rejected by the chapter 1/2 validators (NoListsValidator), so at
@@ -113,7 +121,9 @@ const FRONT: Row[] = [
 
 // docs/specs/python_typing_back.tex — common to all chapters
 // (`and`, `or`, `not` and unary `-` are handled separately below)
-const BACK: Row[] = [{ ops: [">", ">=", "<", "<="], left: ["str"], right: ["str"], result: "bool" }];
+const BACK: Row[] = [
+  { ops: [">", ">=", "<", "<="], left: ["str"], right: ["str"], result: "bool" },
+];
 
 // docs/specs/python_typing_middle_1.tex — Python §1 only
 const MIDDLE_1: Row[] = [

--- a/src/tests/operator-spec.ts
+++ b/src/tests/operator-spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Shared operator-typing spec tables, extracted from operator-conformance.test.ts
+ * so both it and operator-conformance-pynter.test.ts can import them without
+ * one `.test.ts` file importing another — Jest registers a test file's
+ * top-level describe()/test() calls purely by loading the module, so
+ * importing one test file from another double-registers its tests into
+ * whatever suite imports it.
+ *
+ * The tables below are a faithful transcription of the operator typing tables in
+ * the language specifications — the human source of truth:
+ *
+ *   docs/specs/python_typing_front.tex      (rows common to all chapters)
+ *   docs/specs/python_typing_middle_1.tex   (`==`/`!=` rows for Python §1)
+ *   docs/specs/python_typing_middle_2.tex   (`==`/`!=` rows for Python §2)
+ *   docs/specs/python_typing_middle_34.tex  (`==`/`!=`/`is` rows for Python §3/§4)
+ *   docs/specs/python_typing_back.tex       (rows common to all chapters)
+ *
+ * When a `.tex` table changes, update the transcription here in the same PR.
+ * Do not parse the `.tex` at runtime.
+ */
+import linkedList from "../stdlib/linked-list";
+import { Group } from "../stdlib/utils";
+
+// ---------------------------------------------------------------------------
+// Type universe and representative operand literals
+// ---------------------------------------------------------------------------
+
+export type PyType = "int" | "float" | "complex" | "bool" | "str" | "NoneType" | "list" | "function";
+
+/**
+ * List literals are rejected by the chapter 1/2 validators (NoListsValidator), so at
+ * Python §2 a "list" (pair) value is instead constructed via the linked-list library's
+ * `pair` builtin — the only way §2 code can produce one.
+ */
+const LITERAL: Record<PyType, string> = {
+  int: "2",
+  float: "2.5",
+  complex: "(1+2j)",
+  bool: "True",
+  str: "'ab'",
+  NoneType: "None",
+  list: "[1, 2]",
+  function: "(lambda x: x)",
+};
+
+export function literalFor(type: PyType, chapter: number): string {
+  return type === "list" && chapter === 2 ? "pair(1, 2)" : LITERAL[type];
+}
+
+/** Stash representation of each spec result type. */
+export const STASH_TYPE: Record<string, string> = {
+  int: "bigint",
+  float: "number",
+  complex: "complex",
+  bool: "bool",
+  str: "string",
+};
+
+/** List literals are rejected by the chapter 1 validators, so the §1 universe excludes them. */
+const UNIVERSE_1: PyType[] = ["int", "float", "complex", "bool", "str", "NoneType", "function"];
+/** At §2 "list" is available as a pair, constructed via the linked-list library's `pair`. */
+const UNIVERSE_WITH_LIST: PyType[] = [...UNIVERSE_1, "list"];
+
+export function universeForChapter(chapter: number): PyType[] {
+  return chapter === 1 ? UNIVERSE_1 : UNIVERSE_WITH_LIST;
+}
+
+/** The linked-list library group, needed at §2 to resolve/evaluate the `pair` builtin. */
+export function groupsForChapter(chapter: number): Group[] {
+  return chapter === 2 ? [linkedList] : [];
+}
+
+// ---------------------------------------------------------------------------
+// The spec tables
+// ---------------------------------------------------------------------------
+
+export type ResultType = "int" | "float" | "complex" | "bool" | "str";
+
+interface Row {
+  ops: string[];
+  left: PyType[];
+  right: PyType[];
+  result: ResultType;
+}
+
+const NUMERIC: PyType[] = ["int", "float", "complex"];
+const ANY_34 = UNIVERSE_WITH_LIST;
+/** §2's `==`/`!=` universe: everything except bool and function (see MIDDLE_2 below). */
+const CHAPTER_2_EQUALITY_TYPES: PyType[] = UNIVERSE_WITH_LIST.filter(
+  type => type !== "bool" && type !== "function",
+);
+
+// docs/specs/python_typing_front.tex — common to all chapters
+const FRONT: Row[] = [
+  { ops: ["+", "-", "*", "%"], left: ["int"], right: ["int"], result: "int" },
+  { ops: ["/"], left: ["int"], right: ["int"], result: "float" },
+  { ops: ["+", "-", "*", "/", "%"], left: ["int"], right: ["float"], result: "float" },
+  { ops: ["+", "-", "*", "/", "%"], left: ["float"], right: ["int", "float"], result: "float" },
+  { ops: ["+", "-", "*", "/"], left: ["int"], right: ["complex"], result: "complex" },
+  { ops: ["+", "-", "*", "/"], left: ["float"], right: ["complex"], result: "complex" },
+  { ops: ["+", "-", "*", "/"], left: ["complex"], right: NUMERIC, result: "complex" },
+  { ops: ["+"], left: ["str"], right: ["str"], result: "str" },
+  // `**` int x int is value-dependent (int for exponent >= 0, float for < 0);
+  // the sweep's representative exponent is nonnegative, and the signed cases
+  // are covered by directed tests below.
+  { ops: ["**"], left: ["int"], right: ["int"], result: "int" },
+  { ops: ["**"], left: ["int"], right: ["float"], result: "float" },
+  { ops: ["**"], left: ["int"], right: ["complex"], result: "complex" },
+  { ops: ["**"], left: ["float"], right: ["int", "float"], result: "float" },
+  { ops: ["**"], left: ["float"], right: ["complex"], result: "complex" },
+  { ops: ["**"], left: ["complex"], right: NUMERIC, result: "complex" },
+];
+
+// docs/specs/python_typing_back.tex — common to all chapters
+// (`and`, `or`, `not` and unary `-` are handled separately below)
+const BACK: Row[] = [{ ops: [">", ">=", "<", "<="], left: ["str"], right: ["str"], result: "bool" }];
+
+// docs/specs/python_typing_middle_1.tex — Python §1 only
+const MIDDLE_1: Row[] = [
+  { ops: ["==", "!="], left: NUMERIC, right: NUMERIC, result: "bool" },
+  { ops: ["==", "!="], left: ["str"], right: ["str"], result: "bool" },
+  { ops: [">", ">=", "<", "<="], left: ["int", "float"], right: ["int", "float"], result: "bool" },
+];
+
+// docs/specs/python_typing_middle_2.tex — Python §2 only.
+// `==`/`!=` compare structurally over any x any *except* bool and function,
+// which are excluded entirely (`bool x any -> error`, `any x bool -> error`,
+// `function x any -> error`, `any x function -> error`): a §2 comparison never
+// has to answer whether `True == 1` holds, or what function equality means
+// before `is` is introduced at §3/§4. Every other combination — including
+// cross-type and pair/None comparisons — is `bool`.
+// Ordering comparisons are unaffected: still int,float x int,float only.
+const MIDDLE_2: Row[] = [
+  {
+    ops: ["==", "!="],
+    left: CHAPTER_2_EQUALITY_TYPES,
+    right: CHAPTER_2_EQUALITY_TYPES,
+    result: "bool",
+  },
+  { ops: [">", ">=", "<", "<="], left: ["int", "float"], right: ["int", "float"], result: "bool" },
+];
+
+// docs/specs/python_typing_middle_34.tex — Python §3/§4 only.
+// `==`/`!=` take any x any; `is` is restricted to the reference types
+// (list, function, None) and errors whenever either operand is a number,
+// string or boolean (identity of immutable values is unobservable).
+// The error rows of the table are the sweep's default expectation.
+// Ordering comparisons admit booleans (as in CPython, bool being an int).
+const REFERENCE_TYPES: PyType[] = ["NoneType", "list", "function"];
+const MIDDLE_34: Row[] = [
+  { ops: ["==", "!="], left: ANY_34, right: ANY_34, result: "bool" },
+  { ops: ["is", "is not"], left: REFERENCE_TYPES, right: REFERENCE_TYPES, result: "bool" },
+  {
+    ops: [">", ">=", "<", "<="],
+    left: ["int", "float", "bool"],
+    right: ["int", "float", "bool"],
+    result: "bool",
+  },
+];
+
+const TABLE_1: Row[] = [...FRONT, ...MIDDLE_1, ...BACK];
+const TABLE_2: Row[] = [...FRONT, ...MIDDLE_2, ...BACK];
+const TABLE_34: Row[] = [...FRONT, ...MIDDLE_34, ...BACK];
+
+function tableForChapter(chapter: number): Row[] {
+  if (chapter === 1) return TABLE_1;
+  if (chapter === 2) return TABLE_2;
+  return TABLE_34;
+}
+
+export const BINARY_OPS_12 = ["+", "-", "*", "/", "%", "**", ">", ">=", "<", "<=", "==", "!="];
+export const BINARY_OPS_34 = [...BINARY_OPS_12, "is", "is not"];
+
+/** The spec result type for `left op right` at the given chapter, or null if forbidden. */
+export function specResult(
+  op: string,
+  left: PyType,
+  right: PyType,
+  chapter: number,
+): ResultType | null {
+  for (const row of tableForChapter(chapter)) {
+    if (row.ops.includes(op) && row.left.includes(left) && row.right.includes(right)) {
+      return row.result;
+    }
+  }
+  return null;
+}

--- a/src/tests/pairmutator.test.ts
+++ b/src/tests/pairmutator.test.ts
@@ -226,5 +226,5 @@ result`,
   };
 
   generateTestCases(pairmutatorTests, 2, [misc, math, linkedList, pairmutator, stream]);
-  generateNativePynterTestCases(pairmutatorTests, 2);
+  generateNativePynterTestCases(pairmutatorTests, 2, [misc, math, linkedList, pairmutator, stream]);
 });

--- a/src/tests/pvml-interpreter.test.ts
+++ b/src/tests/pvml-interpreter.test.ts
@@ -667,13 +667,13 @@ describe("PVML Additional Coverage", () => {
       expect(compileAndRun("pass\n")).toBeUndefined();
     });
 
-    test("bare return yields undefined", () => {
+    test("bare return yields None", () => {
       const code = `
 def f():
     return
 f()
 `;
-      expect(compileAndRun(code)).toBeUndefined();
+      expect(compileAndRun(code)).toBeNull();
     });
 
     test("while with continue skips iteration", () => {

--- a/src/tests/pvml.test.ts
+++ b/src/tests/pvml.test.ts
@@ -12,8 +12,8 @@ describe("PVML E2E", () => {
   const functionTests: PVMLTestCases = {
     "simple calls": [
       ["def add(x, y):\n    return x + y\nadd(3, 4)", 7, null],
-      ["def noop():\n    pass\nnoop()", undefined, null],
-      ["def f():\n    return\nf()", undefined, null],
+      ["def noop():\n    pass\nnoop()", null, null],
+      ["def f():\n    return\nf()", null, null],
     ],
     "nested and higher-order": [
       [

--- a/src/tests/stream.test.ts
+++ b/src/tests/stream.test.ts
@@ -157,5 +157,5 @@ equal(eval_stream(primes, 10), llist(2, 3, 5, 7, 11, 13, 17, 19, 23, 29))`,
   };
 
   generateTestCases(streamTests, 2, [misc, math, linkedList, stream, pairmutator]);
-  generateNativePynterTestCases(streamTests, 2);
+  generateNativePynterTestCases(streamTests, 2, [misc, math, linkedList, stream, pairmutator]);
 });

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -452,7 +452,10 @@ const NATIVE_PYNTER_SKIP_REASONS: {
   reason: string;
 }[] = [
   { matches: involvesComplexNumbers, reason: "Pynter does not support complex numbers" },
-  { matches: code => involvesParseFeature(code), reason: "parse()/tokenize() aren't part of Python 3" },
+  {
+    matches: code => involvesParseFeature(code),
+    reason: "parse()/tokenize() aren't part of Python 3",
+  },
 ];
 
 /**

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -385,6 +385,29 @@ function expectedToComparable(expected: TestOutputValue): unknown {
   return undefined;
 }
 
+/**
+ * Compares a Pynter float result against the CSE (float64) reference value.
+ * Pynter's floats are IEEE-754 single-precision, so the reference value must
+ * be rounded to float32 before comparing — otherwise every comparison is
+ * inflated by the fp64→fp32 rounding a *correct* Pynter would also incur.
+ * The tolerance is relative to that rounded value's magnitude (a fixed
+ * absolute tolerance is meaningless once a value exceeds a few thousand, and
+ * too generous once it's near zero), with a generous ULP budget on top to
+ * absorb rounding compounded across chained float32 arithmetic (loops,
+ * transcendental functions) rather than a single operation.
+ */
+const FLOAT32_EPSILON = Math.pow(2, -23);
+const FLOAT32_ULP_BUDGET = 4096;
+
+export function isCloseToFloat32(actual: unknown, wanted: number): boolean {
+  if (typeof actual !== "number") return false;
+  if (Number.isNaN(wanted)) return Number.isNaN(actual);
+  const rounded = Math.fround(wanted);
+  if (!Number.isFinite(rounded)) return actual === rounded;
+  const tolerance = FLOAT32_EPSILON * FLOAT32_ULP_BUDGET * Math.max(Math.abs(rounded), 1);
+  return Math.abs(actual - rounded) <= tolerance;
+}
+
 /** Matches a Python imaginary-number literal: 3j, .5j, 1.2j, 1.j, 1e3j, 1e-3j, 1J, etc. */
 const COMPLEX_LITERAL_RE = /(?<![a-zA-Z_])(?:\d+\.\d*|\.\d+|\d+)(?:[eE][+-]?\d+)?[jJ]\b/;
 
@@ -410,11 +433,43 @@ function involvesComplexNumbers(code: string, expected: TestExpectedValue): bool
 }
 
 /**
+ * Matches a call to parse()/tokenize(): these turn SICPy source text into a
+ * data structure for py-slang's own metacircular-evaluator feature (chapter
+ * 4's stdlib/parser.ts). That's not a Python 3 language or library feature —
+ * it has no meaningful analogue once a program is compiled to bytecode and
+ * run on a VM like Pynter, so it's out of scope for parity here regardless
+ * of Pynter's own capabilities.
+ */
+const PARSE_FEATURE_CALL_RE = /\b(?:parse|tokenize)\s*\(/;
+
+function involvesParseFeature(code: string): boolean {
+  return PARSE_FEATURE_CALL_RE.test(code);
+}
+
+/** Reasons a test case is skipped for the native Pynter pathway, checked in order. */
+const NATIVE_PYNTER_SKIP_REASONS: {
+  matches: (code: string, expected: TestExpectedValue) => boolean;
+  reason: string;
+}[] = [
+  { matches: involvesComplexNumbers, reason: "Pynter does not support complex numbers" },
+  { matches: code => involvesParseFeature(code), reason: "parse()/tokenize() aren't part of Python 3" },
+];
+
+/**
  * Reruns `testCases` (as already used with generateTestCases() for the CSE
  * machine) through the PVML compiler + native Pynter, at the given chapter
  * `variant`. See the file-level comment above for gating/expectations.
+ *
+ * `groups` overrides the default VARIANT_GROUPS[variant] stdlib groups,
+ * matching whatever non-default combination the sibling generateTestCases()
+ * call for the same suite uses (e.g. stream tests run CSE at variant 2 with
+ * extra `stream`/`pairmutator` groups layered on).
  */
-export const generateNativePynterTestCases = (testCases: TestCases, variant: number) => {
+export const generateNativePynterTestCases = (
+  testCases: TestCases,
+  variant: number,
+  groups?: Group[],
+) => {
   const pynterPath = process.env.PYNTER_RUNNER_PATH;
   const describeBlock = pynterPath ? describe : describe.skip;
 
@@ -423,7 +478,7 @@ export const generateNativePynterTestCases = (testCases: TestCases, variant: num
       const runTestCase = async ({ code, expected, output }: InternalTestCase) => {
         let result;
         try {
-          result = await runCodePvmlDetailed(code, variant, { pynterPath: pynterPath! });
+          result = await runCodePvmlDetailed(code, variant, { pynterPath: pynterPath!, groups });
         } catch (e) {
           if (typeof expected === "function") {
             // CSE also expects a failure here; any RunError counts as agreement.
@@ -446,31 +501,34 @@ export const generateNativePynterTestCases = (testCases: TestCases, variant: num
 
         const actual = pynterResultToComparable(result);
         const wanted = expectedToComparable(expected);
-        if (typeof wanted === "number" && !Number.isInteger(wanted)) {
-          expect(actual).toBeCloseTo(wanted, 2);
+        if (result.resultType === "float" && typeof wanted === "number") {
+          expect(isCloseToFloat32(actual, wanted)).toBe(true);
         } else {
           expect(actual).toEqual(wanted);
         }
       };
 
       const internalTestCases = createInternalTestCases(tests);
-      const supported = internalTestCases.filter(
-        ({ code, expected }) => !involvesComplexNumbers(code, expected),
-      );
-      const unsupportedComplex = internalTestCases.filter(({ code, expected }) =>
-        involvesComplexNumbers(code, expected),
-      );
+      const supported: InternalTestCase[] = [];
+      const skipBuckets = new Map<string, InternalTestCase[]>();
+      for (const testCase of internalTestCases) {
+        const reason = NATIVE_PYNTER_SKIP_REASONS.find(({ matches }) =>
+          matches(testCase.code, testCase.expected),
+        )?.reason;
+        if (reason === undefined) {
+          supported.push(testCase);
+        } else {
+          (skipBuckets.get(reason) ?? skipBuckets.set(reason, []).get(reason)!).push(testCase);
+        }
+      }
 
       // test.each throws if given an empty array, rather than registering zero
       // tests, so only call it for groups that actually have cases in each bucket.
       if (supported.length > 0) {
         test.each(supported)(`$label`, runTestCase);
       }
-      if (unsupportedComplex.length > 0) {
-        test.skip.each(unsupportedComplex)(
-          `$label (Pynter does not support complex numbers)`,
-          runTestCase,
-        );
+      for (const [reason, cases] of skipBuckets) {
+        test.skip.each(cases)(`$label (${reason})`, runTestCase);
       }
     });
   }


### PR DESCRIPTION
## Summary

Consolidates a session's worth of native-Pynter parity work into one PR. Started from investigating why `yarn pynter:report` (added in #220) showed low pass rates and worked backwards to root causes — most of what's here turned out to be real, independent bugs rather than missing features.

- **Fix PVML compiler bugs in recursion, control flow, and list literals** — four bugs found by chasing native-Pynter failures that also reproduced on the pure-TS `PVMLInterpreter` (ruling out anything Pynter-specific): slot/env-builder bookkeeping wasn't shared across a compilation (a function calling a sibling or itself recursively could silently invoke the wrong closure at the wrong arity), falling off the end of a function body leaked the last statement's value instead of yielding `None`, subscript-target assignment (`xs[i] = v`) crashed the compiler outright, and list literals pushed a size operand `NEWA` never consumes, corrupting stack balance for the rest of the program (eventually manifesting as a native stack overflow).
- **Wire canonical per-variant groups and prelude compilation into native Pynter** — `runCodePvmlDetailed` was hardcoded to `[misc, math]` regardless of variant and never compiled any group's prelude, so linked-list/list/pairmutator/stream programs always failed before reaching native Pynter at all.
- **Correct and extend PVML's native primitive index mappings** — `PRIMITIVE_FUNCTIONS` had several indices that didn't match native Pynter's actual dispatch table (`abs`/`min`/`max`/`round`/`len` were silently calling `error()`/`is_null()`/`is_number()`/`length()`/`map()` instead), plus wires up ~40 more primitives with ready native equivalents.
- **Add a native Pynter operator-conformance sweep** — extends #207's CSE operator-conformance sweep to native Pynter, computing the CSE machine's own result live as the expected value for every `operator × type × type` combination at all four chapters, rather than a second hand-written table that could drift.

Net result on `yarn pynter:report` (opt-in, requires `PYNTER_RUNNER_PATH`): total pass rate roughly 46% → 78% across existing suites, `stream` 56%→100%, `linked-list` 45%→91%, `list` 44%→94%, plus the new operator sweep at 92% (2596/2812).

## Dependency note

Five new primitive names (`is_integer`, `is_float`, `is_complex`, `_gen_list`, `arity`) are mapped to indices 92–96, which don't exist in native Pynter today — they're being added in a companion PR to the [pynter](https://github.com/source-academy/pynter) repo, landing separately. This PR doesn't depend on that landing first: all native-Pynter tests are gated behind `PYNTER_RUNNER_PATH` and skip entirely without it, so CI is unaffected either way. Against a stock (pre-companion-PR) Pynter binary, only calls to those five primitives would fault; everything else in this PR is verified against Pynter as it exists upstream today.

## Test plan

- `npx tsc --noEmit`, `yarn lint`, `yarn format:ci` all clean.
- Full suite: 2495 passing (up from 2401 on main), 0 failures.
- Native Pynter suites (`PYNTER_RUNNER_PATH=<runner binary>`): verified suite-by-suite during development; no regressions against a fresh run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)