### PR TITLE
Add WASM to the table-driven operator conformance sweep

### DIFF
--- a/src/engines/wasm/builderGenerator.ts
+++ b/src/engines/wasm/builderGenerator.ts
@@ -23,6 +23,8 @@ import {
   ARITHMETIC_OP_TAG,
   BOOL_NOT_FX,
   BOOLISE_FX,
+  CHAPTER,
+  CHECK_BOOL_FX,
   CHECK_INT_FX,
   CLEAR_GC_HEADER_FX,
   COLLECT_FX,
@@ -108,6 +110,7 @@ export class BuilderGenerator implements BuilderVisitor<WasmInstruction, WasmNum
   private builtIns: WasmCall[];
   private interactiveMode = false;
   private pageCount: number;
+  private chapter: number;
 
   private environment: Binding[][] = [[]];
   private userFunctions: WasmInstruction[][] = [];
@@ -201,9 +204,11 @@ export class BuilderGenerator implements BuilderVisitor<WasmInstruction, WasmNum
     builtInFunctions: LibFuncType[],
     interactiveMode: boolean,
     pageCount: number,
+    chapter: number,
   ) {
     this.strings = initialStrings;
     this.pageCount = pageCount;
+    this.chapter = chapter;
 
     this.builtIns = builtInFunctions.map(({ name, arity, body, isVoid, hasVarArgs }, i) => {
       this.environment[0].push({ name, tag: "local" });
@@ -298,6 +303,11 @@ export class BuilderGenerator implements BuilderVisitor<WasmInstruction, WasmNum
           .func("$_host_parse")
           .params(i32, i32)
           .results(i32, i64),
+        wasm
+          .import("arith", "ext")
+          .func("$_host_arith_ext")
+          .params(i32, i32, i64, i32, i64)
+          .results(i32, i64),
       )
       .globals(
         wasm.global(DATA_END, i32).init(i32.const(heapPointer)),
@@ -310,6 +320,7 @@ export class BuilderGenerator implements BuilderVisitor<WasmInstruction, WasmNum
         wasm.global(SHADOW_STACK_TOP, i32).init(i32.const(memoryEndPointer)),
         wasm.global(SHADOW_STACK_PTR, mut.i32).init(i32.const(memoryEndPointer)),
         wasm.global(CURR_ENV, mut.i32).init(i32.const(0)),
+        wasm.global(CHAPTER, i32).init(i32.const(this.chapter)),
       )
       .datas(...strings)
       .funcs(
@@ -359,6 +370,9 @@ export class BuilderGenerator implements BuilderVisitor<WasmInstruction, WasmNum
     else if (type === TokenType.MINUS) opTag = ARITHMETIC_OP_TAG.SUB;
     else if (type === TokenType.STAR) opTag = ARITHMETIC_OP_TAG.MUL;
     else if (type === TokenType.SLASH) opTag = ARITHMETIC_OP_TAG.DIV;
+    else if (type === TokenType.DOUBLESLASH) opTag = ARITHMETIC_OP_TAG.FLOORDIV;
+    else if (type === TokenType.PERCENT) opTag = ARITHMETIC_OP_TAG.MOD;
+    else if (type === TokenType.DOUBLESTAR) opTag = ARITHMETIC_OP_TAG.POW;
     else throw new Error(`Unsupported binary operator: ${type}`);
 
     return wasm.call(ARITHMETIC_OP_FX).args(left, right, i32.const(opTag));
@@ -376,6 +390,8 @@ export class BuilderGenerator implements BuilderVisitor<WasmInstruction, WasmNum
     else if (type === TokenType.LESSEQUAL) opTag = COMPARISON_OP_TAG.LTE;
     else if (type === TokenType.GREATER) opTag = COMPARISON_OP_TAG.GT;
     else if (type === TokenType.GREATEREQUAL) opTag = COMPARISON_OP_TAG.GTE;
+    else if (type === TokenType.IS) opTag = COMPARISON_OP_TAG.IS;
+    else if (type === TokenType.ISNOT) opTag = COMPARISON_OP_TAG.ISNOT;
     else throw new Error(`Unsupported comparison operator: ${type}`);
 
     return wasm.call(COMPARISON_OP_FX).args(left, right, i32.const(opTag));
@@ -386,12 +402,16 @@ export class BuilderGenerator implements BuilderVisitor<WasmInstruction, WasmNum
 
     const type = expr.operator.type;
     if (type === TokenType.MINUS) return wasm.call(NEG_FX).args(right);
-    else if (type === TokenType.NOT) return wasm.call(BOOL_NOT_FX).args(right);
+    else if (type === TokenType.NOT)
+      return wasm.call(BOOL_NOT_FX).args(wasm.call(CHECK_BOOL_FX).args(right));
     else throw new Error(`Unsupported unary operator: ${type}`);
   }
 
   visitBoolOpExpr(expr: ExprNS.BoolOp): WasmNumeric {
-    const left = this.visit(expr.left);
+    // `and`/`or`'s *left* operand must be an actual bool (see
+    // docs/specs/python_typing_back.tex: `bool, any -> any`) -- only the
+    // right operand's short-circuit test is general BOOLISE_FX truthiness.
+    const left = wasm.call(CHECK_BOOL_FX).args(this.visit(expr.left));
     const right = this.visit(expr.right);
 
     const type = expr.operator.type;

--- a/src/engines/wasm/compiler.ts
+++ b/src/engines/wasm/compiler.ts
@@ -31,6 +31,7 @@ export async function compileScriptToWasmBinary(
     makeLibraryFunctions(groups),
     interactiveMode,
     options.pageCount ?? 1,
+    options.chapter ?? 4,
   );
   const passes: IrPass[] = [
     ...(options.irPasses ?? []),

--- a/src/engines/wasm/hostImports.ts
+++ b/src/engines/wasm/hostImports.ts
@@ -1,9 +1,46 @@
 import { parse } from "../../parser";
 import pythonLexer from "../../parser/lexer";
 import { toAstToken } from "../../parser/token-bridge";
+import { pythonMod } from "../cse/utils";
+import { PyComplexNumber } from "../../types/value-types";
 import { MetacircularGenerator } from "./metacircularGenerator";
-import { ERROR_MAP, GC_OBJECT_HEADER_SIZE } from "./runtime";
+import { ARITHMETIC_OP_TAG, ERROR_MAP, GC_OBJECT_HEADER_SIZE, TYPE_TAG } from "./runtime";
 import type { WasmExports } from "./types";
+
+/** Decodes a (tag, val) operand pair into the JS numeric representation
+ * arith.ext's host-side computation works with: an int stays a bigint, a
+ * float's bit-reinterpreted i64 is read back out as a JS number, and a
+ * complex operand's real/imag pair is read directly off the GC heap at its
+ * pointer (mirroring operators.ts's own f64.load(...)/f64.load(...+8) reads
+ * for complex operands elsewhere in the runtime). */
+function decodeArithOperand(
+  memory: WebAssembly.Memory,
+  tag: number,
+  val: bigint,
+): bigint | number | PyComplexNumber {
+  switch (tag) {
+    case TYPE_TAG.INT:
+      return val;
+    case TYPE_TAG.FLOAT: {
+      const buf = new ArrayBuffer(8);
+      new DataView(buf).setBigInt64(0, val, true);
+      return new DataView(buf).getFloat64(0, true);
+    }
+    case TYPE_TAG.COMPLEX: {
+      const dv = new DataView(memory.buffer, Number(val), 16);
+      return new PyComplexNumber(dv.getFloat64(0, true), dv.getFloat64(8, true));
+    }
+    default:
+      throw new Error(ERROR_MAP.ARITH_OP_UNKNOWN_TYPE);
+  }
+}
+
+function toComplex(value: bigint | number | PyComplexNumber): PyComplexNumber {
+  if (value instanceof PyComplexNumber) return value;
+  return typeof value === "bigint"
+    ? PyComplexNumber.fromBigInt(value)
+    : PyComplexNumber.fromNumber(value);
+}
 
 export type HostRuntimeState = {
   output: string[];
@@ -94,6 +131,65 @@ export function createHostImports(memory: WebAssembly.Memory, runtime: HostRunti
 
         const metacircularGenerator = new MetacircularGenerator(runtime.wasmExports, memory);
         return metacircularGenerator.visit(ast);
+      },
+    },
+    arith: {
+      /**
+       * `//`, `%`, `**` (see runtime/operators.ts's ARITHMETIC_OP_FX,
+       * whose FLOORDIV/MOD/POW branches delegate here entirely): reuses
+       * CSE's own pythonMod and PyComplexNumber.pow so WASM's floor-division
+       * (floors toward -infinity, not i64 div_s's truncation-toward-zero)
+       * and complex exponentiation (needs log/exp/atan2/cos/sin -- none of
+       * which are native WASM instructions) match CSE bit-for-bit instead of
+       * a second, independently-derived implementation.
+       */
+      ext: (op: number, xTag: number, xVal: bigint, yTag: number, yVal: bigint): [number, bigint] => {
+        if (!runtime.wasmExports) throw new Error("WASM exports not initialised");
+        const { makeInt, makeFloat, makeComplex } = runtime.wasmExports;
+
+        const x = decodeArithOperand(memory, xTag, xVal);
+        const y = decodeArithOperand(memory, yTag, yVal);
+
+        if (x instanceof PyComplexNumber || y instanceof PyComplexNumber) {
+          if (op !== ARITHMETIC_OP_TAG.POW) throw new Error(ERROR_MAP.ARITH_OP_UNKNOWN_TYPE);
+          const result = toComplex(x).pow(toComplex(y));
+          return makeComplex(result.real, result.imag);
+        }
+
+        if (typeof x === "number" || typeof y === "number") {
+          const xf = Number(x);
+          const yf = Number(y);
+          switch (op) {
+            case ARITHMETIC_OP_TAG.FLOORDIV:
+              if (yf === 0) throw new Error(ERROR_MAP.ZERO_DIVISION);
+              return makeFloat(Math.floor(xf / yf));
+            case ARITHMETIC_OP_TAG.MOD:
+              if (yf === 0) throw new Error(ERROR_MAP.ZERO_DIVISION);
+              return makeFloat(pythonMod(xf, yf));
+            case ARITHMETIC_OP_TAG.POW:
+              if (xf === 0 && yf < 0) throw new Error(ERROR_MAP.ZERO_DIVISION);
+              return makeFloat(xf ** yf);
+            default:
+              throw new Error(ERROR_MAP.ARITH_OP_UNKNOWN_TYPE);
+          }
+        }
+
+        const xb = x;
+        const yb = y;
+        switch (op) {
+          case ARITHMETIC_OP_TAG.FLOORDIV:
+            if (yb === 0n) throw new Error(ERROR_MAP.ZERO_DIVISION);
+            return makeInt((xb - pythonMod(xb, yb)) / yb);
+          case ARITHMETIC_OP_TAG.MOD:
+            if (yb === 0n) throw new Error(ERROR_MAP.ZERO_DIVISION);
+            return makeInt(pythonMod(xb, yb));
+          case ARITHMETIC_OP_TAG.POW:
+            if (xb === 0n && yb < 0n) throw new Error(ERROR_MAP.ZERO_DIVISION);
+            if (yb < 0n) return makeFloat(Number(xb) ** Number(yb));
+            return makeInt(xb ** yb);
+          default:
+            throw new Error(ERROR_MAP.ARITH_OP_UNKNOWN_TYPE);
+        }
       },
     },
     js: { memory },

--- a/src/engines/wasm/hostImports.ts
+++ b/src/engines/wasm/hostImports.ts
@@ -143,7 +143,13 @@ export function createHostImports(memory: WebAssembly.Memory, runtime: HostRunti
        * which are native WASM instructions) match CSE bit-for-bit instead of
        * a second, independently-derived implementation.
        */
-      ext: (op: number, xTag: number, xVal: bigint, yTag: number, yVal: bigint): [number, bigint] => {
+      ext: (
+        op: number,
+        xTag: number,
+        xVal: bigint,
+        yTag: number,
+        yVal: bigint,
+      ): [number, bigint] => {
         if (!runtime.wasmExports) throw new Error("WASM exports not initialised");
         const { makeInt, makeFloat, makeComplex } = runtime.wasmExports;
 

--- a/src/engines/wasm/runtime/index.ts
+++ b/src/engines/wasm/runtime/index.ts
@@ -25,7 +25,9 @@ import { PARSE_FX, TOKENIZE_FX } from "./mce";
 import {
   ARITHMETIC_OP_FX,
   BOOL_NOT_FX,
+  CHECK_BOOL_FX,
   COMPARISON_OP_FX,
+  LIST_STRUCT_EQ_FX,
   NEG_FX,
   STRING_COMPARE_FX,
 } from "./operators";
@@ -142,5 +144,7 @@ export const nativeFunctions = [
   ARITHMETIC_OP_FX,
   STRING_COMPARE_FX,
   COMPARISON_OP_FX,
+  LIST_STRUCT_EQ_FX,
+  CHECK_BOOL_FX,
   BOOL_NOT_FX,
 ];

--- a/src/engines/wasm/runtime/metadata.ts
+++ b/src/engines/wasm/runtime/metadata.ts
@@ -49,6 +49,9 @@ export const ERROR_MAP = {
   STACK_UNDERFLOW: "Stack underflow.",
   GEN_LIST_NOT_INT: "Trying to generate a list of non-integer length.",
   ARITY_NOT_CLOSURE: "Trying to get arity of a non-closure value.",
+  ZERO_DIVISION: "ZeroDivisionError: division by zero.",
+  BOOL_OPERAND_NOT_SUPPORTED: "Calling an operation on an unsupported operand type: bool.",
+  EXPECTED_BOOL_OPERAND: "TypeError: expected a bool operand for this operation.",
 } as const;
 
 export const getErrorIndex = (errorKey: (typeof ERROR_MAP)[keyof typeof ERROR_MAP]) =>
@@ -57,6 +60,8 @@ export const getErrorIndex = (errorKey: (typeof ERROR_MAP)[keyof typeof ERROR_MA
 export const DATA_END = "$_data_end";
 export const SHADOW_STACK_BOTTOM = "$_shadow_stack_bottom_pointer";
 export const SHADOW_STACK_TOP = "$_shadow_stack_top_pointer";
+
+export const CHAPTER = "$_chapter";
 
 export const HEAP_PTR = "$_heap_pointer";
 export const FROM_SPACE_START_PTR = "$_from_space_start_pointer";

--- a/src/engines/wasm/runtime/metadata.ts
+++ b/src/engines/wasm/runtime/metadata.ts
@@ -50,8 +50,8 @@ export const ERROR_MAP = {
   GEN_LIST_NOT_INT: "Trying to generate a list of non-integer length.",
   ARITY_NOT_CLOSURE: "Trying to get arity of a non-closure value.",
   ZERO_DIVISION: "ZeroDivisionError: division by zero.",
-  BOOL_OPERAND_NOT_SUPPORTED: "Calling an operation on an unsupported operand type: bool.",
-  EXPECTED_BOOL_OPERAND: "TypeError: expected a bool operand for this operation.",
+  BOOL_OPERAND_NOT_SUPPORTED: "TypeError: unsupported operand type(s) for this operation: boolean.",
+  EXPECTED_BOOL_OPERAND: "TypeError: expected a boolean operand for this operation.",
 } as const;
 
 export const getErrorIndex = (errorKey: (typeof ERROR_MAP)[keyof typeof ERROR_MAP]) =>

--- a/src/engines/wasm/runtime/operators.ts
+++ b/src/engines/wasm/runtime/operators.ts
@@ -171,7 +171,9 @@ export const ARITHMETIC_OP_FX = wasm
         ),
       )
       .then(
-        wasm.call("$_log_error").args(i32.const(getErrorIndex(ERROR_MAP.BOOL_OPERAND_NOT_SUPPORTED))),
+        wasm
+          .call("$_log_error")
+          .args(i32.const(getErrorIndex(ERROR_MAP.BOOL_OPERAND_NOT_SUPPORTED))),
         wasm.unreachable(),
       ),
 
@@ -528,10 +530,7 @@ function identityCheck(): WasmInstruction[] {
                       // pointer (no recursive structural comparison, unlike ==),
                       // closures by their packed representation (see doc comment).
                       .else(
-                        local.set(
-                          "$is_result",
-                          i64.eq(local.get("$x_val"), local.get("$y_val")),
-                        ),
+                        local.set("$is_result", i64.eq(local.get("$x_val"), local.get("$y_val"))),
                       ),
                   ),
               ),
@@ -907,14 +906,10 @@ export const LIST_STRUCT_EQ_FX = wasm
   .body(
     local.set("$len_x", i32.wrap_i64(local.get("$x_val"))),
     local.set("$len_y", i32.wrap_i64(local.get("$y_val"))),
-    wasm
-      .if(i32.ne(local.get("$len_x"), local.get("$len_y")))
-      .then(wasm.return(i32.const(0))),
+    wasm.if(i32.ne(local.get("$len_x"), local.get("$len_y"))).then(wasm.return(i32.const(0))),
 
     wasm.loop("$loop").body(
-      wasm
-        .if(i32.ge_s(local.get("$i"), local.get("$len_x")))
-        .then(wasm.return(i32.const(1))),
+      wasm.if(i32.ge_s(local.get("$i"), local.get("$len_x"))).then(wasm.return(i32.const(1))),
 
       local.set(
         "$ex_tag",

--- a/src/engines/wasm/runtime/operators.ts
+++ b/src/engines/wasm/runtime/operators.ts
@@ -1,6 +1,23 @@
-import { f64, global, i32, i64, local, memory, wasm } from "@sourceacademy/wasm-util";
+import {
+  f64,
+  global,
+  i32,
+  i64,
+  local,
+  memory,
+  wasm,
+  type WasmInstruction,
+} from "@sourceacademy/wasm-util";
 import { MALLOC_FX } from "./gc";
-import { DATA_END, ERROR_MAP, GC_OBJECT_HEADER_SIZE, TYPE_TAG, getErrorIndex } from "./metadata";
+import { LIST_SLOT_TAG_LOAD_FX, LIST_SLOT_VAL_LOAD_FX } from "./list";
+import {
+  CHAPTER,
+  DATA_END,
+  ERROR_MAP,
+  GC_OBJECT_HEADER_SIZE,
+  TYPE_TAG,
+  getErrorIndex,
+} from "./metadata";
 import { POP_SHADOW_STACK_FX } from "./shadowStack";
 import { BOOLISE_FX } from "./stdlib";
 import {
@@ -52,7 +69,15 @@ export const NEG_FX = wasm
     wasm.unreachable(),
   );
 
-export const ARITHMETIC_OP_TAG = { ADD: 0, SUB: 1, MUL: 2, DIV: 3 } as const;
+export const ARITHMETIC_OP_TAG = {
+  ADD: 0,
+  SUB: 1,
+  MUL: 2,
+  DIV: 3,
+  FLOORDIV: 4,
+  MOD: 5,
+  POW: 6,
+} as const;
 // binary operation function
 export const ARITHMETIC_OP_FX = wasm
   .func("$_py_arith_op")
@@ -134,13 +159,54 @@ export const ARITHMETIC_OP_FX = wasm
         ),
       ),
 
-    // if either's bool, convert to int
+    // bool is never a valid arithmetic operand, at every chapter (see
+    // docs/specs/python_typing_front.tex: NUMERIC excludes bool; mirrors
+    // CSE's evaluateBinaryExpression, which never coerces bool for +,-,*,/,
+    // //,%,** -- only for ordering comparisons, and only at §3/§4).
     wasm
-      .if(i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.BOOL)))
-      .then(local.set("$x_tag", i32.const(TYPE_TAG.INT))),
+      .if(
+        i32.or(
+          i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.BOOL)),
+          i32.eq(local.get("$y_tag"), i32.const(TYPE_TAG.BOOL)),
+        ),
+      )
+      .then(
+        wasm.call("$_log_error").args(i32.const(getErrorIndex(ERROR_MAP.BOOL_OPERAND_NOT_SUPPORTED))),
+        wasm.unreachable(),
+      ),
+
+    // //, %, ** are delegated to a host import that mirrors CSE's exact
+    // numeric branches (see hostImports.ts's arith_ext): int floor-div/mod
+    // need Python's floor-toward-negative-infinity semantics (not i64's
+    // truncating div_s/rem_s), and ** needs arbitrary-precision bigint
+    // exponentiation plus PyComplexNumber's general complex-power formula
+    // (log/exp/atan2/cos/sin -- transcendental functions with no native WASM
+    // instruction) -- reusing CSE's own implementations guarantees bit-for-bit
+    // parity instead of a second, independently-derived formula that could
+    // drift from it.
     wasm
-      .if(i32.eq(local.get("$y_tag"), i32.const(TYPE_TAG.BOOL)))
-      .then(local.set("$y_tag", i32.const(TYPE_TAG.INT))),
+      .if(
+        i32.or(
+          i32.eq(local.get("$op"), i32.const(ARITHMETIC_OP_TAG.FLOORDIV)),
+          i32.or(
+            i32.eq(local.get("$op"), i32.const(ARITHMETIC_OP_TAG.MOD)),
+            i32.eq(local.get("$op"), i32.const(ARITHMETIC_OP_TAG.POW)),
+          ),
+        ),
+      )
+      .then(
+        wasm.return(
+          wasm
+            .call("$_host_arith_ext")
+            .args(
+              local.get("$op"),
+              local.get("$x_tag"),
+              local.get("$x_val"),
+              local.get("$y_tag"),
+              local.get("$y_val"),
+            ),
+        ),
+      ),
 
     // if both int, use int instr (except for division: use float)
     wasm
@@ -289,32 +355,35 @@ export const ARITHMETIC_OP_FX = wasm
           ),
       ),
       // (a+bi)/(c+di) = (ac+bd)/(c^2+d^2) + (bc-ad)/(c^2+d^2)i
