### PR TITLE
py2js: bridge the real stdlib (misc + math) at the value boundary

### DIFF
--- a/src/engines/py2js/compiler.ts
+++ b/src/engines/py2js/compiler.ts
@@ -129,8 +129,10 @@ function emitExpr(e: ExprNS.Expr, a: boolean, dual: boolean): string {
     case "Lambda": {
       const l = e as ExprNS.Lambda;
       // A lambda body is in tail position: evaluating it *is* the return.
+      // "(anonymous)" matches the CSE machine's rendering of lambda values
+      // (toPythonString on a nameless closure), pinned by the stdlib sweep.
       return emitFunctionValue(
-        "<lambda>",
+        "(anonymous)",
         l.parameters.map(p => mangle(p.lexeme)),
         bodyAsync => emitTailPosition(l.body, bodyAsync, dual),
         dual,

--- a/src/engines/py2js/index.ts
+++ b/src/engines/py2js/index.ts
@@ -20,7 +20,7 @@ import misc from "../../stdlib/misc";
 import type { Group } from "../../stdlib/utils";
 import { makeValidatorsForChapter } from "../../validator";
 import { CompileMode, compileProgram, Py2JsCompileError } from "./compiler";
-import { Py2JsRuntime, Py2JsRuntimeError, PyValue } from "./runtime";
+import { annotateHostFunction, Py2JsRuntime, Py2JsRuntimeError, PyValue } from "./runtime";
 import { bridgeStdlibGroups } from "./stdlibBridge";
 
 /**
@@ -86,7 +86,13 @@ function prepare(
     if (!(name in rt.builtins)) rt.builtins[name] = value;
   }
   const extra = options.extraBuiltins;
-  Object.assign(rt.builtins, typeof extra === "function" ? extra(rt) : (extra ?? {}));
+  const extraResolved = typeof extra === "function" ? extra(rt) : (extra ?? {});
+  for (const [name, value] of Object.entries(extraResolved)) {
+    // Plain JS functions from outside get the PyFunction metadata invariant
+    // established here (name, arity reporting, built-in rendering) — see
+    // annotateHostFunction; already-annotated functions pass through as-is.
+    rt.builtins[name] = annotateHostFunction(name, value);
+  }
 
   let ast;
   try {

--- a/src/engines/py2js/index.ts
+++ b/src/engines/py2js/index.ts
@@ -15,9 +15,22 @@
  */
 import { parse } from "../../parser";
 import { Resolver } from "../../resolver";
+import math from "../../stdlib/math";
+import misc from "../../stdlib/misc";
+import type { Group } from "../../stdlib/utils";
 import { makeValidatorsForChapter } from "../../validator";
 import { CompileMode, compileProgram, Py2JsCompileError } from "./compiler";
 import { Py2JsRuntime, Py2JsRuntimeError, PyValue } from "./runtime";
+import { bridgeStdlibGroups } from "./stdlibBridge";
+
+/**
+ * Stdlib groups per chapter, bridged into the runtime by prepare(). Mirrors
+ * runner.ts's VARIANT_GROUPS[1] (kept separate so the engine does not pull
+ * in the runner's conductor plumbing); extend as chapters 2+ land.
+ */
+const PY2JS_GROUPS: Record<number, Group[]> = {
+  1: [misc, math],
+};
 
 export { Py2JsCompileError, Py2JsRuntime, Py2JsRuntimeError };
 export type { CompileMode, PyValue };
@@ -63,10 +76,18 @@ function prepare(
   }
 
   const rt = new Py2JsRuntime();
+  const script = code.endsWith("\n") ? code : code + "\n";
+
+  // The chapter's stdlib groups, bridged to native values (stdlibBridge.ts).
+  // The runtime's native core (print/input/arity) wins over same-named
+  // bridged entries; extraBuiltins (module bindings etc.) override anything.
+  const bridged = bridgeStdlibGroups(rt, PY2JS_GROUPS[variant] ?? [], script, variant);
+  for (const [name, value] of Object.entries(bridged)) {
+    if (!(name in rt.builtins)) rt.builtins[name] = value;
+  }
   const extra = options.extraBuiltins;
   Object.assign(rt.builtins, typeof extra === "function" ? extra(rt) : (extra ?? {}));
 
-  const script = code.endsWith("\n") ? code : code + "\n";
   let ast;
   try {
     ast = parse(script);

--- a/src/engines/py2js/runtime.ts
+++ b/src/engines/py2js/runtime.ts
@@ -525,8 +525,32 @@ export class Py2JsRuntime {
       }
       // Bridged stdlib builtins report their CSE minArgs (pyMinArgs); user
       // functions and native builtins report their parameter count, which is
-      // what the CSE machine reports for its closures.
-      return BigInt(f.pyMinArgs ?? Math.max(0, f.pyArity));
+      // what the CSE machine reports for its closures. The f.length fallback
+      // covers bare JS functions that bypassed annotateHostFunction (e.g.
+      // stuffed into rt.builtins directly).
+      return BigInt(f.pyMinArgs ?? Math.max(0, f.pyArity ?? f.length));
     }),
   };
+}
+
+/**
+ * Establish the PyFunction metadata invariant on a host-supplied function
+ * (extraBuiltins — module bindings etc.). Compiled user functions always get
+ * their metadata from def/def2; this is for plain JS functions arriving from
+ * outside. Fills only what is missing: pyName from the binding name, pyArity
+ * -1 (argument counts are not enforced for host functions — a rest-args
+ * implementation reports Function#length 0, so enforcing it would wrongly
+ * reject every call), pyMinArgs from Function#length for arity() reporting,
+ * and pyBuiltin so rendering says <built-in function name>.
+ */
+export function annotateHostFunction(name: string, fn: PyValue): PyValue {
+  if (typeof fn !== "function") return fn;
+  const f = fn as Partial<PyFunction> & ((...args: PyValue[]) => PyValue | TailCall);
+  if (f.pyArity === undefined) {
+    f.pyMinArgs ??= f.length;
+    f.pyArity = -1;
+  }
+  f.pyName ??= name;
+  f.pyBuiltin ??= true;
+  return f as PyFunction;
 }

