### PR TITLE
python/README.md: note sourceacademy-sicp isn't on PyPI yet

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -15,6 +15,15 @@ for CS1101S or the SICP Python edition runs the same way on your own machine.
 pip install sourceacademy-sicp
 ```
 
+**Not on PyPI yet.** No GitHub Release has been cut, so the `publish` job
+below has never run and this currently fails with "No matching distribution
+found". Until a release exists, install straight from this repository
+instead:
+
+```bash
+pip install "git+https://github.com/source-academy/py-slang.git#subdirectory=python"
+```
+
 ## Use
 
 Put this at the top of your program:


### PR DESCRIPTION
## Summary
- The Install section said `pip install sourceacademy-sicp` with no caveat, but the package has never actually been published — no GitHub Release has been cut, so the release-gated `publish` job in `python-package.yml` has never fired.
- Adds a note plus a working fallback (`pip install "git+https://github.com/source-academy/py-slang.git#subdirectory=python"`) so readers aren't surprised by "No matching distribution found".

Found while wiring CPython-based SICPy testing into the `sicp` repo's CI, which hit this same gap (source-academy/sicp#1289).

## Test plan
- [x] Doc-only change, no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)