-      wasm.return(
-        wasm
-          .call(MAKE_COMPLEX_FX)
-          .args(
-            local.tee(
-              "$denom",
+      [
+        local.set(
+          "$denom",
+          f64.add(
+            f64.mul(local.get("$c"), local.get("$c")),
+            f64.mul(local.get("$d"), local.get("$d")),
+          ),
+        ),
+        wasm.return(
+          wasm
+            .call(MAKE_COMPLEX_FX)
+            .args(
               f64.div(
                 f64.add(
                   f64.mul(local.get("$a"), local.get("$c")),
                   f64.mul(local.get("$b"), local.get("$d")),
                 ),
-                f64.add(
-                  f64.mul(local.get("$c"), local.get("$c")),
-                  f64.mul(local.get("$d"), local.get("$d")),
+                local.get("$denom"),
+              ),
+              f64.div(
+                f64.sub(
+                  f64.mul(local.get("$b"), local.get("$c")),
+                  f64.mul(local.get("$a"), local.get("$d")),
                 ),
+                local.get("$denom"),
               ),
             ),
-            f64.div(
-              f64.sub(
-                f64.mul(local.get("$b"), local.get("$c")),
-                f64.mul(local.get("$a"), local.get("$d")),
-              ),
-              local.get("$denom"),
-            ),
-          ),
-      ),
+        ),
+      ],
     ),
 
     wasm.unreachable(),
@@ -327,6 +396,8 @@ export const COMPARISON_OP_TAG = {
   LTE: 3,
   GT: 4,
   GTE: 5,
+  IS: 6,
+  ISNOT: 7,
 } as const;
 
 // comparison function
@@ -363,12 +434,205 @@ export const STRING_COMPARE_FX = wasm
     wasm.return(i32.sub(local.get("$x_len"), local.get("$y_len"))),
   );
 
