### PR TITLE
Fix currentLine collapsing to 0 during for/range() loop synthetic steps

### DIFF
--- a/src/conductor/plugins/PyCseMachinePlugin.ts
+++ b/src/conductor/plugins/PyCseMachinePlugin.ts
@@ -411,6 +411,13 @@ export async function collectSnapshots(
   maxSnapshots: number = 1000,
 ): Promise<CseSnapshot[]> {
   const snapshots: CseSnapshot[] = [];
+  // Runtime-fabricated nodes (e.g. implicit range() bounds, the for-loop increment —
+  // see utils.ts's evaluateForIterator/generateForIncrement) carry tokens pinned to
+  // line 0, since they don't correspond to any line the user actually wrote. Real
+  // tokens are always 1-based (see parser/token-bridge.ts), so line 0 is an
+  // unambiguous "not a real line" signal. Keep showing the last real line instead of
+  // flickering to 0 while these synthetic nodes are being evaluated.
+  let lastKnownLine: number | undefined;
 
   const stream = generateCSEMachineStateStream(
     code,
@@ -452,14 +459,17 @@ export async function collectSnapshots(
     // machine's updateInspector, which reads context.runtime.nodes[0] for the blue
     // "current line" highlight. py-slang nodes carry a 1-based startToken.line.
     const currentNode = context.runtime.nodes[0] as { startToken?: { line?: number } } | undefined;
-    const currentLine: number | undefined = currentNode?.startToken?.line;
+    const rawLine = currentNode?.startToken?.line;
+    if (rawLine) {
+      lastKnownLine = rawLine;
+    }
 
     snapshots.push({
       stepIndex: steps - 1,
       control: controlItems,
       stash: stashItems,
       environments,
-      currentLine,
+      currentLine: lastKnownLine,
     });
   }
 

--- a/src/engines/cse/interpreter.ts
+++ b/src/engines/cse/interpreter.ts
@@ -1121,14 +1121,17 @@ const cmdEvaluators: CmdEvaluators = {
         return;
       }
       control.push(instr);
+      // Line is the real for-statement's line — this per-iteration bookkeeping is
+      // logically part of evaluating that statement, not a separate, lineless step.
+      const forLine = node.startToken.line;
       const generateBigIntLiteral = (value: bigint): ExprNS.BigIntLiteral => {
-        const token = new Token(TokenType.BIGINT, value.toString(), 0, 0, -1);
+        const token = new Token(TokenType.BIGINT, value.toString(), forLine, 0, -1);
         token.synthetic = true;
         return new ExprNS.BigIntLiteral(token, token, value.toString());
       };
       const v1Lit = generateBigIntLiteral(start.value);
       const v3Lit = generateBigIntLiteral(step.value);
-      const plusToken = new Token(TokenType.PLUS, "+", 0, 0, -1);
+      const plusToken = new Token(TokenType.PLUS, "+", forLine, 0, -1);
       plusToken.synthetic = true;
       const nextStartExpr = new ExprNS.Binary(plusToken, plusToken, v1Lit, plusToken, v3Lit);
       Object.assign(nextStartExpr, { syntheticLabel: `${start.value}+${step.value}` });
@@ -1137,7 +1140,7 @@ const cmdEvaluators: CmdEvaluators = {
       control.push(nextStartExpr);
       control.push(instrCreator.continueMarkerInstr(node));
       control.push(...instr.body.slice().reverse());
-      control.push(generateForIncrement(node.target.lexeme, start.value));
+      control.push(generateForIncrement(node.target.lexeme, start.value, forLine));
     }
   },
   [InstrType.CONTINUE_MARKER]: function () {},

--- a/src/engines/cse/utils.ts
+++ b/src/engines/cse/utils.ts
@@ -674,9 +674,13 @@ export function evaluateForIterator(
       new TooManyPositionalArgumentsError(code, forNode.iter, "range", 3, rangeArguments, true),
     );
   }
-  const tempTokenZero = new Token(TokenType.BIGINT, "0", 0, 0, 0);
+  // Line is the real for-statement's line, not 0 — these bounds are logically part of
+  // evaluating that statement, and the CSE Machine visualizer's currentLine tracking
+  // relies on synthetic nodes carrying a meaningful line rather than none at all.
+  const forLine = forNode.startToken.line;
+  const tempTokenZero = new Token(TokenType.BIGINT, "0", forLine, 0, 0);
   tempTokenZero.synthetic = true;
