### PR TITLE
Fix #284: compute complex magnitudes with Math.hypot

### DIFF
--- a/src/engines/pvml/builtins.ts
+++ b/src/engines/pvml/builtins.ts
@@ -930,7 +930,8 @@ export function executePrimitive(
       const [x] = args;
       if (typeof x === "bigint") return x < 0n ? -x : x;
       if (typeof x === "number") return Math.abs(x);
-      if (x instanceof PyComplexNumber) return Math.sqrt(x.real * x.real + x.imag * x.imag);
+      // Math.hypot survives components whose squares overflow/underflow (see #284).
+      if (x instanceof PyComplexNumber) return Math.hypot(x.real, x.imag);
       throw new PVMLInterpreterError(
         `TypeError: unsupported argument type for abs: ${friendlyTypeName(getPVMLType(x), variant)}`,
       );

--- a/src/stdlib/misc.ts
+++ b/src/stdlib/misc.ts
@@ -114,10 +114,11 @@ export class MiscBuiltins {
         return { type: "number", value: Math.abs(x.value) };
       }
       case "complex": {
-        // Calculate the modulus (absolute value) of a complex number.
-        const real = x.value.real;
-        const imag = x.value.imag;
-        const modulus = Math.sqrt(real * real + imag * imag);
+        // The modulus (absolute value) of a complex number. Math.hypot
+        // scales internally, so components whose squares overflow/underflow
+        // still produce the right modulus (abs(complex(1e200, 0)) is 1e200,
+        // not inf) — the same algorithm CPython's abs(complex) uses. See #284.
+        const modulus = Math.hypot(x.value.real, x.value.imag);
         return { type: "number", value: modulus };
       }
       default:

--- a/src/tests/complex-magnitude.test.ts
+++ b/src/tests/complex-magnitude.test.ts
@@ -1,0 +1,36 @@
+/**
+ * #284: complex magnitudes must be computed with Math.hypot, which scales
+ * internally — sqrt(re² + im²) overflows to inf (or underflows to 0) when a
+ * component's square leaves the float range even though the true modulus is
+ * representable. CPython uses hypot for abs(complex) too.
+ *
+ * Covers the three sites the issue lists: the CSE machine's abs
+ * (stdlib/misc.ts), the PVML interpreter's abs (engines/pvml/builtins.ts),
+ * and PyComplexNumber.pow's magnitude (types/value-types.ts, shared by every
+ * engine).
+ */
+import { runCodePvmlInterpreter } from "../pvml-runner";
+import { runCode } from "../runner";
+import { PyComplexNumber } from "../types";
+
+const ABS_EXTREME = `print(abs(complex(1e200, 0)))`;
+
+test("CSE abs(complex) survives components whose squares overflow", async () => {
+  expect(await runCode(ABS_EXTREME, 1)).toBe("1e+200\n");
+});
+
+test("PVML abs(complex) survives components whose squares overflow", async () => {
+  expect(await runCodePvmlInterpreter(ABS_EXTREME, 1)).toBe("1e+200\n");
+});
+
+test("PyComplexNumber.pow magnitude survives components whose squares overflow", () => {
+  // (1e200+0j) ** 0.5 = 1e100 — representable, but the old sqrt-of-squares
+  // magnitude overflowed to inf on the way there.
+  const result = new PyComplexNumber(1e200, 0).pow(new PyComplexNumber(0.5, 0));
+  expect(result.real / 1e100).toBeCloseTo(1, 10);
+  expect(result.imag).toBe(0);
+});
+
+test("abs(complex) of an ordinary value is unchanged", async () => {
+  expect(await runCode(`print(abs(complex(3, 4)))`, 1)).toBe("5.0\n");
+});

--- a/src/types/value-types.ts
+++ b/src/types/value-types.ts
@@ -181,7 +181,8 @@ export class PyComplexNumber {
     const A = other.real;
     const B = other.imag;
 
-    const r = Math.sqrt(a * a + b * b);
+    // Math.hypot survives components whose squares overflow/underflow (see #284).
+    const r = Math.hypot(a, b);
     const theta = Math.atan2(b, a);
 
     if (r === 0) {


### PR DESCRIPTION
## Summary

`sqrt(re² + im²)` overflows to `inf` (or underflows to `0`) when a component's square leaves the float range, even though the true modulus is representable — `abs(complex(1e200, 0))` came out as `inf` instead of `1e+200`. `Math.hypot` scales internally and is what CPython's `abs(complex)` uses.

Fixes the three sites #284 lists:
- `src/stdlib/misc.ts` — the CSE machine's `abs`, complex case
- `src/engines/pvml/builtins.ts` — the PVML interpreter's `abs`, complex case
- `src/types/value-types.ts` — `PyComplexNumber.pow`'s magnitude, shared by every engine

This also restores cross-engine agreement with py2js (#282), whose `abs` already switched to hypot in Gemini review.

Fixes #284

## Test plan

- `src/tests/complex-magnitude.test.ts` (new): CSE and PVML `abs(complex(1e200, 0))` → `1e+200`; `(1e200+0j) ** 0.5` → `1e100` through `PyComplexNumber.pow`; an ordinary `abs(complex(3, 4))` → `5.0` regression check
- `yarn jest src/tests/stdlib.test.ts src/tests/pvml-interpreter.test.ts` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbExZBaxgeUL4oi1t7PG93