+/**
+ * `is`/`is not` (COMPARISON_OP_TAG.IS/ISNOT): identity, not structural equality.
+ * Mirrors CSE's pyIdentical (see engines/cse/operators.ts): different tags are
+ * never identical; same-tag values compare by their underlying value for
+ * every scalar type (no int/bool cross-coercion, unlike `==`), by pointer for
+ * lists/tuples, and None is always identical to None. Closures compare by
+ * their packed (tag,arity,env_size,parent_env) representation, which is an
+ * approximation of CPython's per-object identity: two separately evaluated
+ * closures with identical arity/captured-environment happen to compare equal
+ * here, unlike CSE's real per-object identity -- a known gap in the absence
+ * of a distinct heap-allocated closure object to compare by pointer.
+ */
+function identityCheck(): WasmInstruction[] {
+  return [
+    wasm
+      .if(i32.ne(local.get("$x_tag"), local.get("$y_tag")))
+      .then(local.set("$is_result", i32.const(0)))
+      .else(
+        wasm
+          .if(i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.NONE)))
+          .then(local.set("$is_result", i32.const(1)))
+          .else(
+            wasm
+              .if(i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.FLOAT)))
+              .then(
+                local.set(
+                  "$is_result",
+                  f64.eq(
+                    f64.reinterpret_i64(local.get("$x_val")),
+                    f64.reinterpret_i64(local.get("$y_val")),
+                  ),
+                ),
+              )
+              .else(
+                wasm
+                  .if(i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.COMPLEX)))
+                  .then(
+                    local.set(
+                      "$is_result",
+                      i32.and(
+                        f64.eq(
+                          f64.load(i32.wrap_i64(local.get("$x_val"))),
+                          f64.load(i32.wrap_i64(local.get("$y_val"))),
+                        ),
+                        f64.eq(
+                          f64.load(i32.add(i32.wrap_i64(local.get("$x_val")), i32.const(8))),
+                          f64.load(i32.add(i32.wrap_i64(local.get("$y_val")), i32.const(8))),
+                        ),
+                      ),
+                    ),
+                  )
+                  .else(
+                    wasm
+                      .if(i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.STRING)))
+                      .then(
+                        local.set(
+                          "$is_result",
+                          i32.eqz(
+                            wasm
+                              .call(STRING_COMPARE_FX)
+                              .args(
+                                i32.add(
+                                  i32.wrap_i64(i64.shr_u(local.get("$x_val"), i64.const(32))),
+                                  wasm.select(
+                                    i32.const(0),
+                                    i32.const(GC_OBJECT_HEADER_SIZE),
+                                    i32.lt_u(
+                                      i32.wrap_i64(i64.shr_u(local.get("$x_val"), i64.const(32))),
+                                      global.get(DATA_END),
+                                    ),
+                                  ),
+                                ),
+                                i32.wrap_i64(local.get("$x_val")),
+                                i32.add(
+                                  i32.wrap_i64(i64.shr_u(local.get("$y_val"), i64.const(32))),
+                                  wasm.select(
+                                    i32.const(0),
+                                    i32.const(GC_OBJECT_HEADER_SIZE),
+                                    i32.lt_u(
+                                      i32.wrap_i64(i64.shr_u(local.get("$y_val"), i64.const(32))),
+                                      global.get(DATA_END),
+                                    ),
+                                  ),
+                                ),
+                                i32.wrap_i64(local.get("$y_val")),
+                              ),
+                          ),
+                        ),
+                      )
+                      // Ints, bools, lists/tuples and closures: identity is raw
+                      // (tag already matched) value equality -- lists/tuples by
+                      // pointer (no recursive structural comparison, unlike ==),
+                      // closures by their packed representation (see doc comment).
+                      .else(
+                        local.set(
+                          "$is_result",
+                          i64.eq(local.get("$x_val"), local.get("$y_val")),
+                        ),
+                      ),
+                  ),
+              ),
+          ),
+      ),
+    wasm.return(
+      wasm
+        .call(MAKE_BOOL_FX)
+        .args(
+          wasm.select(
+            i32.eqz(local.get("$is_result")),
+            local.get("$is_result"),
+            i32.eq(local.get("$op"), i32.const(COMPARISON_OP_TAG.ISNOT)),
+          ),
+        ),
+    ),
+  ];
+}
+
 export const COMPARISON_OP_FX = wasm
   .func("$_py_compare_op")
   .params({ $x_tag: i32, $x_val: i64, $y_tag: i32, $y_val: i64, $op: i32 })
   .results(i32, i64)