--- a/src/engines/py2js/runtime.ts
+++ b/src/engines/py2js/runtime.ts
@@ -39,6 +39,13 @@ export interface PyFunction {
   pyArity: number;
   pyBuiltin?: boolean;
   /**
+   * For bridged stdlib builtins: the CSE-side minArgs, reported by the
+   * native arity() builtin so both engines answer arity questions
+   * identically (bridged functions run with pyArity -1, leaving argument
+   * count validation to the stdlib's own @Validate wrappers).
+   */
+  pyMinArgs?: number;
+  /**
    * Dual compilation: the async twin of this (sync) body, sharing the same
    * closure environment. Present on every user function compiled in dual
    * mode; absent on builtins (which are plain sync JS, or return a Promise
@@ -491,54 +498,35 @@ export class Py2JsRuntime {
   }
 
   /**
-   * Minimal native builtin set — placeholder until the stdlib bridge lands
-   * (src/stdlib's misc/math groups are written against the CSE machine's
-   * tagged Value union and cannot be loaded directly; see the engine README).
+   * The native builtin core: the few builtins that cannot go through the
+   * stdlib bridge (see stdlibBridge.ts, which supplies everything else from
+   * the real src/stdlib groups). print and input are async/stream-based in
+   * the stdlib; arity inspects CSE closures, which py2js functions are not.
    */
   readonly builtins: Record<string, PyValue> = {
     print: this.builtin("print", -1, (...args) => {
+      // Same formatting as the stdlib's print: str() of each argument,
+      // space-joined, one trailing newline (pyStr mirrors toPythonString).
       this.output.push(args.map(pyStr).join(" ") + "\n");
       return null;
     }),
-    str: this.builtin("str", 1, v => pyStr(v)),
-    abs: this.builtin("abs", 1, v => {
-      if (typeof v === "bigint") return v < 0n ? -v : v;
-      if (typeof v === "number") return Math.abs(v);
-      // Math.hypot scales internally, so |z| survives components whose
-      // squares overflow/underflow (abs(complex(1e200, 0)) is 1e200, not
-      // inf) — same algorithm CPython's abs(complex) uses.
-      if (isComplex(v)) return Math.hypot(v.real, v.imag);
-      throw new Py2JsRuntimeError("TypeError", `bad operand type for abs(): '${pyTypeName(v)}'`);
+    input: this.builtin("input", -1, () => {
+      throw new Py2JsRuntimeError(
+        "RuntimeError",
+        "input() is not supported by the py2js engine yet",
+      );
     }),
-    max: this.builtin("max", 2, (a, b) => (pyOrder(">=", a, b) ? a! : b!)),
-    min: this.builtin("min", 2, (a, b) => (pyOrder("<=", a, b) ? a! : b!)),
-    math_sqrt: this.numericBuiltin("math_sqrt", Math.sqrt),
-    math_exp: this.numericBuiltin("math_exp", Math.exp),
-    math_log: this.numericBuiltin("math_log", Math.log),
-    math_sin: this.numericBuiltin("math_sin", Math.sin),
-    math_cos: this.numericBuiltin("math_cos", Math.cos),
-    math_floor: this.builtin("math_floor", 1, v => {
-      if (typeof v === "bigint") return v;
-      if (typeof v === "number") {
-        // BigInt() throws RangeError on non-finite floats; raise the same
-        // errors CPython's math.floor does instead.
-        if (Number.isNaN(v))
-          throw new Py2JsRuntimeError("ValueError", "cannot convert float NaN to integer");
-        if (!Number.isFinite(v))
-          throw new Py2JsRuntimeError("OverflowError", "cannot convert float infinity to integer");
-        return BigInt(Math.floor(v));
+    arity: this.builtin("arity", 1, f => {
+      if (typeof f !== "function") {
+        throw new Py2JsRuntimeError(
+          "TypeError",
+          `unsupported argument type for arity: '${pyTypeName(f)}'`,
+        );
       }
-      throw new Py2JsRuntimeError("TypeError", `must be real number, not ${pyTypeName(v)}`);
+      // Bridged stdlib builtins report their CSE minArgs (pyMinArgs); user
+      // functions and native builtins report their parameter count, which is
+      // what the CSE machine reports for its closures.
+      return BigInt(f.pyMinArgs ?? Math.max(0, f.pyArity));
     }),
-    math_pi: Math.PI,
-    math_e: Math.E,
   };
-
-  private numericBuiltin(name: string, fn: (x: number) => number): PyFunction {
-    return this.builtin(name, 1, v => {
-      if (!isNum(v))
-        throw new Py2JsRuntimeError("TypeError", `must be real number, not ${pyTypeName(v)}`);
-      return fn(Number(v));
-    });
-  }
 }

--- a/src/engines/py2js/stdlibBridge.ts
+++ b/src/engines/py2js/stdlibBridge.ts
@@ -1,0 +1,163 @@
+/**
+ * py2js engine — stdlib bridge.
+ *
+ * The stdlib groups (src/stdlib/misc.ts, math.ts, …) are written against the
+ * CSE machine's tagged Value union with `(args, source, command, context)`
+ * signatures. This bridge exposes them to py2js by converting the engine's
+ * native (unboxed) values to tagged Values at the call boundary and back for
+ * the result — so both engines run the *same* builtin implementations, and
+ * stdlib semantics can never drift between them. Conformance is pinned by
+ * src/tests/stdlib-conformance-py2js.test.ts.
+ *
+ * What crosses the boundary at chapter 1: int/float/bool/str/None/complex
+ * round-trip losslessly (complex is a PyComplexNumber on both sides).
+ * Functions cross one way only (as arguments — no chapter-1 stdlib builtin
+ * returns a function): a user function becomes a minimal FunctionValue (so
+ * is_function answers True and error messages say 'function'), a py2js
+ * builtin becomes a stub BuiltinValue. Neither is callable from stdlib code,
+ * which no chapter-1 builtin attempts.
+ *
+ * Error handling: stdlib builtins raise through handleRuntimeError, which
+ * records on the bridge's Context and throws the error class — the throw
+ * propagates out of the compiled py2js program and is wrapped into a
+ * Py2JsRunError by index.ts, preserving the error-class name. The `command`
+ * node each builtin receives is a synthetic Call whose callee token carries
+ * the builtin's name, so messages that name the callee ("unsupported argument
+ * type for math_sin…") stay accurate; source positions point at the program
+ * start until py2js grows real error locations.
+ *
+ * Async builtins (print, input — the stream-based ones) are NOT bridged:
+ * their sync py2js replacements live in runtime.ts's native core, and the
+ * bridge's Promise guard below is the backstop for any future async stdlib
+ * addition. `arity` is also native (py2js functions are not CSE closures);
+ * bridged builtins carry pyMinArgs so it reports the same numbers the CSE
+ * machine does.
+ */
+import { ExprNS } from "../../ast-types";
+import { Token, TokenType } from "../../tokenizer";
+import type { Group } from "../../stdlib/utils";
+import { Context } from "../cse/context";
+import type { Environment } from "../cse/environment";
+import type { BuiltinValue, Value } from "../cse/stash";
+import { Py2JsRuntime, Py2JsRuntimeError, PyFunction, PyValue } from "./runtime";
+
+function syntheticCallNode(name: string): ExprNS.Call {
+  const token = new Token(TokenType.NAME, name, 1, 0, 0);
+  token.synthetic = true;
+  const callee = new ExprNS.Variable(token, token, token);
+  return new ExprNS.Call(token, token, callee, []);
+}
+
+function toTagged(v: PyValue): Value {
+  switch (typeof v) {
+    case "bigint":
+      return { type: "bigint", value: v };
+    case "number":
+      return { type: "number", value: v };
+    case "boolean":
+      return { type: "bool", value: v };
+    case "string":
+      return { type: "string", value: v };
+    case "function":
+      // See file header: functions cross as inspectable, non-callable stand-ins.
+      return v.pyBuiltin
+        ? {
+            type: "builtin",
+            name: v.pyName,
+            minArgs: v.pyMinArgs ?? Math.max(0, v.pyArity),
+            func: () => {
+              throw new Py2JsRuntimeError(
+                "SystemError",
+                `stdlib bridge: ${v.pyName} cannot be called from a bridged builtin`,
+              );
+            },
+          }
+        : {
+            type: "function",
+            name: v.pyName,
+            params: [],
+            body: [],
+            env: undefined as unknown as Environment,
+          };
+    default:
+      if (v === null) return { type: "none" };
+      return { type: "complex", value: v };
+  }
+}
+
+function fromTagged(name: string, v: Value): PyValue {
+  switch (v.type) {
+    case "bigint":
+    case "number":
+    case "string":
+    case "complex":
+      return v.value;
+    case "bool":
+      return v.value;
+    case "none":
+      return null;
+    default:
+      // No chapter-1 stdlib builtin returns a function/closure/list; reaching
+      // this means the bridge needs extending, not that user code is wrong.
+      throw new Py2JsRuntimeError(
+        "SystemError",
+        `stdlib bridge: ${name}() returned an unbridgeable '${v.type}' value`,
+      );
+  }
+}
+
+function bridgeBuiltin(
+  rt: Py2JsRuntime,
+  name: string,
+  builtin: BuiltinValue,
+  context: Context,
+  source: string,
+): PyFunction {
+  const command = syntheticCallNode(name);
+  const call = builtin.func as (
+    args: Value[],
+    source: string,
+    command: ExprNS.Call,
+    context: Context,
+  ) => Value | undefined | Promise<Value | undefined>;
+  // pyArity -1: argument-count validation is the builtin's own @Validate
+  // wrapper, so arity errors carry the CSE machine's exact messages.
+  const f = rt.def(name, -1, (...args: PyValue[]) => {
+    const result = call(args.map(toTagged), source, command, context);
+    if (result instanceof Promise) {
+      throw new Py2JsRuntimeError(
+        "RuntimeError",
+        `${name}() is asynchronous and not yet supported by the py2js engine`,
+      );
+    }
+    return result === undefined ? null : fromTagged(name, result);
+  });
+  f.pyBuiltin = true;
+  f.pyMinArgs = builtin.minArgs;
+  return f;
+}
+
+/**
+ * Bridge every builtin (and constant) of the given stdlib groups into py2js
+ * native values. `source` is the program text, used by stdlib error
+ * constructors for their (currently synthetic) location info.
+ */
+export function bridgeStdlibGroups(
+  rt: Py2JsRuntime,
+  groups: Group[],
+  source: string,
+  variant: number,
+): Record<string, PyValue> {
+  const context = new Context();
+  context.variant = variant;
+  const out: Record<string, PyValue> = {};
+  for (const group of groups) {
+    for (const [name, value] of group.builtins) {
+      out[name] =
+        value.type === "builtin"
+          ? bridgeBuiltin(rt, name, value, context, source)
+          : fromTagged(name, value);
+    }
+  }
+  return out;
+}

--- a/src/engines/py2js/stdlibBridge.ts
+++ b/src/engines/py2js/stdlibBridge.ts
@@ -58,27 +58,32 @@ function toTagged(v: PyValue): Value {
       return { type: "bool", value: v };
     case "string":
       return { type: "string", value: v };
-    case "function":
-      // See file header: functions cross as inspectable, non-callable stand-ins.
+    case "function": {
+      // See file header: functions cross as inspectable, non-callable
+      // stand-ins. The fallbacks cover bare JS functions that bypassed
+      // annotateHostFunction (index.ts establishes the metadata invariant
+      // for extraBuiltins; Function#name can be "", hence || not ??).
+      const name = v.pyName ?? (v.name || "(anonymous)");
       return v.pyBuiltin
         ? {
             type: "builtin",
-            name: v.pyName,
-            minArgs: v.pyMinArgs ?? Math.max(0, v.pyArity),
+            name,
+            minArgs: v.pyMinArgs ?? Math.max(0, v.pyArity ?? v.length),
             func: () => {
               throw new Py2JsRuntimeError(
                 "SystemError",
-                `stdlib bridge: ${v.pyName} cannot be called from a bridged builtin`,
+                `stdlib bridge: ${name} cannot be called from a bridged builtin`,
               );
             },
           }
         : {
             type: "function",
-            name: v.pyName,
+            name,
             params: [],
             body: [],
             env: undefined as unknown as Environment,
           };
+    }
     default:
       if (v === null) return { type: "none" };
       return { type: "complex", value: v };

--- a/src/tests/py2js-host-functions.test.ts
+++ b/src/tests/py2js-host-functions.test.ts
@@ -1,0 +1,37 @@
+/**
+ * py2js host-function boundary (#287 review): a plain JS function supplied
+ * via extraBuiltins — no pyName/pyArity metadata — must behave like a proper
+ * builtin, not crash. prepare() establishes the PyFunction metadata invariant
+ * (annotateHostFunction in engines/py2js/runtime.ts); arity() and the stdlib
+ * bridge's toTagged additionally carry Function#length fallbacks for
+ * functions that bypass it.
+ */
+import { runCodePy2Js, PyValue } from "../engines/py2js";
+
+// Deliberately un-annotated: what a naive host/module integration would pass.
+const bare = ((x: PyValue) => (x as bigint) * 2n) as unknown as PyValue;
+const bareRest = ((...xs: PyValue[]) => BigInt(xs.length)) as unknown as PyValue;
+
+test("bare host function is callable", () => {
+  const { output } = runCodePy2Js(`print(twice(21))`, 1, { extraBuiltins: { twice: bare } });
+  expect(output).toBe("42\n");
+});
+
+test("arity() of a bare host function reports Function#length instead of crashing", () => {
+  const { output } = runCodePy2Js(`print(arity(twice))`, 1, { extraBuiltins: { twice: bare } });
+  expect(output).toBe("1\n");
+});
+
+test("argument counts are not enforced for bare host functions (rest args report length 0)", () => {
+  const { output } = runCodePy2Js(`print(count(1, 2, 3))`, 1, {
+    extraBuiltins: { count: bareRest },
+  });
+  expect(output).toBe("3\n");
+});
+
+test("bare host function renders under its binding name", () => {
+  const { output } = runCodePy2Js(`print(twice)\nprint(str(twice))`, 1, {
+    extraBuiltins: { twice: bare },
+  });
+  expect(output).toBe("<built-in function twice>\n<built-in function twice>\n");
+});

--- a/src/tests/stdlib-conformance-py2js.test.ts
+++ b/src/tests/stdlib-conformance-py2js.test.ts
@@ -1,0 +1,130 @@
+/**
+ * py2js stdlib-bridge parity sweep.
+ *
+ * The py2js engine runs the *same* stdlib builtin implementations as the CSE
+ * machine, through the value-conversion bridge in
+ * src/engines/py2js/stdlibBridge.ts. This suite pins that bridge: every
+ * chapter-1 builtin and constant of the misc/math groups is swept over
+ * representative argument tuples drawn from the chapter-1 type universe, and
+ * the outcome (printed text, or error) is compared against the CSE machine
+ * evaluating the identical program via runner.ts's runCode — the reference
+ * implementation, computed fresh, exactly as the operator conformance sweeps
+ * do.
+ *
+ * Argument tuples per builtin: the empty call, one argument of each
+ * chapter-1 type, and int/float pairs — enough to exercise every @Validate
+ * arity gate, every per-type dispatch arm, and the bridge's conversions in
+ * both directions. Value outcomes compare full printed text (both engines
+ * format through toPythonString/pyStr conventions); error outcomes compare
+ * that both engines raised.
+ *
+ * Exclusions:
+ *  - input: stream-based; py2js deliberately raises "not supported yet"
+ *    while the CSE runner blocks on (closed) stdin — no comparable outcome.
+ *  - random_random / time_time: nondeterministic values; success-vs-error
+ *    only (KIND_ONLY).
+ */
+import { Py2JsRunError, runCodePy2Js } from "../engines/py2js";
+import { RunError, runCode } from "../runner";
+import math from "../stdlib/math";
+import misc from "../stdlib/misc";
+import type { Group } from "../stdlib/utils";
+
+/** Representative literal per chapter-1 type (operator-spec.ts's set, minus
+ * list, which chapter 1 rejects). */
+const LITERALS = ["2", "2.5", "(1+2j)", "True", "'ab'", "None", "(lambda x: x)"];
+
+const SKIP = new Set(["input"]);
+const KIND_ONLY = new Set(["random_random", "time_time"]);
+
+type Outcome = { kind: "value"; text: string } | { kind: "error" };
+
+async function cseOutcome(code: string): Promise<Outcome> {
+  try {
+    return { kind: "value", text: await runCode(code, 1) };
+  } catch (e) {
+    if (e instanceof RunError) return { kind: "error" };
+    throw e;
+  }
+}
+
+function py2jsOutcome(code: string): Outcome {
+  try {
+    return { kind: "value", text: runCodePy2Js(code, 1).output };
+  } catch (e) {
+    if (e instanceof Py2JsRunError) return { kind: "error" };
+    throw e;
+  }
+}
+
+async function expectParity(code: string, kindOnly = false): Promise<void> {
+  const wanted = await cseOutcome(code);
+  const actual = py2jsOutcome(code);
+  if (kindOnly) {
+    expect(actual.kind).toBe(wanted.kind);
+  } else {
+    expect(actual).toStrictEqual(wanted);
+  }
+}
+
+const argTuples: string[][] = [
+  [],
+  ...LITERALS.map(l => [l]),
+  ["2", "2"],
+  ["2", "2.5"],
+  ["2.5", "2"],
+  ["2.5", "2.5"],
+];
+
+for (const group of [misc, math] as Group[]) {
+  describe(`[py2js] stdlib parity: ${group.name}`, () => {
+    for (const [name, value] of group.builtins) {
+      if (SKIP.has(name)) continue;
+
+      if (value.type !== "builtin") {
+        test(`constant ${name}`, async () => {
+          await expectParity(`print(${name})`);
+        });
+        continue;
+      }
+
+      describe(name, () => {
+        for (const args of argTuples) {
+          const code = `print(${name}(${args.join(", ")}))`;
+          test(code, async () => {
+            await expectParity(code, KIND_ONLY.has(name));
+          });
+        }
+      });
+    }
+  });
+}
+
+describe("[py2js] stdlib parity: directed cases", () => {
+  const cases = [
+    // arity must agree across user functions, lambdas, native and bridged builtins
+    `def f(a, b):\n    return a\nprint(arity(f))`,
+    `print(arity(lambda x: x))`,
+    `print(arity(abs))`,
+    `print(arity(print))`,
+    `print(arity(complex))`,
+    // function values rendered through bridged str/repr
+    `def f(a):\n    return a\nprint(str(f))`,
+    `print(str(abs))`,
+    // results flow back into the program as native values
+    `print(max(2, 3) + abs(-4))`,
+    `print(math_sqrt(abs(complex(-3, 4))))`,
+    `print(round(2.675, 2) + 1.0)`,
+    `print(complex(1, 2) + complex(3, -1))`,
+    `print(real(complex(1.5, 2)) + imag(complex(1.5, 2)))`,
+    `print(is_function(lambda x: x), is_function(abs), is_function(2))`,
+    `print(len('hello') + 1)`,
+    // user-level error builtin
+    `error("boom")`,
+  ];
+  for (const code of cases) {
+    test(JSON.stringify(code), async () => {
+      await expectParity(code);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Stacked on #282. First step of the chapter-1 depth work: py2js now runs the **actual stdlib** — the same `misc`/`math` builtin implementations the CSE machine uses — instead of its placeholder builtin set, so stdlib semantics cannot drift between engines.

- **`stdlibBridge.ts`** (new) — converts native py2js values (int=`bigint`, float=`number`, None=`null`, complex=`PyComplexNumber`, …) to the CSE tagged `Value` union at the builtin call boundary and back for the result. Functions cross one way, as inspectable stand-ins (a minimal `FunctionValue` for user functions, a stub `BuiltinValue` for py2js natives): `is_function`, `str()`/`repr()` rendering and error messages all agree with the CSE machine. Errors raised through `handleRuntimeError` propagate out under their class names; each bridged builtin gets a synthetic `Call` node carrying its own name, so callee-naming messages ("unsupported argument type for `math_sin`…") stay accurate. A `Promise` guard rejects any future async stdlib addition loudly.
- **`runtime.ts`** — the native builtin core shrinks to what the bridge cannot supply: `print` (stream-based/async in the stdlib; the native version pushes to the runtime's output with identical formatting), `input` (raises "not supported yet"), and `arity` (py2js functions aren't CSE closures; bridged builtins carry `pyMinArgs` so both engines report identical arities — argument-count validation itself stays with the stdlib's own `@Validate` wrappers, preserving its exact error messages).
- **`compiler.ts`** — lambdas are named `(anonymous)`, matching the CSE machine's rendering of nameless closures.
- **`index.ts`** — `prepare()` bridges `PY2JS_GROUPS[variant]` (misc + math at chapter 1); native core wins over same-named bridged entries; `extraBuiltins` (future module bindings) override anything.

### Table-driven parity: `stdlib-conformance-py2js.test.ts`

**896 cases, all passing**: every misc/math builtin and constant swept over the chapter-1 type universe — the empty call, one argument of each type, and int/float pairs — exercising every `@Validate` arity gate, every per-type dispatch arm, and both conversion directions; plus directed arity/str/composition cases. Each case compares against the CSE machine running the identical `print(...)`-wrapped program via `runCode`, computed fresh (same philosophy as the operator sweeps). Exclusions: `input` (no comparable outcome) and value-comparison for `random_random`/`time_time` (nondeterministic; success-vs-error only).

Note: with the bridge, py2js's `abs(complex)` follows `misc.ts` — parity with CSE is guaranteed either way, and the hypot fix for extreme components lands for all engines together via #285.

## Test plan

- `yarn jest src/tests/stdlib-conformance-py2js.test.ts` — 896/896
- `yarn jest src/tests/operator-conformance-py2js.test.ts` — 749/749 (unchanged, now with bridged builtin resolution)
- `yarn jest` — full suite green (44 suites, 15 777 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbExZBaxgeUL4oi1t7PG93