-  const tempTokenOne = new Token(TokenType.BIGINT, "1", 0, 0, 0);
+  const tempTokenOne = new Token(TokenType.BIGINT, "1", forLine, 0, 0);
   tempTokenOne.synthetic = true;
   if (rangeArguments.length === 1) {
     return {
@@ -701,12 +705,16 @@ export function evaluateForIterator(
   };
 }
 
-export function generateForIncrement(variableName: string, value: bigint): StmtNS.Stmt {
-  const token = new Token(TokenType.NAME, variableName, 0, 0, -1);
+export function generateForIncrement(
+  variableName: string,
+  value: bigint,
+  line: number,
+): StmtNS.Stmt {
+  const token = new Token(TokenType.NAME, variableName, line, 0, -1);
   token.synthetic = true;
   const variable = new ExprNS.Variable(token, token, token);
 
-  const literalToken = new Token(TokenType.BIGINT, value.toString(), 0, 0, -1);
+  const literalToken = new Token(TokenType.BIGINT, value.toString(), line, 0, -1);
   literalToken.synthetic = true;
   const literal = new ExprNS.BigIntLiteral(literalToken, literalToken, value.toString());
   return new StmtNS.Assign(token, literalToken, variable, literal);

--- a/src/tests/PyCseMachinePlugin.test.ts
+++ b/src/tests/PyCseMachinePlugin.test.ts
@@ -563,6 +563,17 @@ describe("collectSnapshots", () => {
     }
   });
 
+  // Regression test for https://github.com/source-academy/py-slang/issues/233.
+  it("currentLine never collapses to 0 during a for/range() loop's synthetic bookkeeping steps", async () => {
+    const snapshots = await runAndCollect(`for x in range(3):\n    print(x)`);
+    for (const snap of snapshots) {
+      expect(snap.currentLine).not.toBe(0);
+    }
+    // Once the loop body has run at least once, currentLine should have reached line 2
+    // (print(x)) rather than getting stuck on line 1 forever.
+    expect(snapshots.some(s => s.currentLine === 2)).toBe(true);
+  });
+
   it("frame transition on return happens at the ENVIRONMENT instruction, not the return statement itself", async () => {
     const snapshots = await runAndCollect(
       `def f():

--- a/src/tests/PyCseMachinePlugin.test.ts
+++ b/src/tests/PyCseMachinePlugin.test.ts
@@ -619,6 +619,19 @@ describe("collectSnapshots", () => {
     expect(snapshots.some(s => s.currentLine === 2)).toBe(true);
   });
 
+  it("currentLine alternates between the for-line and the body line across iterations, not stuck on one", async () => {
+    const snapshots = await runAndCollect(`for x in range(3):\n    print(x)`);
+    const lines = snapshots.map(s => s.currentLine);
+    // Collapse consecutive duplicates: [1,1,1,2,2,1,1,2,2] -> [1,2,1,2].
+    const transitions = lines.filter((line, i) => line !== lines[i - 1]);
+    // The loop's per-iteration bookkeeping (implicit range() bounds, condition re-check,
+    // increment) is logically part of the for-statement (line 1), so currentLine should
+    // return there after each body execution (line 2) instead of getting stuck on
+    // whichever line last had a "real" (non-synthetic) node.
+    expect(transitions.filter(l => l === 1).length).toBeGreaterThan(1);
+    expect(transitions.filter(l => l === 2).length).toBeGreaterThan(1);
+  });
+
   it("frame transition on return happens at the ENVIRONMENT instruction, not the return statement itself", async () => {
     const snapshots = await runAndCollect(
       `def f():


### PR DESCRIPTION
## Summary

Closes #233.

`currentLine` in `collectSnapshots` (`src/conductor/plugins/PyCseMachinePlugin.ts`) drives the CSE Machine visualizer's "current line" highlight. It read `context.runtime.nodes[0]?.startToken?.line` directly, with no guard for runtime-fabricated nodes — the implicit `range()` start/step bounds (`utils.ts`'s `evaluateForIterator`) and the per-iteration loop-variable increment (`utils.ts`'s `generateForIncrement`, plus the synthetic nodes built in `interpreter.ts`'s `FOR` instruction handler). Those tokens are always constructed with `line: 0`, since they don't correspond to any line the user actually wrote.

`generateForIncrement` runs on **every iteration of every `for`/`range()` loop**, so this wasn't a rare corner case. For:

```python
for x in range(3):
    print(x)
```

`currentLine` collapses to `0` for roughly half the steps of even this trivial 3-iteration loop, and — worse — the `for` line's reported line never recovers after the very first step: every subsequent condition re-check and increment overwrites it with `0` again. The user-visible effect is that the `for` line's highlight lights up once on initial entry and then never again for the rest of the loop's execution.

## Fix

Track the last real (`line > 0`) line seen across the snapshot stream, and keep reporting it whenever the current node's own line is `0`, instead of overwriting with the meaningless synthetic value. Real tokens are always 1-based (see `parser/token-bridge.ts`'s `mooToken.line ?? 0` — Moo produces 1-based lines), so `line === 0` is an unambiguous "not a real line" signal on its own; no dependency on any synthetic-token flag/metadata is needed.

```ts
const rawLine = currentNode?.startToken?.line;
if (rawLine) {
  lastKnownLine = rawLine;
}
// ...
currentLine: lastKnownLine,
```

## Test plan

- Added a regression test in `src/tests/PyCseMachinePlugin.test.ts`'s existing `collectSnapshots` describe block: steps a `for x in range(3): print(x)` snippet and asserts `currentLine` is never `0` across any snapshot, and that it does reach line 2 (the loop body) rather than getting stuck.
- `npx tsc --noEmit` clean.
- `npx eslint` clean on changed files.
- Full `npx jest`: all non-skipped suites pass, matching a clean `main` checkout (one suite is skipped in this environment on `main` too, unrelated to this change).