-  .locals({ $a: f64, $b: f64, $c: f64, $d: f64 })
+  .locals({ $a: f64, $b: f64, $c: f64, $d: f64, $is_result: i32, $eq_result: i32 })
   .body(
+    wasm
+      .if(
+        i32.or(
+          i32.eq(local.get("$op"), i32.const(COMPARISON_OP_TAG.IS)),
+          i32.eq(local.get("$op"), i32.const(COMPARISON_OP_TAG.ISNOT)),
+        ),
+      )
+      .then(...identityCheck()),
+
+    // Python §1/§2 restrictions the runtime alone can enforce (chapter-gated
+    // static validators can't see values flowing through variables): `==`/`!=`
+    // exclude bool and closures entirely (docs/specs/python_typing_middle_12.tex
+    // -- mirrors CSE's excludedFromChapter12Equality), and ordering comparisons
+    // exclude bool (bool only participates in ordering, as the int it is, from
+    // §3/§4 -- mirrors CSE's isOrderable/asIntIfBool gating on variant >= 3).
+    wasm
+      .if(i32.lt_s(global.get(CHAPTER), i32.const(3)))
+      .then(
+        wasm
+          .if(
+            i32.or(
+              i32.eq(local.get("$op"), i32.const(COMPARISON_OP_TAG.EQ)),
+              i32.eq(local.get("$op"), i32.const(COMPARISON_OP_TAG.NEQ)),
+            ),
+          )
+          .then(
+            wasm
+              .if(
+                i32.or(
+                  i32.or(
+                    i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.BOOL)),
+                    i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.CLOSURE)),
+                  ),
+                  i32.or(
+                    i32.eq(local.get("$y_tag"), i32.const(TYPE_TAG.BOOL)),
+                    i32.eq(local.get("$y_tag"), i32.const(TYPE_TAG.CLOSURE)),
+                  ),
+                ),
+              )
+              .then(
+                wasm
+                  .call("$_log_error")
+                  .args(i32.const(getErrorIndex(ERROR_MAP.COMPARE_OP_UNKNOWN_TYPE))),
+                wasm.unreachable(),
+              ),
+          ),
+        wasm
+          .if(
+            i32.or(
+              i32.or(
+                i32.eq(local.get("$op"), i32.const(COMPARISON_OP_TAG.LT)),
+                i32.eq(local.get("$op"), i32.const(COMPARISON_OP_TAG.LTE)),
+              ),
+              i32.or(
+                i32.eq(local.get("$op"), i32.const(COMPARISON_OP_TAG.GT)),
+                i32.eq(local.get("$op"), i32.const(COMPARISON_OP_TAG.GTE)),
+              ),
+            ),
+          )
+          .then(
+            wasm
+              .if(
+                i32.or(
+                  i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.BOOL)),
+                  i32.eq(local.get("$y_tag"), i32.const(TYPE_TAG.BOOL)),
+                ),
+              )
+              .then(
+                wasm
+                  .call("$_log_error")
+                  .args(i32.const(getErrorIndex(ERROR_MAP.COMPARE_OP_UNKNOWN_TYPE))),
+                wasm.unreachable(),
+              ),
+          ),
+      ),
+
     // if both are strings
     wasm
       .if(
@@ -560,19 +824,164 @@ export const COMPARISON_OP_FX = wasm
           ),
       ),
 
-    // else, default to not equal
+    // Remaining types reaching here (None, list/tuple, closures) only support
+    // `==`/`!=` -- never ordering. Mismatched tags are simply unequal, as in
+    // Python (structuralEquals: "if two types are different, they are not
+    // equal"); same-tag list/tuple values compare structurally, recursively,
+    // element-by-element (see LIST_STRUCT_EQ_FX); every other same-tag value
+    // reaching here (None, closures) compares by its raw representation --
+    // None always to itself, closures by their packed representation (the
+    // same approximation of object identity `is` uses above).
     wasm
-      .if(i32.eq(local.get("$op"), i32.const(COMPARISON_OP_TAG.EQ)))
-      .then(wasm.return(wasm.call(MAKE_BOOL_FX).args(i32.const(0))))
-      .else(
+      .if(
+        i32.or(
+          i32.eq(local.get("$op"), i32.const(COMPARISON_OP_TAG.EQ)),
+          i32.eq(local.get("$op"), i32.const(COMPARISON_OP_TAG.NEQ)),
+        ),
+      )
+      .then(
         wasm
-          .if(i32.eq(local.get("$op"), i32.const(COMPARISON_OP_TAG.NEQ)))
-          .then(wasm.return(wasm.call(MAKE_BOOL_FX).args(i32.const(1)))),
+          .if(i32.ne(local.get("$x_tag"), local.get("$y_tag")))
+          .then(local.set("$eq_result", i32.const(0)))
+          .else(
+            wasm
+              .if(
+                i32.or(
+                  i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.LIST)),
+                  i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.TUPLE)),
+                ),
+              )
+              .then(
+                local.set(
+                  "$eq_result",
+                  wasm.call("$_list_struct_eq").args(local.get("$x_val"), local.get("$y_val")),
+                ),
+              )
+              .else(local.set("$eq_result", i64.eq(local.get("$x_val"), local.get("$y_val")))),
+          ),
+        wasm.return(
+          wasm
+            .call(MAKE_BOOL_FX)
+            .args(
+              wasm.select(
+                i32.eqz(local.get("$eq_result")),
+                local.get("$eq_result"),
+                i32.eq(local.get("$op"), i32.const(COMPARISON_OP_TAG.NEQ)),
+              ),
+            ),
+        ),
       ),
 
-    // other operators: unreachable
+    // other operators (ordering) on None/list/tuple/closure: unreachable
     wasm.call("$_log_error").args(i32.const(getErrorIndex(ERROR_MAP.COMPARE_OP_UNKNOWN_TYPE))),
     wasm.unreachable(),
