### PR TITLE
Fix complex magnitude overflow with Math.hypot

### DIFF
--- a/src/engines/pvml/builtins.ts
+++ b/src/engines/pvml/builtins.ts
@@ -930,7 +930,7 @@ export function executePrimitive(
       const [x] = args;
       if (typeof x === "bigint") return x < 0n ? -x : x;
       if (typeof x === "number") return Math.abs(x);
-      if (x instanceof PyComplexNumber) return Math.sqrt(x.real * x.real + x.imag * x.imag);
+      if (x instanceof PyComplexNumber) return Math.hypot(x.real, x.imag);
       throw new PVMLInterpreterError(
         `TypeError: unsupported argument type for abs: ${friendlyTypeName(getPVMLType(x), variant)}`,
       );

--- a/src/stdlib/misc.ts
+++ b/src/stdlib/misc.ts
@@ -117,7 +117,7 @@ export class MiscBuiltins {
         // Calculate the modulus (absolute value) of a complex number.
         const real = x.value.real;
         const imag = x.value.imag;
-        const modulus = Math.sqrt(real * real + imag * imag);
+        const modulus = Math.hypot(real, imag);
         return { type: "number", value: modulus };
       }
       default:

--- a/src/tests/pvml.test.ts
+++ b/src/tests/pvml.test.ts
@@ -605,6 +605,7 @@ describe("PVML E2E", () => {
     ],
     "abs() is the modulus": [
       ["abs(3+4j)", asFloat(5), null],
+      ["abs(1e200+0j)", asFloat(1e200), null],
       ["is_float(abs(3+4j))", true, null],
     ],
     "real() / imag() / complex() constructor": [

--- a/src/tests/stdlib.test.ts
+++ b/src/tests/stdlib.test.ts
@@ -33,6 +33,7 @@ describe("Standard Library Tests", () => {
         ["abs(0)", 0n, null],
         ["abs(-2147483648)", 2147483648n, null],
         ["abs(2147483647)", 2147483647n, null],
+        ["abs(1e200+0j)", 1e200, null],
         ['abs("")', TypeError, null],
         ["abs(True)", TypeError, null],
       ],

--- a/src/tests/value-types.test.ts
+++ b/src/tests/value-types.test.ts
@@ -1,0 +1,14 @@
+import { PyComplexNumber } from "../types/value-types";
+
+describe("PyComplexNumber", () => {
+  test("pow keeps a representable result when a component's square overflows", () => {
+    const result = new PyComplexNumber(1e200, 0).pow(new PyComplexNumber(0.5, 0));
+
+    // Before the Math.hypot fix, r = sqrt(1e200**2) overflowed to Infinity and
+    // the whole result degraded to (Infinity, NaN). The exp/log path still has
+    // its usual relative rounding (as in CPython), so compare relatively.
+    expect(Number.isFinite(result.real)).toBe(true);
+    expect(result.real / 1e100).toBeCloseTo(1, 10);
+    expect(result.imag).toBe(0);
+  });
+});

--- a/src/types/value-types.ts
+++ b/src/types/value-types.ts
@@ -181,7 +181,7 @@ export class PyComplexNumber {
     const A = other.real;
     const B = other.imag;
 
-    const r = Math.sqrt(a * a + b * b);
+    const r = Math.hypot(a, b);
     const theta = Math.atan2(b, a);
 
     if (r === 0) {


### PR DESCRIPTION
## Summary

- use `Math.hypot(real, imag)` for complex magnitudes in the CSE and PVML `abs` implementations
- use the same overflow-safe magnitude calculation in `PyComplexNumber.pow`
- add regression coverage for large representable complex magnitudes and powers

## Why

The previous `Math.sqrt(real * real + imag * imag)` calculation overflowed when either squared component exceeded the floating-point range. For example, `abs(1e200+0j)` became `Infinity` even though `1e200` is representable. `Math.hypot` scales its inputs internally, matching CPython and the existing stepper implementation.

Fixes #284.

## Validation

- `yarn jest src/tests/value-types.test.ts src/tests/stdlib.test.ts src/tests/pvml.test.ts --runInBand` — 3 suites passed; 2,482 tests passed (1,333 skipped)
- `yarn eslint src/stdlib/misc.ts src/engines/pvml/builtins.ts src/types/value-types.ts src/tests/stdlib.test.ts src/tests/pvml.test.ts src/tests/value-types.test.ts` — passed
- Prettier check/write applied to the new test
