### PR TITLE
CSE machine: allocate local variables as unassigned at CALL time

### DIFF
--- a/src/conductor/plugins/PyCseMachinePlugin.ts
+++ b/src/conductor/plugins/PyCseMachinePlugin.ts
@@ -7,7 +7,7 @@ import type {
 import { Closure } from "../../engines/cse/closure";
 import { Context } from "../../engines/cse/context";
 import { Control } from "../../engines/cse/control";
-import { Environment } from "../../engines/cse/environment";
+import { Environment, UNASSIGNED } from "../../engines/cse/environment";
 import { generateCSEMachineStateStream } from "../../engines/cse/interpreter";
 import { Stash, Value } from "../../engines/cse/stash";
 import { InstrType, operatorTranslator, typeTranslator } from "../../engines/cse/types";
@@ -83,7 +83,10 @@ function formatValue(v: Value): string {
   }
 }
 
-function serializeValue(v: Value, envId = ""): SerializedValue {
+function serializeValue(v: Value | typeof UNASSIGNED, envId = ""): SerializedValue {
+  // A local that createEnvironment preallocated at CALL time but that hasn't been
+  // assigned yet — mirrors js-slang's uninitialized-`const`/`let` placeholder rendering.
+  if (v === UNASSIGNED) return { displayValue: "", label: "unassigned" };
   if (v === undefined || v === null) return { displayValue: "None", label: "NoneType" };
   const base = { displayValue: formatValue(v), label: typeTranslator(v.type) };
   if (v.type === "closure") {
@@ -351,7 +354,7 @@ function serializeEnvChain(
     queue.push(env);
     visit(env.tail);
     for (const val of Object.values(env.head)) {
-      if (val && val.type === "closure") visit(val.closure?.environment);
+      if (val && val !== UNASSIGNED && val.type === "closure") visit(val.closure?.environment);
     }
   };
 

--- a/src/engines/cse/environment.ts
+++ b/src/engines/cse/environment.ts
@@ -5,8 +5,17 @@ import { Context } from "./context";
 import { handleRuntimeError } from "./error";
 import { Value } from "./stash";
 
+/**
+ * Sentinel stored in a Frame for a local variable that has been allocated (by CALL,
+ * per its owning function's static scan of assignments/def/for-targets) but not yet
+ * assigned a value. Distinguishes "declared, no value yet" from "no such local" so
+ * reads can raise the correct Python-shaped error instead of silently resolving to an
+ * unrelated binding of the same name further up the environment chain.
+ */
+export const UNASSIGNED = Symbol("unassigned");
+
 export interface Frame {
-  [name: string]: Value;
+  [name: string]: Value | typeof UNASSIGNED;
 }
 
 /**
@@ -108,6 +117,18 @@ export const createEnvironment = (
         isVariadic,
       ),
     );
+  }
+
+  // Allocate every local of this function (assignment/def/for targets, minus params
+  // already bound above) as UNASSIGNED right now, at CALL time — not lazily, whenever
+  // its first assignment happens to execute. This makes reads that race ahead of their
+  // binding (temporal-dead-zone reads, including free-variable reads from a nested
+  // closure) find an unassigned cell owned by this frame instead of falling through to
+  // an unrelated binding of the same name further up the chain (e.g. a global).
+  for (const name of closure.localVariables) {
+    if (!Object.prototype.hasOwnProperty.call(environment.head, name)) {
+      environment.head[name] = UNASSIGNED;
+    }
   }
 
   return environment;

--- a/src/engines/cse/utils.ts
+++ b/src/engines/cse/utils.ts
@@ -289,11 +289,12 @@ export function pyGetVariable(code: string, context: Context, name: string, node
       if (value === UNASSIGNED) {
         if (currentEnv === env) {
           handleRuntimeError(context, new UnboundLocalError(code, name, node as ExprNS.Variable));
+        } else {
+          handleRuntimeError(
+            context,
+            new FreeVariableUnboundError(code, name, node as ExprNS.Variable),
+          );
         }
-        handleRuntimeError(
-          context,
-          new FreeVariableUnboundError(code, name, node as ExprNS.Variable),
-        );
       }
       return value;
     }

--- a/src/engines/cse/utils.ts
+++ b/src/engines/cse/utils.ts
@@ -13,7 +13,7 @@ import { Token, TokenType } from "../../tokenizer";
 import { isStatementSequence } from "./closure";
 import { Context } from "./context";
 import { Control, ControlItem } from "./control";
-import { currentEnvironment, Environment } from "./environment";
+import { currentEnvironment, Environment, UNASSIGNED } from "./environment";
 import { AssertionError, handleRuntimeError } from "./error";
 
 export function getProgramEnvironment(context: Context): Environment | null {
@@ -274,35 +274,30 @@ export function pyDefineVariable(
 
 export function pyGetVariable(code: string, context: Context, name: string, node: Node): Value {
   const env = currentEnvironment(context);
-  if (env.closure && env.closure.localVariables.has(name)) {
-    if (!env.head.hasOwnProperty(name)) {
-      handleRuntimeError(context, new UnboundLocalError(code, name, node as ExprNS.Variable));
-    }
-  }
 
+  // Every local of a function frame is preallocated (as UNASSIGNED) by createEnvironment
+  // at CALL time, so a name owned by some frame on the chain is always found there — as
+  // either a real value or the UNASSIGNED sentinel — before the walk can reach an
+  // unrelated binding of the same name further out (e.g. a global). This is what makes
+  // reads of the frame that's still executing raise UnboundLocalError, and reads of an
+  // enclosing frame (an implicit closure read, no `nonlocal` needed) raise the
+  // "free variable" error, instead of both silently falling through to an outer scope.
   let currentEnv: Environment | null = env;
   while (currentEnv) {
     if (Object.prototype.hasOwnProperty.call(currentEnv.head, name)) {
-      return currentEnv.head[name];
-    } else {
-      currentEnv = currentEnv.tail;
+      const value = currentEnv.head[name];
+      if (value === UNASSIGNED) {
+        if (currentEnv === env) {
+          handleRuntimeError(context, new UnboundLocalError(code, name, node as ExprNS.Variable));
+        }
+        handleRuntimeError(
+          context,
+          new FreeVariableUnboundError(code, name, node as ExprNS.Variable),
+        );
+      }
+      return value;
     }
-  }
-
-  // Not bound anywhere in the chain — but it may still be a legitimate implicit closure
-  // read of an enclosing function's own local (no `nonlocal` needed for reads), whose
-  // binding construct just hasn't executed yet (e.g. a `def`/assignment that appears later
-  // in that enclosing scope's body). Distinguish this from a genuinely undefined name, the
-  // same way pyGetNonlocalVariable already does for explicit `nonlocal` targets.
-  let ancestorEnv: Environment | null = env.tail;
-  while (ancestorEnv) {
-    if (ancestorEnv.closure && ancestorEnv.closure.localVariables.has(name)) {
-      handleRuntimeError(
-        context,
-        new FreeVariableUnboundError(code, name, node as ExprNS.Variable),
-      );
-    }
-    ancestorEnv = ancestorEnv.tail;
+    currentEnv = currentEnv.tail;
   }
 
   if (context.nativeStorage.builtins.has(name)) {
@@ -319,10 +314,13 @@ export function pyGetGlobalVariable(
   name: string,
   node: Node,
 ): Value {
+  // The global/module frame is never preallocated with UNASSIGNED locals (per the issue:
+  // "only the global environment supports dynamic allocation"), so a bound property here
+  // is always a real value.
   let currentEnv: Environment | null = getProgramEnvironment(context);
   while (currentEnv) {
     if (Object.prototype.hasOwnProperty.call(currentEnv.head, name)) {
-      return currentEnv.head[name];
+      return currentEnv.head[name] as Value;
     }
     currentEnv = currentEnv.tail;
   }
@@ -363,14 +361,20 @@ export function pyGetNonlocalVariable(
 ): Value {
   const owningEnv = findNonlocalOwningEnvironment(context, name);
   if (owningEnv) {
-    if (Object.prototype.hasOwnProperty.call(owningEnv.head, name)) {
-      return owningEnv.head[name];
+    // owningEnv was found via closure.localVariables, so createEnvironment preallocated
+    // `name` in its head — either as a real value or as UNASSIGNED.
+    const value = owningEnv.head[name];
+    if (value === UNASSIGNED) {
+      // `name` is a free variable captured from an enclosing scope (via `nonlocal`), not a
+      // local of the *current* function — CPython raises NameError with "free variable ...
+      // in enclosing scope" wording here, distinct from UnboundLocalError (which is for a
+      // name that's local to the function actually doing the reading).
+      handleRuntimeError(
+        context,
+        new FreeVariableUnboundError(code, name, node as ExprNS.Variable),
+      );
     }
-    // `name` is a free variable captured from an enclosing scope (via `nonlocal`), not a
-    // local of the *current* function — CPython raises NameError with "free variable ...
-    // in enclosing scope" wording here, distinct from UnboundLocalError (which is for a
-    // name that's local to the function actually doing the reading).
-    handleRuntimeError(context, new FreeVariableUnboundError(code, name, node as ExprNS.Variable));
+    return value;
   }
   handleRuntimeError(context, new NameError(code, name, node as ExprNS.Variable));
 }

--- a/src/tests/nonlocal.test.ts
+++ b/src/tests/nonlocal.test.ts
@@ -418,6 +418,43 @@ outer()
         null,
       ],
     ],
+
+  // Issue #223: local variables must be allocated (as unassigned) by CALL, not lazily
+  // whenever their assignment happens to execute. Without this, a closure reading a local
+  // that hasn't been assigned yet on this control-flow path (here, `g()` runs before the
+  // unreachable `z = "local"`) falls through past the owning frame's empty cell and
+  // wrongly resolves to an unrelated same-named global instead of raising an error.
+  "closure reads a local before its assignment runs, with a same-named global present — raises FreeVariableUnboundError, not the global (#223)":
+    [
+      [
+        `
+z = "global"
+def f():
+    g = lambda: z
+    return g()
+    z = "local"
+print(f())
+`,
+        FreeVariableUnboundError,
+        null,
+      ],
+    ],
+
+  "closure reads a local after its assignment has run, with a same-named global present — resolves to the local (#223)":
+    [
+      [
+        `
+z = "global"
+def f():
+    z = "local"
+    g = lambda: z
+    return g()
+print(f())
+`,
+        null,
+        ["local"],
+      ],
+    ],
 };
 
 generateTestCases(nonlocalTests, 3, ch3);


### PR DESCRIPTION
## Summary

Fixes #223.

Local variables were being bound lazily whenever their assignment statement happened to execute, rather than being allocated up front when the function is called. This meant a read that raced ahead of its own binding (e.g. inside a closure created before the assignment runs) would fall straight through the empty frame and resolve to an unrelated binding of the same name further up the environment chain, such as a global, instead of raising an error like CPython does.

Repro from the issue:

```python
z = "global"
def f():
    g = lambda: z
    return g()
    z = "local"
print(f())
```

CPython raises `NameError: cannot access free variable 'z' where it is not associated with a value in enclosing scope`. py-slang was printing `global`.

## Changes

- `environment.ts`: added an `UNASSIGNED` sentinel. `createEnvironment` now preallocates every local of a function frame (assignment/def/for targets, minus params already bound) as `UNASSIGNED` at CALL time, instead of leaving the slot missing until the first assignment executes.
- `utils.ts`: `pyGetVariable` and `pyGetNonlocalVariable` now check for the `UNASSIGNED` sentinel and raise `UnboundLocalError` when the owning frame is the current frame, or `FreeVariableUnboundError` when it's an enclosing frame, matching CPython's distinction. `pyGetGlobalVariable` is unaffected since the global frame is never preallocated (only the global scope supports dynamic allocation, per the issue).
- `PyCseMachinePlugin.ts`: the CSE visualizer's `serializeValue`/`serializeEnvChain` now handle the `UNASSIGNED` sentinel so an unassigned local renders sensibly in the frame display instead of crashing or showing garbage.
- `nonlocal.test.ts`: added the issue's repro as a test case, plus the mirror case where the assignment does run before the closure read, to confirm the local resolves normally in that path.

## Test plan

- [x] `yarn jest src/tests/nonlocal.test.ts` — all passing, including the two new cases for this issue
- [x] `yarn jest` (full suite) — passing aside from one pre-existing flaky timeout in `pvml-runner.test.ts` (subprocess test, unrelated to this change, confirmed to pass in isolation both with and without this diff)
- [x] `yarn lint` — no errors