+  );
+
+/**
+ * Structural equality for list/tuple `==`/`!=` (see COMPARISON_OP_FX's
+ * fallback above): same length, and every element pair recursively equal.
+ * Recurses through COMPARISON_OP_FX itself (called by name, not by direct
+ * reference -- this function is defined after it, and the two are mutually
+ * recursive: list elements can themselves be lists) so nested lists, and
+ * elements of every other type (string, numeric, complex, None, closures),
+ * get exactly the same comparison logic already implemented there, with no
+ * separate re-implementation to drift from it. Self-referential lists
+ * without shared identity exhaust the call stack, mirroring CPython's
+ * RecursionError on such comparisons (same as CSE's structuralEquals).
+ */
+export const LIST_STRUCT_EQ_FX = wasm
+  .func("$_list_struct_eq")
+  .params({ $x_val: i64, $y_val: i64 })
+  .results(i32)
+  .locals({
+    $len_x: i32,
+    $len_y: i32,
+    $i: i32,
+    $ex_tag: i32,
+    $ex_val: i64,
+    $ey_tag: i32,
+    $ey_val: i64,
+    $eq_tag: i32,
+    $eq_val: i64,
+  })
+  .body(
+    local.set("$len_x", i32.wrap_i64(local.get("$x_val"))),
+    local.set("$len_y", i32.wrap_i64(local.get("$y_val"))),
+    wasm
+      .if(i32.ne(local.get("$len_x"), local.get("$len_y")))
+      .then(wasm.return(i32.const(0))),
+
+    wasm.loop("$loop").body(
+      wasm
+        .if(i32.ge_s(local.get("$i"), local.get("$len_x")))
+        .then(wasm.return(i32.const(1))),
+
+      local.set(
+        "$ex_tag",
+        wasm.call(LIST_SLOT_TAG_LOAD_FX).args(local.get("$x_val"), local.get("$i")),
+      ),
+      local.set(
+        "$ex_val",
+        wasm.call(LIST_SLOT_VAL_LOAD_FX).args(local.get("$x_val"), local.get("$i")),
+      ),
+      local.set(
+        "$ey_tag",
+        wasm.call(LIST_SLOT_TAG_LOAD_FX).args(local.get("$y_val"), local.get("$i")),
+      ),
+      local.set(
+        "$ey_val",
+        wasm.call(LIST_SLOT_VAL_LOAD_FX).args(local.get("$y_val"), local.get("$i")),
+      ),
+
+      wasm
+        .call(COMPARISON_OP_FX)
+        .args(
+          local.get("$ex_tag"),
+          local.get("$ex_val"),
+          local.get("$ey_tag"),
+          local.get("$ey_val"),
+          i32.const(COMPARISON_OP_TAG.EQ),
+        ),
+      wasm.raw`(local.set $eq_val) (local.set $eq_tag)`,
+
+      wasm.if(i64.eqz(local.get("$eq_val"))).then(wasm.return(i32.const(0))),
+
+      local.set("$i", i32.add(local.get("$i"), i32.const(1))),
+      wasm.br("$loop"),
+    ),
+
+    // Every path through the loop above returns explicitly; this is
+    // structurally unreachable, but the function's declared (result i32)
+    // still needs *something* after a void-typed loop statement to satisfy
+    // validation (see NEG_FX/ARITHMETIC_OP_FX's identical trailing
+    // unreachable() for the same reason).
+    wasm.unreachable(),
+  );
+
+/**
+ * `not`'s sole operand, and `and`/`or`'s *left* operand specifically, must be
+ * an actual bool -- see docs/specs/python_typing_back.tex: `and`/`or`/`not`
+ * are all typed `bool, any -> any` / `bool -> bool` (only the right operand
+ * of `and`/`or` is `any`). Passes the (tag,val) pair through unchanged so
+ * callers can use this as a transparent wrapper around the operand
+ * expression, matching CSE's evaluateUnaryExpression / BOOL_OP instruction
+ * handler, which reject a non-bool operand here outright (not a truthiness
+ * shortcut like BOOLISE_FX, which is for contexts -- if/while conditions,
+ * and/or's *right* operand's short-circuit test -- that spec any x truthy).
+ */
+export const CHECK_BOOL_FX = wasm
+  .func("$_check_bool")
+  .params({ $tag: i32, $val: i64 })
+  .results(i32, i64)
+  .body(
+    wasm
+      .if(i32.ne(local.get("$tag"), i32.const(TYPE_TAG.BOOL)))
+      .then(
+        wasm.call("$_log_error").args(i32.const(getErrorIndex(ERROR_MAP.EXPECTED_BOOL_OPERAND))),
+        wasm.unreachable(),
+      ),
+    local.get("$tag"),
+    local.get("$val"),
   );
 
 export const BOOL_NOT_FX = wasm

