### PR TITLE
Lex float/complex exponents without a required decimal point

### DIFF
--- a/src/parser/lexer.ts
+++ b/src/parser/lexer.ts
@@ -55,8 +55,8 @@ const mooLexer = moo.compile({
   ws: /[ \t]+/,
   comment: /#[^\r\n]*/,
 
-  number_complex: /(?:\d+\.?\d*|\.\d+)[jJ]/,
-  number_float: /(?:\d+\.\d*|\.\d+)(?:[eE][+-]?\d+)?/,
+  number_complex: /(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?[jJ]/,
+  number_float: /(?:\d+\.\d*|\.\d+)(?:[eE][+-]?\d+)?|\d+[eE][+-]?\d+/,
   number_hex: /0[xX][0-9a-fA-F]+/,
   number_oct: /0[oO][0-7]+/,
   number_bin: /0[bB][01]+/,

--- a/src/tests/nearley-parser.test.ts
+++ b/src/tests/nearley-parser.test.ts
@@ -87,6 +87,22 @@ describe("Literal expressions", () => {
     expect((expr as ExprNS.Literal).value).toBeCloseTo(3.14);
   });
 
+  // Python's exponentfloat grammar allows a digitpart exponent with no
+  // decimal point at all (see #214); the lexer used to require a dot before
+  // the exponent was recognized, so `1e400` lexed as `1` followed by a
+  // garbage `e400` token instead of a single float.
+  test("exponent float without a decimal point produces Literal with float value", () => {
+    const expr = parseExpr("2e3");
+    expect(expr).toBeInstanceOf(ExprNS.Literal);
+    expect((expr as ExprNS.Literal).value).toBeCloseTo(2000);
+  });
+
+  test("exponent float without a decimal point overflows to Infinity, as in CPython", () => {
+    const expr = parseExpr("1e400");
+    expect(expr).toBeInstanceOf(ExprNS.Literal);
+    expect((expr as ExprNS.Literal).value).toBe(Infinity);
+  });
+
   test("True produces Literal(true)", () => {
     const expr = parseExpr("True");
     expect(expr).toBeInstanceOf(ExprNS.Literal);
@@ -150,6 +166,23 @@ describe("Literal expressions", () => {
     expect(expr).toBeInstanceOf(ExprNS.Complex);
     expect((expr as ExprNS.Complex).value.real).toBe(0);
     expect((expr as ExprNS.Complex).value.imag).toBe(3);
+  });
+
+  // Same exponentfloat gap as above (#214), but for the imaginary part of a
+  // complex literal: neither `2e3j` (no dot) nor `6.2E2j` (dot, but the
+  // lexer had no exponent handling for number_complex at all) used to lex.
+  test("complex literal with exponent and no decimal point", () => {
+    const expr = parseExpr("2e3j");
+    expect(expr).toBeInstanceOf(ExprNS.Complex);
+    expect((expr as ExprNS.Complex).value.real).toBe(0);
+    expect((expr as ExprNS.Complex).value.imag).toBe(2000);
+  });
+
+  test("complex literal with exponent and a decimal point", () => {
+    const expr = parseExpr("6.2E2j");
+    expect(expr).toBeInstanceOf(ExprNS.Complex);
+    expect((expr as ExprNS.Complex).value.real).toBe(0);
+    expect((expr as ExprNS.Complex).value.imag).toBeCloseTo(620);
   });
 
   test("large integer produces BigIntLiteral", () => {


### PR DESCRIPTION
Fixes #214.

## Summary
- `src/parser/lexer.ts`: the Moo lexer rules for `number_float` and `number_complex` only recognized a scientific-notation exponent (`e`/`E`) after a pattern that already contained a decimal point. Python's `exponentfloat` grammar allows a bare `digitpart exponent` with no dot at all — `1e400` lexed as int `1` followed by a garbage `e400` token instead of a single float, and `number_complex` had no exponent handling at all, so even dotted exponents like `6.2E2j` failed too.
- As a result, `docs/specs/python_numbers.tex`'s own worked example (`1e3-6.2E2J`) did not actually parse before this fix.
- `src/tests/nearley-parser.test.ts`: added coverage for bare-exponent floats (`2e3`, `1e400` overflowing to `Infinity` as in CPython) and bare/dotted-exponent complex literals (`2e3j`, `6.2E2j`).

## Test plan
- [x] `npx jest src/tests/nearley-parser.test.ts src/tests/lexer.test.ts` — 198/198 passing, including new cases
- [x] `npx jest` (full suite) — 2523/2523 passing (non-skipped)
- [x] `npx tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)