### PR TITLE
CSE: Fix nested lambdas 

### DIFF
--- a/src/conductor/plugins/PyCseMachinePlugin.ts
+++ b/src/conductor/plugins/PyCseMachinePlugin.ts
@@ -303,15 +303,19 @@ function serializeControlItem(item: ControlStackItem, code: string): SerializedI
     // For block-like nodes pass body length and child types so the adapter can build
     // stub body arrays (used by ControlExpansionAnimation / StatementSequence handling).
     if (
-      jsNodeType === "StatementSequence" ||
-      jsNodeType === "FunctionDeclaration" ||
-      jsNodeType === "ArrowFunctionExpression"
+      (jsNodeType === "StatementSequence" ||
+        jsNodeType === "FunctionDeclaration" ||
+        jsNodeType === "ArrowFunctionExpression") &&
+      item.body !== undefined
     ) {
       const body =
-        item.body !== undefined && item.body !== null && "body" in item.body
+        item.body !== undefined &&
+        item.body !== null &&
+        "body" in item.body &&
+        jsNodeType === "StatementSequence"
           ? item.body.body
           : item.body;
-      const bodyArray = Array.isArray(body) ? body : [];
+      const bodyArray = Array.isArray(body) ? body : [body];
       nodeMeta.bodyLength = bodyArray.length;
       nodeMeta.bodyNodeTypes = bodyArray.map(n => PY_TO_JS_NODE_TYPE[n.kind] ?? "Identifier");
     }

--- a/src/conductor/plugins/PyCseMachinePlugin.ts
+++ b/src/conductor/plugins/PyCseMachinePlugin.ts
@@ -1,18 +1,18 @@
-import { Context } from "../../engines/cse/context";
-import { Control } from "../../engines/cse/control";
-import { generateCSEMachineStateStream } from "../../engines/cse/interpreter";
-import { Stash, Value } from "../../engines/cse/stash";
-import { InstrType, operatorTranslator, typeTranslator } from "../../engines/cse/types";
-import { TokenType } from "../../tokenizer";
-import { toPythonFloat } from "../../stdlib/utils";
-import { Environment } from "../../engines/cse/environment";
-import { Closure } from "../../engines/cse/closure";
 import type {
   CseSnapshot,
   CseSerializedEnvFrame as SerializedEnvFrame,
   CseSerializedInstruction as SerializedInstruction,
   CseSerializedValue as SerializedValue,
 } from "@sourceacademy/common-cse-machine";
+import { Closure } from "../../engines/cse/closure";
+import { Context } from "../../engines/cse/context";
+import { Control } from "../../engines/cse/control";
+import { Environment } from "../../engines/cse/environment";
+import { generateCSEMachineStateStream } from "../../engines/cse/interpreter";
+import { Stash, Value } from "../../engines/cse/stash";
+import { InstrType, operatorTranslator, typeTranslator } from "../../engines/cse/types";
+import { toPythonFloat } from "../../stdlib/utils";
+import { TokenType } from "../../tokenizer";
 
 type ControlStackItem = {
   instrType?: string;
@@ -307,13 +307,13 @@ function serializeControlItem(item: ControlStackItem, code: string): SerializedI
       jsNodeType === "FunctionDeclaration" ||
       jsNodeType === "ArrowFunctionExpression"
     ) {
-      const body = Array.isArray(item.body)
-        ? item.body
-        : item.body !== undefined && item.body !== null && "body" in item.body
+      const body =
+        item.body !== undefined && item.body !== null && "body" in item.body
           ? item.body.body
-          : [];
-      nodeMeta.bodyLength = body.length;
-      nodeMeta.bodyNodeTypes = body.map(n => PY_TO_JS_NODE_TYPE[n.kind] ?? "Identifier");
+          : item.body;
+      const bodyArray = Array.isArray(body) ? body : [];
+      nodeMeta.bodyLength = bodyArray.length;
+      nodeMeta.bodyNodeTypes = bodyArray.map(n => PY_TO_JS_NODE_TYPE[n.kind] ?? "Identifier");
     }
 
     return Object.keys(nodeMeta).length > 0 ? { displayText, metadata: nodeMeta } : { displayText };
@@ -466,4 +466,4 @@ export async function collectSnapshots(
 // Python-specific serialization of control/stash/environment into CseSnapshots.
 
 // Exported for unit testing only — not part of the public API.
-export { formatValue, serializeValue, instrDisplayText, serializeControlItem, serializeEnvChain };
+export { formatValue, instrDisplayText, serializeControlItem, serializeEnvChain, serializeValue };

--- a/src/tests/PyCseMachinePlugin.test.ts
+++ b/src/tests/PyCseMachinePlugin.test.ts
@@ -377,6 +377,7 @@ describe("serializeControlItem", () => {
     );
     expect((result.metadata as any)?.nodeType).toBe("ArrowFunctionExpression");
     expect((result.metadata as any)?.bodyLength).toBe(1);
+    expect((result.metadata as any)?.bodyNodeTypes).toEqual(["ArrowFunctionExpression"]);
   });
 
   it("FileInput node with StatementSequence body unwraps body correctly", () => {

--- a/src/tests/PyCseMachinePlugin.test.ts
+++ b/src/tests/PyCseMachinePlugin.test.ts
@@ -1,21 +1,21 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
+  collectSnapshots,
   formatValue,
-  serializeValue,
   instrDisplayText,
   serializeControlItem,
   serializeEnvChain,
-  collectSnapshots,
+  serializeValue,
 } from "../conductor/plugins/PyCseMachinePlugin";
-import { InstrType } from "../engines/cse/types";
-import { TokenType } from "../tokenizer";
-import type { Value } from "../engines/cse/stash";
 import { Context } from "../engines/cse/context";
 import { Control } from "../engines/cse/control";
+import type { Value } from "../engines/cse/stash";
 import { Stash } from "../engines/cse/stash";
+import { InstrType } from "../engines/cse/types";
 import { parse } from "../parser/parser-adapter";
 import math from "../stdlib/math";
 import misc from "../stdlib/misc";
+import { TokenType } from "../tokenizer";
 import { PyComplexNumber } from "../types/value-types";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -365,6 +365,18 @@ describe("serializeControlItem", () => {
     );
     expect((result.metadata as any)?.nodeType).toBe("FunctionDeclaration");
     expect((result.metadata as any)?.bodyLength).toBe(2);
+  });
+
+  it("Lambda node with nested Lambda body unwraps body correctly", () => {
+    const result = serializeControlItem(
+      {
+        kind: "Lambda",
+        body: { kind: "Lambda", body: [{ kind: "Return" }] },
+      },
+      code,
+    );
+    expect((result.metadata as any)?.nodeType).toBe("ArrowFunctionExpression");
+    expect((result.metadata as any)?.bodyLength).toBe(1);
   });
 
   it("FileInput node with StatementSequence body unwraps body correctly", () => {


### PR DESCRIPTION
This PR fixes #222, by allowing the body in the CSE machine snapshot collector to wrap itself in an array, so that `map` would work on the resultant body