--- a/src/tests/operator-conformance-wasm.test.ts
+++ b/src/tests/operator-conformance-wasm.test.ts
@@ -1,0 +1,237 @@
+/**
+ * WASM-engine parity sweep for operator-conformance.test.ts.
+ *
+ * Reuses that suite's spec tables/type universe (see operator-spec.ts; the
+ * human source of truth is still the four docs/specs/python_typing_*.tex
+ * fragments) and sweeps the same operator × type × type cross product,
+ * through compileToWasmAndRun (interactive mode) — the WASM compiler +
+ * runtime pathway PyWasmEvaluator1..4 use in the Conductor pathway. For each
+ * combination, the CSE machine's own result is computed fresh and used as
+ * the expected value — so this pins WASM against the *actual* reference
+ * implementation, not a second hand-written copy of it that could drift.
+ * Mirrors operator-conformance-pvml.test.ts's approach.
+ *
+ * Unlike PVML-in-browser's exec-mode-only compiler, compileToWasmAndRun's
+ * interactive mode (see engines/wasm/index.ts) evaluates the program's final
+ * expression directly and renders it via the runtime's own log_* host
+ * imports, without needing a print()-wrapping trick.
+ *
+ * Comparison is *value*-aware, not raw-text: the runtime's log_float host
+ * import renders whole-number floats via plain JS Number#toString (e.g.
+ * "2"), not toPythonFloat's Python-style "2.0" -- and log_complex renders
+ * "re + imj" instead of toPythonString's "(re+imj)". Both are display-format
+ * differences, not value differences, so float/complex results are compared
+ * numerically instead of as exact text (ints/bools/strings, which the
+ * runtime already renders in Python-compatible form, are still compared as
+ * exact text). See the two-run investigation in this file's originating
+ * conversation for the concrete "2" vs "2.0" / "1 + 2j" vs "(1+2j)" cases.
+ *
+ * The WASM engine's group set per chapter mirrors PyWasmEvaluator1..4 (see
+ * conductor/PyWasmEvaluator.ts) rather than runner.ts's VARIANT_GROUPS: WASM
+ * doesn't yet wire up the `math`/`stream` stdlib groups the CSE/PVML
+ * pathways get from VARIANT_GROUPS, so using that table here would ask the
+ * WASM compiler to load preludes it doesn't support. `misc` is added
+ * automatically by compileToWasmAndRun itself and must not be duplicated
+ * here.
+ *
+ * compileToWasmAndRun's interactive-mode main() call isn't wrapped in
+ * try/catch (see engines/wasm/index.ts) -- a runtime trap (e.g. an
+ * operand-type error) rejects the returned promise instead of populating
+ * `errors`, unlike the non-interactive path. wasmOutcome() below catches
+ * that directly, the same way pvmlOutcome() catches RunError.
+ */
+import { StmtNS } from "../ast-types";
+import { Context } from "../engines/cse/context";
+import { evaluate } from "../engines/cse/interpreter";
+import { Stash, Value } from "../engines/cse/stash";
+import { compileToWasmAndRun } from "../engines/wasm";
+import { parse } from "../parser/parser-adapter";
+import { Resolver } from "../resolver";
+import linkedList from "../stdlib/linked-list";
+import list from "../stdlib/list";
+import pairmutator from "../stdlib/pairmutator";
+import parserGroup from "../stdlib/parser";
+import { Group, toPythonString } from "../stdlib/utils";
+import { PyComplexNumber } from "../types/value-types";
+import { makeValidatorsForChapter } from "../validator";
+import { BINARY_OPS_12, BINARY_OPS_34, literalFor, universeForChapter } from "./operator-spec";
+import { generateMockStreams } from "./utils";
+
+/** Mirrors PyWasmEvaluator1..4's own per-chapter group list, not VARIANT_GROUPS (see file header). */
+const WASM_GROUPS_BY_CHAPTER: Record<number, Group[]> = {
+  1: [],
+  2: [linkedList],
+  3: [linkedList, pairmutator, list],
+  4: [linkedList, pairmutator, list, parserGroup],
+};
+
+type CseOutcome =
+  | { kind: "value"; type: Value["type"]; text: string; value: unknown }
+  | { kind: "error" };
+
+/**
+ * Evaluates `code` through the CSE machine to get the reference outcome —
+ * a trimmed copy of operator-conformance-pvml.test.ts's own cseOutcome that
+ * additionally keeps the popped Value's raw `type`/`value` (not just its
+ * formatted text), so expectMatch() below can decide how to compare the
+ * WASM side per-type instead of always doing an exact text comparison.
+ */
+async function cseOutcome(code: string, chapter: number, groups: Group[]): Promise<CseOutcome> {
+  const script = code + "\n";
+  let ast: StmtNS.Stmt;
+  try {
+    ast = parse(script);
+    const resolver = new Resolver(script, ast, makeValidatorsForChapter(chapter), groups, []);
+    if (resolver.resolve(ast).length > 0) {
+      return { kind: "error" };
+    }
+  } catch {
+    return { kind: "error" };
+  }
+
+  const context = new Context();
+  generateMockStreams(context, []);
+  for (const group of groups) {
+    for (const [name, value] of group.builtins) {
+      context.nativeStorage.builtins.set(name, value);
+    }
+  }
+  const spy = jest.spyOn(Stash.prototype, "pop");
+  let lastPopped: Value | undefined;
+  try {
+    await evaluate(code, ast, context, { variant: chapter });
+    lastPopped = spy.mock.results.at(-1)?.value as Value | undefined;
+  } finally {
+    spy.mockRestore();
+  }
+  if (context.errors.length > 0 || lastPopped === undefined) {
+    return { kind: "error" };
+  }
+  return {
+    kind: "value",
+    type: lastPopped.type,
+    text: toPythonString(lastPopped),
+    value: "value" in lastPopped ? lastPopped.value : undefined,
+  };
+}
+
+type WasmOutcome = { kind: "value"; text: string } | { kind: "error" };
+
+/**
+ * Evaluates `code` through compileToWasmAndRun in interactive mode, whose
+ * renderedResult is the last expression's value already rendered by the
+ * runtime's own log_* host imports — no print()-wrapping needed, unlike
+ * PVML-in-browser's exec-mode-only compiler.
+ */
+async function wasmOutcome(code: string, chapter: number, groups: Group[]): Promise<WasmOutcome> {
+  try {
+    const result = await compileToWasmAndRun(code, true, { chapter, groups });
+    if (result.errors.length > 0) return { kind: "error" };
+    return { kind: "value", text: result.renderedResult };
+  } catch {
+    return { kind: "error" };
+  }
+}
+
+/**
+ * Parses the runtime's log_complex format ("{imag}j" when the real part is
+ * zero, else "{real} {+|-} {|imag|}j" — see hostImports.ts) back into a
+ * PyComplexNumber, so a complex result can be compared numerically against
+ * the CSE reference instead of as exact text (see file header).
+ */
+function parseWasmComplex(text: string): PyComplexNumber {
+  const pureImag = text.match(/^(-?[\d.]+(?:e[+-]?\d+)?)j$/);
+  if (pureImag) return new PyComplexNumber(0, Number(pureImag[1]));
+
+  const signed = text.match(/^(-?[\d.]+(?:e[+-]?\d+)?) ([+-]) ([\d.]+(?:e[+-]?\d+)?)j$/);
+  if (!signed) throw new Error(`Cannot parse WASM complex output: ${JSON.stringify(text)}`);
+  const real = Number(signed[1]);
+  const imag = Number(signed[3]) * (signed[2] === "-" ? -1 : 1);
+  return new PyComplexNumber(real, imag);
+}
+
+function expectMatch(wanted: CseOutcome, actual: WasmOutcome): void {
+  if (wanted.kind === "error") {
+    expect(actual.kind).toBe("error");
+    return;
+  }
+  expect(actual.kind).toBe("value");
+  if (actual.kind !== "value") return;
+
+  if (wanted.type === "number") {
+    // Ignores the runtime's missing toPythonFloat-style ".0" suffix on
+    // whole-number floats -- see file header.
+    expect(Number(actual.text)).toBe(wanted.value as number);
+  } else if (wanted.type === "complex") {
+    const expected = wanted.value as PyComplexNumber;
+    const parsed = parseWasmComplex(actual.text);
+    expect(parsed.real).toBeCloseTo(expected.real);
+    expect(parsed.imag).toBeCloseTo(expected.imag);
+  } else {
+    expect(actual.text).toBe(wanted.text);
+  }
+}
+
+for (const chapter of [1, 2, 3, 4]) {
+  describe(`[wasm] Operator conformance at Python §${chapter}`, () => {
+    const ops = chapter <= 2 ? BINARY_OPS_12 : BINARY_OPS_34;
+    const universe = universeForChapter(chapter);
+    const groups = WASM_GROUPS_BY_CHAPTER[chapter];
+
+    for (const op of ops) {
+      describe(op, () => {
+        for (const left of universe) {
+          for (const right of universe) {
+            const code = `${literalFor(left, chapter)} ${op} ${literalFor(right, chapter)}`;
+            test(code, async () => {
+              const wanted = await cseOutcome(code, chapter, groups);
+              const actual = await wasmOutcome(code, chapter, groups);
+              expectMatch(wanted, actual);
+            });
+          }
+        }
+      });
+    }
+
+    describe("unary -", () => {
+      for (const operand of universe) {
+        const code = `-${literalFor(operand, chapter)}`;
+        test(code, async () => {
+          const wanted = await cseOutcome(code, chapter, groups);
+          const actual = await wasmOutcome(code, chapter, groups);
+          expectMatch(wanted, actual);
+        });
+      }
+    });
+
+    // `and`/`or` result in "any" (one of the operands), and `not` only ever
+    // produces bool -- the sweeps above already pin the operand-type
+    // restrictions for these via CSE parity; only success-vs-error is
+    // checked here, as in the CSE/PVML/native-Pynter versions of this suite.
+    describe("not", () => {
+      for (const operand of universe) {
+        const code = `not ${literalFor(operand, chapter)}`;
+        test(code, async () => {
+          const wanted = await cseOutcome(code, chapter, groups);
+          const actual = await wasmOutcome(code, chapter, groups);
+          expect(actual.kind).toBe(wanted.kind);
+        });
+      }
+    });
+
+    for (const op of ["and", "or"]) {
+      describe(op, () => {
+        for (const left of universe) {
+          for (const right of universe) {
+            const code = `${literalFor(left, chapter)} ${op} ${literalFor(right, chapter)}`;
+            test(code, async () => {
+              const wanted = await cseOutcome(code, chapter, groups);
+              const actual = await wasmOutcome(code, chapter, groups);
+              expect(actual.kind).toBe(wanted.kind);
+            });
+          }
+        }
+      });
+    }
+  });
+}

--- a/src/tests/wasm/wasm-operators.spec.ts
+++ b/src/tests/wasm/wasm-operators.spec.ts
@@ -2,15 +2,16 @@ import { compileToWasmAndRun } from "../../engines/wasm";
 import { ERROR_MAP, TYPE_TAG } from "../../engines/wasm/runtime";
 import linkedList from "../../stdlib/linked-list";
 
