### PR TITLE
python/README.md: sourceacademy-sicp is published on PyPI now

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -15,15 +15,6 @@ for CS1101S or the SICP Python edition runs the same way on your own machine.
 pip install sourceacademy-sicp
 ```
 
-**Not on PyPI yet.** No GitHub Release has been cut, so the `publish` job
-below has never run and this currently fails with "No matching distribution
-found". Until a release exists, install straight from this repository
-instead:
-
-```bash
-pip install "git+https://github.com/source-academy/py-slang.git#subdirectory=python"
-```
-
 ## Use
 
 Put this at the top of your program:


### PR DESCRIPTION
## Summary
- Removes the "not on PyPI yet" caveat added in #264 — v0.1.0 is live at https://pypi.org/project/sourceacademy-sicp/, so `pip install sourceacademy-sicp` works as originally documented.

## Test plan
- [x] Doc-only change.
- [x] Verified `pip install sourceacademy-sicp` succeeds in a clean venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)