+// Basic single-op arithmetic/comparison cases for every type combination are
+// covered far more rigorously by operator-conformance-wasm.test.ts's
+// spec-table sweep (all four chapters, cross-checked against a live CSE
+// reference instead of hand-typed expected values -- it's what caught the
+// complex-division and GEN_LIST_FX bugs this suite's own hand-picked cases
+// missed). What's left here is coverage that sweep can't provide by
+// construction: parser precedence (a compound expression, not a single binary
+// op), literal-rendering edge cases the sweep's fixed representative literals
+// never hit, and UTF-8/multibyte string handling.
 describe("Arithmetic operator tests (int, float, complex, string)", () => {
-  // --- INT ARITHMETIC ---
-  it("int addition", async () => {
-    const pythonCode = `1 + 2`;
-    const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
-    expect(rawResult[0]).toBe(TYPE_TAG.INT);
-    expect(renderedResult).toBe("3");
-  });
-
   it("mixed int arithmetic with precedence", async () => {
     const pythonCode = `2 + 3 * 4 - 5`;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
@@ -18,63 +19,7 @@ describe("Arithmetic operator tests (int, float, complex, string)", () => {
     expect(renderedResult).toBe("9");
   });
 
-  it("int division (floor div semantics unsupported -> float?)", async () => {
-    const pythonCode = `5 / 2`;
-    const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
-    expect(rawResult[0]).toBe(TYPE_TAG.FLOAT);
-    expect(renderedResult).toBe("2.5");
-  });
-
-  // --- FLOAT ARITHMETIC ---
-  it("float addition", async () => {
-    const pythonCode = `1.5 + 2.25`;
-    const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
-    expect(rawResult[0]).toBe(TYPE_TAG.FLOAT);
-    expect(renderedResult).toBe("3.75");
-  });
-
-  it("mixed int + float -> float", async () => {
-    const pythonCode = `3 + 2.5`;
-    const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
-    expect(rawResult[0]).toBe(TYPE_TAG.FLOAT);
-    expect(renderedResult).toBe("5.5");
-  });
-
-  it("float multiplication", async () => {
-    const pythonCode = `1.2 * 3.4`;
-    const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
-    expect(rawResult[0]).toBe(TYPE_TAG.FLOAT);
-    expect(renderedResult).toBe("4.08");
-  });
-
-  // --- COMPLEX ARITHMETIC ---
-  it("complex addition", async () => {
-    const pythonCode = `
-(1+2j) + (3+4j)
-`;
-    const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
-    expect(rawResult[0]).toBe(TYPE_TAG.COMPLEX);
-    expect(renderedResult).toBe("4 + 6j");
-  });
-
-  it("complex multiplication", async () => {
-    const pythonCode = `
-(2+3j) * (4+5j)
-`;
-    const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
-    expect(rawResult[0]).toBe(TYPE_TAG.COMPLEX);
-    expect(renderedResult).toBe("-7 + 22j");
-  });
-
-  it("complex with real (int) -> complex", async () => {
-    const pythonCode = `
-(1+2j) + 10
-`;
-    const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
-    expect(rawResult[0]).toBe(TYPE_TAG.COMPLEX);
-    expect(renderedResult).toBe("11 + 2j");
-  });
-
+  // --- COMPLEX LITERAL RENDERING ---
   it("pure imaginary output omits leading zero real part", async () => {
     const pythonCode = `2j`;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
@@ -89,14 +34,7 @@ describe("Arithmetic operator tests (int, float, complex, string)", () => {
     expect(renderedResult).toBe("1 - 2j");
   });
 
-  // --- STRING ARITHMETIC ---
-  it("string concatenation with +", async () => {
-    const pythonCode = `"hello" + " world"`;
-    const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
-    expect(rawResult[0]).toBe(TYPE_TAG.STRING);
-    expect(renderedResult).toBe("hello world");
-  });
-
+  // --- STRING: UTF-8 ---
   it("string literal with multibyte UTF-8 characters", async () => {
     const pythonCode = `"😀"`;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
@@ -110,80 +48,33 @@ describe("Arithmetic operator tests (int, float, complex, string)", () => {
     expect(rawResult[0]).toBe(TYPE_TAG.STRING);
     expect(renderedResult).toBe("😀é");
   });
+});
 
-  it("string + int should error (type mismatch)", async () => {
-    const pythonCode = `"a" + 1`;
-    await expect(compileToWasmAndRun(pythonCode, true)).rejects.toThrow(
-      new Error(ERROR_MAP.ARITH_OP_UNKNOWN_TYPE),
+// Precise error *messages* (not just success-vs-error, which the sweep
+// already checks across the full type matrix) for a couple of named failure
+// paths worth pinning down explicitly.
+describe("Named error messages", () => {
+  it("complex ordering comparisons report COMPLEX_COMPARISON", async () => {
+    await expect(compileToWasmAndRun(`(1+1j) < (2+2j)`, true)).rejects.toThrow(
+      new Error(ERROR_MAP.COMPLEX_COMPARISON),
     );
   });
 
-  it("unary minus on string should error", async () => {
-    const pythonCode = `-"a"`;
-    await expect(compileToWasmAndRun(pythonCode, true)).rejects.toThrow(
-      new Error(ERROR_MAP.NEG_NOT_SUPPORT),
+  it("string ordering against a non-string reports COMPARE_OP_UNKNOWN_TYPE", async () => {
+    await expect(compileToWasmAndRun(`"x" < 3`, true)).rejects.toThrow(
+      new Error(ERROR_MAP.COMPARE_OP_UNKNOWN_TYPE),
     );
   });
 });
 
-describe("Comparison operator tests (int, float, complex, string)", () => {
-  const expectComparisonToBe = async (pythonCode: string, expected: "True" | "False") => {
-    const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
-    expect(rawResult[0]).toBe(TYPE_TAG.BOOL);
-    expect(renderedResult).toBe(expected);
-  };
-
-  const expectComparisonToError = async (pythonCode: string, errorMessage: string) => {
-    await expect(compileToWasmAndRun(pythonCode, true)).rejects.toThrow(new Error(errorMessage));
-  };
-
-  // --- INT COMPARE ---
-  it("int ==", async () => expectComparisonToBe(`3 == 3`, "True"));
-  it("int !=", async () => expectComparisonToBe(`3 != 4`, "True"));
-  it("int <", async () => expectComparisonToBe(`5 < 1`, "False"));
-  it("int <=", async () => expectComparisonToBe(`5 <= 5`, "True"));
-  it("int >", async () => expectComparisonToBe(`7 > 2`, "True"));
-  it("int >=", async () => expectComparisonToBe(`2 >= 9`, "False"));
-
-  // --- FLOAT/INT MIXED COMPARE ---
-  it("float/int ==", async () => expectComparisonToBe(`1.5 == 1.5`, "True"));
-  it("float/int !=", async () => expectComparisonToBe(`1.5 != 2`, "True"));
-  it("float/int <", async () => expectComparisonToBe(`1.5 < 2`, "True"));
-  it("float/int <=", async () => expectComparisonToBe(`2.0 <= 2`, "True"));
-  it("float/int >", async () => expectComparisonToBe(`3.25 > 3`, "True"));
-  it("float/int >=", async () => expectComparisonToBe(`3.0 >= 4`, "False"));
-
-  // --- COMPLEX COMPARE ---
-  it("complex ==", async () => expectComparisonToBe(`(1+2j) == (1+2j)`, "True"));
-  it("complex !=", async () => expectComparisonToBe(`(1+2j) != (2+1j)`, "True"));
-
-  it("complex < must error", async () =>
-    expectComparisonToError(`(1+1j) < (2+2j)`, ERROR_MAP.COMPLEX_COMPARISON));
-  it("complex <= must error", async () =>
-    expectComparisonToError(`(1+1j) <= (2+2j)`, ERROR_MAP.COMPLEX_COMPARISON));
-  it("complex > must error", async () =>
-    expectComparisonToError(`(1+1j) > (2+2j)`, ERROR_MAP.COMPLEX_COMPARISON));
-  it("complex >= must error", async () =>
-    expectComparisonToError(`(1+1j) >= (2+2j)`, ERROR_MAP.COMPLEX_COMPARISON));
-
-  // --- STRING COMPARE ---
-  it("string ==", async () => expectComparisonToBe(`"abc" == "abc"`, "True"));
-  it("string !=", async () => expectComparisonToBe(`"abc" != "abd"`, "True"));
-  it("string <", async () => expectComparisonToBe(`"apple" < "banana"`, "True"));
-  it("string <=", async () => expectComparisonToBe(`"apple" <= "apple"`, "True"));
-  it("string >", async () => expectComparisonToBe(`"pear" > "orange"`, "True"));
-  it("string >=", async () => expectComparisonToBe(`"pear" >= "zebra"`, "False"));
-
-  it("string < non-string must error", async () =>
-    expectComparisonToError(`"x" < 3`, ERROR_MAP.COMPARE_OP_UNKNOWN_TYPE));
-  it("string <= non-string must error", async () =>
-    expectComparisonToError(`"x" <= 3`, ERROR_MAP.COMPARE_OP_UNKNOWN_TYPE));
-  it("string > non-string must error", async () =>
-    expectComparisonToError(`"x" > 3`, ERROR_MAP.COMPARE_OP_UNKNOWN_TYPE));
-  it("string >= non-string must error", async () =>
-    expectComparisonToError(`"x" >= 3`, ERROR_MAP.COMPARE_OP_UNKNOWN_TYPE));
-});
-
+// `and`/`or`'s *left* operand, and `not`'s sole operand, must be an actual
+// bool -- see docs/specs/python_typing_back.tex: `and`/`or` are typed
+// `bool, any -> any` (only the *right* operand of `and`/`or` is `any`), and
+// `not` is `bool -> bool`. Unlike real Python (where any value's truthiness
+// is valid here), this SICPy dialect deliberately restricts these three
+// operators' bool-typed operand to an actual bool -- see CSE's
+// evaluateUnaryExpression / BOOL_OP instruction handler, which reject e.g.
+// `not 5` and `5 and 3` outright.
 describe("Boolean tests", () => {
   // --- NOT OPERATOR ---
   it("not True", async () => {
@@ -193,60 +84,59 @@ describe("Boolean tests", () => {
     expect(renderedResult).toBe("False");
   });
 
-  it("not 0", async () => {
-    const pythonCode = `not 0`;
+  it("not False", async () => {
+    const pythonCode = `not False`;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
     expect(rawResult[0]).toBe(TYPE_TAG.BOOL);
     expect(renderedResult).toBe("True");
   });
 
-  it("not nonzero", async () => {
-    const pythonCode = `not 5`;
+  it("not on a non-bool operand errors", async () => {
+    await expect(compileToWasmAndRun(`not 5`, true)).rejects.toThrow(
+      new Error(ERROR_MAP.EXPECTED_BOOL_OPERAND),
+    );
+  });
+
+  // --- AND ---
+  it("False and 5 -> False (short-circuits on the falsy left operand)", async () => {
+    const pythonCode = `False and 5`;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
     expect(rawResult[0]).toBe(TYPE_TAG.BOOL);
     expect(renderedResult).toBe("False");
   });
 
-  // --- AND ---
-  it("0 and 5 -> 0 (first falsy)", async () => {
-    const pythonCode = `0 and 5`;
+  it("True and 0 -> 0", async () => {
+    const pythonCode = `True and 0`;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
     expect(rawResult[0]).toBe(TYPE_TAG.INT);
     expect(renderedResult).toBe("0");
   });
 
-  it("5 and 0 -> 0", async () => {
-    const pythonCode = `5 and 0`;
-    const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
-    expect(rawResult[0]).toBe(TYPE_TAG.INT);
-    expect(renderedResult).toBe("0");
-  });
-
-  it("5 and 3 -> 3 (last truthy)", async () => {
-    const pythonCode = `5 and 3`;
+  it("True and 3 -> 3", async () => {
+    const pythonCode = `True and 3`;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
     expect(rawResult[0]).toBe(TYPE_TAG.INT);
     expect(renderedResult).toBe("3");
   });
 
-  it("'hello' and 10 -> 10", async () => {
-    const pythonCode = `"hello" and 10`;
+  it("True and 'hello' -> 'hello'", async () => {
+    const pythonCode = `True and "hello"`;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
-    expect(rawResult[0]).toBe(TYPE_TAG.INT);
-    expect(renderedResult).toBe("10");
+    expect(rawResult[0]).toBe(TYPE_TAG.STRING);
+    expect(renderedResult).toBe("hello");
   });
 
-  it("'hello' and '' -> ''", async () => {
-    const pythonCode = `"hello" and ""`;
+  it("True and '' -> ''", async () => {
+    const pythonCode = `True and ""`;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
     expect(rawResult[0]).toBe(TYPE_TAG.STRING);
     expect(renderedResult).toBe("");
   });
 
-  it("pair and None -> None", async () => {
+  it("True and None -> None", async () => {
     const pythonCode = `
 p = pair(1,2)
-p and None
+True and None
 `;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true, {
       groups: [linkedList],
@@ -255,35 +145,47 @@ p and None
     expect(renderedResult).toBe("None");
   });
 
+  it("and with a non-bool left operand errors", async () => {
+    await expect(compileToWasmAndRun(`5 and 3`, true)).rejects.toThrow(
+      new Error(ERROR_MAP.EXPECTED_BOOL_OPERAND),
+    );
+  });
+
   // --- OR ---
-  it("0 or 5 -> 5 (first truthy)", async () => {
-    const pythonCode = `0 or 5`;
+  it("False or 5 -> 5", async () => {
+    const pythonCode = `False or 5`;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
     expect(rawResult[0]).toBe(TYPE_TAG.INT);
     expect(renderedResult).toBe("5");
   });
 
-  it("'' or 'abc' -> 'abc'", async () => {
-    const pythonCode = `"" or "abc"`;
+  it("False or 'abc' -> 'abc'", async () => {
+    const pythonCode = `False or "abc"`;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
     expect(rawResult[0]).toBe(TYPE_TAG.STRING);
     expect(renderedResult).toBe("abc");
   });
 
-  it("'x' or 100 -> 'x'", async () => {
-    const pythonCode = `"x" or 100`;
+  it("True or 100 -> True (short-circuits on the truthy left operand)", async () => {
+    const pythonCode = `True or 100`;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
-    expect(rawResult[0]).toBe(TYPE_TAG.STRING);
-    expect(renderedResult).toBe("x");
+    expect(rawResult[0]).toBe(TYPE_TAG.BOOL);
+    expect(renderedResult).toBe("True");
   });
 
-  it("None or pair(1,2) -> pair", async () => {
-    const pythonCode = `None or pair(1,2)`;
+  it("False or pair(1,2) -> pair", async () => {
+    const pythonCode = `False or pair(1,2)`;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true, {
       groups: [linkedList],
     });
     expect(rawResult[0]).not.toBe(TYPE_TAG.NONE);
     expect(renderedResult).toBe("[1, 2]");
+  });
+
+  it("or with a non-bool left operand errors", async () => {
+    await expect(compileToWasmAndRun(`5 or 3`, true)).rejects.toThrow(
+      new Error(ERROR_MAP.EXPECTED_BOOL_OPERAND),
+    );
   });
 
   // --- SHORT CIRCUITING ---
@@ -292,12 +194,12 @@ p and None
 x = 0
 def boom():
     x = x + 1  # would error if executed
-0 and boom()
+False and boom()
 `;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
-    // must return 0 (falsy) without calling boom()
-    expect(rawResult[0]).toBe(TYPE_TAG.INT);
-    expect(renderedResult).toBe("0");
+    // must return False without calling boom()
+    expect(rawResult[0]).toBe(TYPE_TAG.BOOL);
+    expect(renderedResult).toBe("False");
   });
 
   it("or short-circuits (second expr not evaluated)", async () => {
@@ -305,10 +207,11 @@ def boom():
 x = 0
 def boom():
     x = x + 1  # would error if executed
-1 or boom()
+True or boom()
 `;
     const { rawResult, renderedResult } = await compileToWasmAndRun(pythonCode, true);
-    expect(rawResult[0]).toBe(TYPE_TAG.INT);
-    expect(renderedResult).toBe("1");
+    // must return True without calling boom()
+    expect(rawResult[0]).toBe(TYPE_TAG.BOOL);
+    expect(renderedResult).toBe("True");
   });
 });


### PR DESCRIPTION
## Summary

- Adds `operator-conformance-wasm.test.ts`, mirroring `operator-conformance-pvml.test.ts`: sweeps the same spec-table-driven type × operator cross product (`docs/specs/python_typing_*.tex`) through `compileToWasmAndRun`, chapters 1–4, validated against a live CSE reference. Comparison is value-aware (not raw-text), since the runtime's `log_float`/`log_complex` host imports render differently from `toPythonString` (e.g. `"2"` vs `"2.0"`, `"1 + 2j"` vs `"(1+2j)"`) without being wrong.
- The sweep surfaced real gaps in the WASM engine, all fixed here:
  - **Complex division was silently wrong** — `DIV_FX` reused the already-divided real part as the imaginary part's divisor instead of the true `c²+d²` denominator (e.g. `2 / (1+2j)` gave `0.4 - 10j` instead of `0.4 - 0.8j`).
  - **`**`, `//`, `%` were entirely unimplemented** (compile-time "Unsupported binary operator"). Added them via a new `arith.ext` host import that reuses CSE's own `pythonMod`/`PyComplexNumber.pow`, guaranteeing bit-for-bit parity instead of a second, independently-derived implementation (floor-division needs Python's floor-toward-−∞ semantics; `**` needs arbitrary-precision bigint exponentiation and general complex power via log/exp/atan2/cos/sin, none of which are native WASM instructions).
  - **`is`/`is not` were entirely unimplemented.** Added an identity check mirroring CSE's `pyIdentical`: value-based for scalars (no bool/int coercion, unlike `==`), pointer-based for lists/tuples, None always identical to None. Closures compare by their packed representation — a known, documented approximation of per-object identity (no distinct heap-allocated closure object to compare by pointer).
  - **`bool` wasn't chapter-gated out of arithmetic/ordering/equality** where the spec restricts it. Added a `$_chapter` global (compiled in from `CompileOptions.chapter`) so the runtime can enforce this, matching CSE's `variant`-gated checks.
  - **`and`/`or`/`not` accepted any type** where `docs/specs/python_typing_back.tex` requires an actual `bool` (`bool, any -> any` / `bool -> bool`).
  - **`==` on list/tuple/None/closure always returned a hardcoded `False`/`True`** instead of comparing at all (e.g. `[1,2] == [1,2]` was `False`). Added recursive structural list/tuple comparison (reusing `COMPARISON_OP_FX` itself for elements) and a same-tag raw-value fallback for None/closures.
- Trims `wasm-operators.spec.ts`'s now-redundant directed cases (basic single-op arithmetic/comparisons across types — now covered far more rigorously by the sweep) down to what the sweep structurally can't provide: parser precedence, complex-literal rendering edge cases, UTF-8/multibyte string handling, exact `and`/`or` value + short-circuit semantics, and a couple of precise error-message checks.

## Test plan

- [x] `operator-conformance-wasm.test.ts`: 3933/3933 passing across chapters 1–4
- [x] Full existing WASM suite (`src/tests/wasm/`): 326/326 passing
- [x] Full repo suite: 13701 passed, 2493 skipped, 0 failed
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (no new errors/warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9vbzJtbfjHCY4CKxbzK7o