### PR TITLE
py2js: conductor evaluator (Py2JsEvaluator1) with persistent REPL sessions

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -18,6 +18,7 @@ const allTargets = [
   "PyPvmlEvaluator3",
   "PyPvmlEvaluator4",
   "PyPvmlPynterEvaluator",
+  "Py2JsEvaluator1",
   "PyStepperEvaluator1",
   "PyStepperEvaluator2",
 ] as const;

--- a/src/conductor/Py2JsEvaluator.ts
+++ b/src/conductor/Py2JsEvaluator.ts
@@ -1,0 +1,51 @@
+import { BasicEvaluator, IRunnerPlugin } from "@sourceacademy/conductor/runner";
+import { Py2JsSession } from "../engines/py2js";
+import { EvaluatorError } from "./errors";
+
+/**
+ * Runs Python by compiling it to JavaScript — the py2js engine
+ * (src/engines/py2js): native unboxed values, tail-call trampoline, the real
+ * stdlib bridged at the value boundary, and operator semantics pinned
+ * against the CSE machine by the table-driven conformance sweeps.
+ *
+ * Mirrors PyPvmlEvaluatorBase's persistence model: one Py2JsSession survives
+ * across evaluateChunk() calls, holding the runtime and its module-level
+ * globals table (REPL compile mode — see compiler.ts), so a later chunk sees
+ * every name an earlier chunk defined, and functions from earlier chunks see
+ * later redefinitions via late lookup, as with the CSE machine's global
+ * environment. Group preludes (none at chapter 1) are compiled into the same
+ * session by its first runChunk().
+ *
+ * Exec-style, like the PVML-in-browser evaluator: every chunk reports no
+ * result value; a chunk that wants to surface a value print()s it. Output
+ * streams per print() line through the session's onOutput hook.
+ *
+ * Chapter 1 only for now (the engine rejects other variants); Py2JsEvaluator2..4
+ * will follow the engine's chapter coverage.
+ */
+abstract class Py2JsEvaluatorBase extends BasicEvaluator {
+  private readonly session: Py2JsSession;
+
+  protected constructor(conductor: IRunnerPlugin, variant: number) {
+    super(conductor);
+    this.session = new Py2JsSession(variant, {
+      onOutput: line => this.conductor.sendOutput(line),
+    });
+  }
+
+  evaluateChunk(chunk: string): Promise<void> {
+    try {
+      this.session.runChunk(chunk);
+      this.conductor.sendResult(undefined);
+    } catch (e) {
+      this.conductor.sendError(new EvaluatorError(e));
+    }
+    return Promise.resolve();
+  }
+}
+
+export class Py2JsEvaluator1 extends Py2JsEvaluatorBase {
+  constructor(conductor: IRunnerPlugin) {
+    super(conductor, 1);
+  }
+}

--- a/src/conductor/index.ts
+++ b/src/conductor/index.ts
@@ -12,6 +12,7 @@ export {
   PyPvmlEvaluator4,
 } from "./PyPvmlEvaluator";
 export { PyPvmlPynterEvaluator } from "./PyPvmlPynterEvaluator";
+export { Py2JsEvaluator1 } from "./Py2JsEvaluator";
 export { PyStepperEvaluator1, PyStepperEvaluator2 } from "./PyStepperEvaluator";
 export {
   PyWasmEvaluator1,

--- a/src/engines/py2js/compiler.ts
+++ b/src/engines/py2js/compiler.ts
@@ -26,8 +26,23 @@
  *    program's async spine so module round-trips can suspend. The top level
  *    is compiled async in this mode.
  *
+ * REPL mode (options.repl, used by Py2JsSession / the conductor evaluator):
+ * the program is one *chunk* of a persistent session. Top-level bindings —
+ * this chunk's and all earlier chunks' — live in the runtime's `globals`
+ * table instead of `let` declarations: writes are direct stores, reads go
+ * through `__py.gref`, which raises Python's NameError for a name whose
+ * binding statement never actually executed. Routing every module-level
+ * reference through the table (rather than freezing values into per-chunk
+ * `const`s, as js-slang's transpiler does) gives CSE-machine parity for late
+ * binding: a function defined in chunk 1 that calls helper g sees chunk 3's
+ * *redefinition* of g, exactly like the CSE machine's global environment
+ * frame. Function-local scopes are unaffected — locals stay `let`-compiled.
+ * Chapter 1 has no `global` keyword, so a name is module-level iff it is
+ * bound at the top level of some chunk; no other scope analysis is needed.
+ *
  * Inside the emitters, `a` says whether the code being emitted right now is
- * the async body (await calls) or the sync one.
+ * the async body (await calls) or the sync one; `ctx` carries the fixed
+ * compilation config plus the stack of enclosing function scopes.
  *
  * The compiler assumes the program has already passed the resolver with the
  * chapter's validators (see index.ts); the Py2JsCompileError throws below are
@@ -47,39 +62,115 @@ export type CompileMode = "sync" | "dual";
 
 export interface CompileOptions {
   mode?: CompileMode;
+  /**
+   * REPL mode (see file header): compile as one chunk of a persistent
+   * session. `priorGlobals` are the names earlier chunks (or the prelude)
+   * have already bound in the runtime's globals table.
+   */
+  repl?: { priorGlobals: string[] };
+}
+
+interface Scope {
+  /** Parameters: always bound at function entry — reads need no guard. */
+  params: Set<string>;
+  /** Non-parameter locals (`let`-declared at body top, assigned where the
+   * Python assignment executes): a read may precede the assignment. */
+  locals: Set<string>;
+}
+
+interface EmitCtx {
+  dual: boolean;
+  /**
+   * REPL mode only: every module-level name — this chunk's top-level
+   * bindings plus priorGlobals. References resolve through the runtime's
+   * globals table unless shadowed by an enclosing function scope. undefined
+   * in program mode.
+   */
+  globals?: Set<string>;
+  /** Program mode only: the program's top-level names — `let`-compiled, with
+   * reads guarded like locals but raising NameError (module level). */
+  programGlobals?: Set<string>;
+  /** Enclosing function scopes, outermost first. */
+  scopes: Scope[];
 }
 
 const mangle = (name: string) => "$" + name;
+
+/**
+ * A name reference or assignment target, resolved against the scope stack.
+ *
+ * Unbound-read guards: Python has no TDZ — its environments grow
+ * dynamically — but reading a binding whose assignment never executed is
+ * still an error (UnboundLocalError for function locals, NameError at module
+ * level), which the CSE machine mirrors. JS `let` initializes to undefined
+ * instead, so every read of a guardable binding compiles to an inline
+ * `=== undefined` check; undefined is not a PyValue (None is null), so the
+ * check is exact, and it costs one perfectly-predicted comparison. Parameters
+ * are always bound and skip the guard; REPL-mode module names go through
+ * gref, which performs the same check inside the runtime.
+ */
+function emitName(name: string, ctx: EmitCtx, write: boolean): string {
+  const j = JSON.stringify(name);
+  for (let i = ctx.scopes.length - 1; i >= 0; i--) {
+    if (ctx.scopes[i].params.has(name)) return mangle(name);
+    if (ctx.scopes[i].locals.has(name)) {
+      const m = mangle(name);
+      return write ? m : `(${m} === undefined ? __py.unboundErr(${j}) : ${m})`;
+    }
+  }
+  if (ctx.globals?.has(name)) {
+    return write ? `__py.globals[${j}]` : `__py.gref(${j})`;
+  }
+  if (ctx.programGlobals?.has(name)) {
+    const m = mangle(name);
+    return write ? m : `(${m} === undefined ? __py.nameErr(${j}) : ${m})`;
+  }
+  return mangle(name);
+}
 
 /** Serialize a float component of a complex literal (finite, or inf/nan from
  * PyComplexNumber.fromString) into a JS number expression. */
 const emitFloat = (n: number): string =>
   Number.isFinite(n) ? String(n) : Number.isNaN(n) ? "NaN" : n > 0 ? "Infinity" : "-Infinity";
 
-function emitCall(c: ExprNS.Call, a: boolean, dual: boolean): string {
-  const callee = emitExpr(c.callee, a, dual);
-  const args = c.args.map(arg => emitExpr(arg, a, dual)).join(", ");
+function emitCall(c: ExprNS.Call, a: boolean, ctx: EmitCtx): string {
+  const callee = emitExpr(c.callee, a, ctx);
+  const args = c.args.map(arg => emitExpr(arg, a, ctx)).join(", ");
   return a ? `(await __py.acall(${callee}, [${args}]))` : `__py.call(${callee}, [${args}])`;
 }
 
+/**
+ * Emit a function value (def or lambda). `scope` is the new function scope
+ * (params + locals); it is pushed around each body emission — twice in dual
+ * mode, once per body, both over the same closure environment.
+ */
 function emitFunctionValue(
   name: string,
   params: string[],
+  scope: Scope,
   emitBody: (a: boolean) => string,
-  dual: boolean,
+  ctx: EmitCtx,
 ): string {
-  const plist = params.join(", ");
-  if (!dual) {
-    return `__py.def(${JSON.stringify(name)}, ${params.length}, (${plist}) => ${emitBody(false)})`;
+  const emitOnce = (a: boolean): string => {
+    ctx.scopes.push(scope);
+    try {
+      return emitBody(a);
+    } finally {
+      ctx.scopes.pop();
+    }
+  };
+  const plist = params.map(mangle).join(", ");
+  if (!ctx.dual) {
+    return `__py.def(${JSON.stringify(name)}, ${params.length}, (${plist}) => ${emitOnce(false)})`;
   }
   return (
     `__py.def2(${JSON.stringify(name)}, ${params.length}, ` +
-    `(${plist}) => ${emitBody(false)}, ` +
-    `async (${plist}) => ${emitBody(true)})`
+    `(${plist}) => ${emitOnce(false)}, ` +
+    `async (${plist}) => ${emitOnce(true)})`
   );
 }
 
-function emitExpr(e: ExprNS.Expr, a: boolean, dual: boolean): string {
+function emitExpr(e: ExprNS.Expr, a: boolean, ctx: EmitCtx): string {
   switch (e.kind) {
     case "BigIntLiteral":
       return `${(e as ExprNS.BigIntLiteral).value}n`;
@@ -95,25 +186,25 @@ function emitExpr(e: ExprNS.Expr, a: boolean, dual: boolean): string {
     case "None":
       return "null";
     case "Variable":
-      return mangle((e as ExprNS.Variable).name.lexeme);
+      return emitName((e as ExprNS.Variable).name.lexeme, ctx, false);
     case "Grouping":
-      return `(${emitExpr((e as ExprNS.Grouping).expression, a, dual)})`;
+      return `(${emitExpr((e as ExprNS.Grouping).expression, a, ctx)})`;
     case "Unary": {
       const u = e as ExprNS.Unary;
-      return `__py.unop(${JSON.stringify(u.operator.lexeme)}, ${emitExpr(u.right, a, dual)})`;
+      return `__py.unop(${JSON.stringify(u.operator.lexeme)}, ${emitExpr(u.right, a, ctx)})`;
     }
     case "Binary": {
       const b = e as ExprNS.Binary;
-      return `__py.binop(${JSON.stringify(b.operator.lexeme)}, ${emitExpr(b.left, a, dual)}, ${emitExpr(b.right, a, dual)})`;
+      return `__py.binop(${JSON.stringify(b.operator.lexeme)}, ${emitExpr(b.left, a, ctx)}, ${emitExpr(b.right, a, ctx)})`;
     }
     case "Compare": {
       const c = e as ExprNS.Compare;
-      return `__py.binop(${JSON.stringify(c.operator.lexeme)}, ${emitExpr(c.left, a, dual)}, ${emitExpr(c.right, a, dual)})`;
+      return `__py.binop(${JSON.stringify(c.operator.lexeme)}, ${emitExpr(c.left, a, ctx)}, ${emitExpr(c.right, a, ctx)})`;
     }
     case "BoolOp": {
       const b = e as ExprNS.BoolOp;
-      const l = emitExpr(b.left, a, dual);
-      const r = emitExpr(b.right, a, dual);
+      const l = emitExpr(b.left, a, ctx);
+      const r = emitExpr(b.right, a, ctx);
       // Left operand must be bool; result is the left bool when it decides,
       // otherwise the right operand's value (see the CSE BOOL_OP instruction).
       return b.operator.lexeme === "and"
@@ -122,20 +213,22 @@ function emitExpr(e: ExprNS.Expr, a: boolean, dual: boolean): string {
     }
     case "Ternary": {
       const t = e as ExprNS.Ternary;
-      return `(__py.truth(${emitExpr(t.predicate, a, dual)}) ? ${emitExpr(t.consequent, a, dual)} : ${emitExpr(t.alternative, a, dual)})`;
+      return `(__py.truth(${emitExpr(t.predicate, a, ctx)}) ? ${emitExpr(t.consequent, a, ctx)} : ${emitExpr(t.alternative, a, ctx)})`;
     }
     case "Call":
-      return emitCall(e as ExprNS.Call, a, dual);
+      return emitCall(e as ExprNS.Call, a, ctx);
     case "Lambda": {
       const l = e as ExprNS.Lambda;
+      const params = l.parameters.map(p => p.lexeme);
       // A lambda body is in tail position: evaluating it *is* the return.
       // "(anonymous)" matches the CSE machine's rendering of lambda values
       // (toPythonString on a nameless closure), pinned by the stdlib sweep.
       return emitFunctionValue(
         "(anonymous)",
-        l.parameters.map(p => mangle(p.lexeme)),
-        bodyAsync => emitTailPosition(l.body, bodyAsync, dual),
-        dual,
+        params,
+        { params: new Set(params), locals: new Set() },
+        bodyAsync => emitTailPosition(l.body, bodyAsync, ctx),
+        ctx,
       );
     }
     default:
@@ -144,30 +237,30 @@ function emitExpr(e: ExprNS.Expr, a: boolean, dual: boolean): string {
 }
 
 /** Compile an expression that sits in return position of a function body. */
-function emitTailPosition(e: ExprNS.Expr, a: boolean, dual: boolean): string {
+function emitTailPosition(e: ExprNS.Expr, a: boolean, ctx: EmitCtx): string {
   switch (e.kind) {
     case "Call": {
       // Tail markers work identically in both modes: the marker is returned
       // synchronously (no stack growth, no await) and the caller's
       // trampoline — sync or async — bounces it.
       const c = e as ExprNS.Call;
-      return `__py.tail(${emitExpr(c.callee, a, dual)}, [${c.args.map(arg => emitExpr(arg, a, dual)).join(", ")}])`;
+      return `__py.tail(${emitExpr(c.callee, a, ctx)}, [${c.args.map(arg => emitExpr(arg, a, ctx)).join(", ")}])`;
     }
     case "Grouping":
-      return `(${emitTailPosition((e as ExprNS.Grouping).expression, a, dual)})`;
+      return `(${emitTailPosition((e as ExprNS.Grouping).expression, a, ctx)})`;
     case "Ternary": {
       const t = e as ExprNS.Ternary;
-      return `(__py.truth(${emitExpr(t.predicate, a, dual)}) ? ${emitTailPosition(t.consequent, a, dual)} : ${emitTailPosition(t.alternative, a, dual)})`;
+      return `(__py.truth(${emitExpr(t.predicate, a, ctx)}) ? ${emitTailPosition(t.consequent, a, ctx)} : ${emitTailPosition(t.alternative, a, ctx)})`;
     }
     case "BoolOp": {
       const b = e as ExprNS.BoolOp;
-      const l = emitExpr(b.left, a, dual);
+      const l = emitExpr(b.left, a, ctx);
       return b.operator.lexeme === "and"
-        ? `(__py.boolLeft(${l}, "and") ? ${emitTailPosition(b.right, a, dual)} : false)`
-        : `(__py.boolLeft(${l}, "or") ? true : ${emitTailPosition(b.right, a, dual)})`;
+        ? `(__py.boolLeft(${l}, "and") ? ${emitTailPosition(b.right, a, ctx)} : false)`
+        : `(__py.boolLeft(${l}, "or") ? true : ${emitTailPosition(b.right, a, ctx)})`;
     }
     default:
-      return emitExpr(e, a, dual);
+      return emitExpr(e, a, ctx);
   }
 }
 
@@ -199,52 +292,54 @@ function emitDecls(names: Set<string>, exclude: Set<string>, indent: string): st
   return filtered.length === 0 ? "" : `${indent}let ${filtered.map(mangle).join(", ")};\n`;
 }
 
-function emitStmts(stmts: StmtNS.Stmt[], indent: string, a: boolean, dual: boolean): string {
-  return stmts.map(s => emitStmt(s, indent, a, dual)).join("");
+function emitStmts(stmts: StmtNS.Stmt[], indent: string, a: boolean, ctx: EmitCtx): string {
+  return stmts.map(s => emitStmt(s, indent, a, ctx)).join("");
 }
 
-function emitStmt(s: StmtNS.Stmt, indent: string, a: boolean, dual: boolean): string {
+function emitStmt(s: StmtNS.Stmt, indent: string, a: boolean, ctx: EmitCtx): string {
   switch (s.kind) {
     case "Pass":
       return `${indent};\n`;
     case "SimpleExpr":
-      return `${indent}${emitExpr((s as StmtNS.SimpleExpr).expression, a, dual)};\n`;
+      return `${indent}${emitExpr((s as StmtNS.SimpleExpr).expression, a, ctx)};\n`;
     case "Assign": {
       const asg = s as StmtNS.Assign;
       if (asg.target.kind !== "Variable") throw new Py2JsCompileError("subscript assignment");
-      return `${indent}${mangle(asg.target.name.lexeme)} = ${emitExpr(asg.value, a, dual)};\n`;
+      return `${indent}${emitName(asg.target.name.lexeme, ctx, true)} = ${emitExpr(asg.value, a, ctx)};\n`;
     }
     case "FunctionDef": {
       const f = s as StmtNS.FunctionDef;
       if (f.parameters.some(p => p.isStarred)) throw new Py2JsCompileError("rest parameters");
+      const params = f.parameters.map(p => p.lexeme);
+      const locals = boundNames(f.body);
+      const paramSet = new Set(params);
+      const scope: Scope = {
+        params: paramSet,
+        locals: new Set([...locals].filter(n => !paramSet.has(n))),
+      };
       const inner = indent + "  ";
       const emitBody = (bodyAsync: boolean) =>
         `{\n` +
-        emitDecls(boundNames(f.body), new Set(f.parameters.map(p => p.lexeme)), inner) +
-        emitStmts(f.body, inner, bodyAsync, dual) +
+        emitDecls(locals, new Set(params), inner) +
+        emitStmts(f.body, inner, bodyAsync, ctx) +
         `${inner}return null;\n${indent}}`;
-      const fnValue = emitFunctionValue(
-        f.name.lexeme,
-        f.parameters.map(p => mangle(p.lexeme)),
-        emitBody,
-        dual,
-      );
-      return `${indent}${mangle(f.name.lexeme)} = ${fnValue};\n`;
+      const fnValue = emitFunctionValue(f.name.lexeme, params, scope, emitBody, ctx);
+      return `${indent}${emitName(f.name.lexeme, ctx, true)} = ${fnValue};\n`;
     }
     case "Return": {
       const r = s as StmtNS.Return;
       return r.value === null
         ? `${indent}return null;\n`
-        : `${indent}return ${emitTailPosition(r.value, a, dual)};\n`;
+        : `${indent}return ${emitTailPosition(r.value, a, ctx)};\n`;
     }
     case "If": {
       const i = s as StmtNS.If;
-      const head = `${indent}if (__py.truth(${emitExpr(i.condition, a, dual)})) {\n${emitStmts(i.body, indent + "  ", a, dual)}${indent}}`;
+      const head = `${indent}if (__py.truth(${emitExpr(i.condition, a, ctx)})) {\n${emitStmts(i.body, indent + "  ", a, ctx)}${indent}}`;
       if (i.elseBlock === null) return head + "\n";
-      return `${head} else {\n${emitStmts(i.elseBlock, indent + "  ", a, dual)}${indent}}\n`;
+      return `${head} else {\n${emitStmts(i.elseBlock, indent + "  ", a, ctx)}${indent}}\n`;
     }
     case "Assert":
-      return `${indent}__py.assertCheck(${emitExpr((s as StmtNS.Assert).value, a, dual)});\n`;
+      return `${indent}__py.assertCheck(${emitExpr((s as StmtNS.Assert).value, a, ctx)});\n`;
     default:
       throw new Py2JsCompileError(`statement kind '${s.kind}'`);
   }
@@ -265,15 +360,24 @@ export function compileProgram(
   const dual = options.mode === "dual";
 
   const topLevelNames = boundNames(file.statements);
+  const ctx: EmitCtx = {
+    dual,
+    scopes: [],
+    globals: options.repl ? new Set([...options.repl.priorGlobals, ...topLevelNames]) : undefined,
+    programGlobals: options.repl ? undefined : topLevelNames,
+  };
+
+  // A builtin resolves as a preamble const unless some chunk-level binding
+  // (this chunk's, or in REPL mode any earlier chunk's) takes the name over.
   const preamble = builtinNames
-    .filter(n => !topLevelNames.has(n))
+    .filter(n => !topLevelNames.has(n) && !ctx.globals?.has(n))
     .map(n => `const ${mangle(n)} = __py.builtins[${JSON.stringify(n)}];\n`)
     .join("");
 
   return (
     `"use strict";\n` +
     preamble +
-    emitDecls(topLevelNames, new Set(), "") +
-    emitStmts(file.statements, "", dual, dual)
+    (ctx.globals ? "" : emitDecls(topLevelNames, new Set(), "")) +
+    emitStmts(file.statements, "", dual, ctx)
   );
 }

--- a/src/engines/py2js/index.ts
+++ b/src/engines/py2js/index.ts
@@ -178,3 +178,92 @@ export function compilePy2Js(code: string, variant = 1, mode: CompileMode = "syn
   const { js } = prepare(code, variant, mode, {});
   return js;
 }
+
+export interface Py2JsSessionOptions extends RunPy2JsOptions {
+  /** Streams each print() line (no trailing newline) as it happens — the
+   * conductor evaluator forwards these to the frontend. */
+  onOutput?: (line: string) => void;
+}
+
+/**
+ * A persistent py2js session: chunks share one runtime and one module-level
+ * globals table (REPL compile mode, see compiler.ts), so a later chunk sees
+ * every name an earlier chunk (or a group prelude) bound — and functions from
+ * earlier chunks see later *redefinitions*, via gref's late lookup, matching
+ * the CSE machine's global-environment semantics. This is what the conductor
+ * evaluator (src/conductor/Py2JsEvaluator.ts) drives, one runChunk() per
+ * evaluateChunk().
+ *
+ * Unlike runCodePy2Js (which wraps everything in Py2JsRunError), runChunk
+ * throws the underlying errors raw — parse errors, the first resolver error,
+ * or the runtime's Py2JsRuntimeError — so callers like the conductor
+ * evaluator keep the error's name and any source location it carries.
+ */
+export class Py2JsSession {
+  readonly rt: Py2JsRuntime;
+  private readonly variant: number;
+  private readonly groups: Group[];
+  private preludeLoaded = false;
+
+  constructor(variant: number, options: Py2JsSessionOptions = {}) {
+    if (variant !== 1) {
+      throw new Py2JsRunError("parse", `py2js currently supports chapter 1 only (got ${variant})`);
+    }
+    this.variant = variant;
+    this.groups = PY2JS_GROUPS[variant] ?? [];
+    this.rt = new Py2JsRuntime();
+    this.rt.onOutput = options.onOutput;
+
+    // Same builtin layering as prepare(): bridged stdlib under the native
+    // core, extraBuiltins over everything. The bridge's source string is
+    // empty — its synthetic error nodes never point at real chunk text.
+    const bridged = bridgeStdlibGroups(this.rt, this.groups, "", variant);
+    for (const [name, value] of Object.entries(bridged)) {
+      if (!(name in this.rt.builtins)) this.rt.builtins[name] = value;
+    }
+    const extra = options.extraBuiltins;
+    const extraResolved = typeof extra === "function" ? extra(this.rt) : (extra ?? {});
+    for (const [name, value] of Object.entries(extraResolved)) {
+      this.rt.builtins[name] = annotateHostFunction(name, value);
+    }
+  }
+
+  /** Compile and run one chunk against the persistent globals (sync mode). */
+  runChunk(code: string): void {
+    if (!this.preludeLoaded) {
+      this.preludeLoaded = true;
+      const preludeText = this.groups
+        .map(g => g.prelude ?? "")
+        .filter(p => p.trim())
+        .join("\n");
+      if (preludeText.trim()) this.runChunkInternal(preludeText);
+    }
+    this.runChunkInternal(code);
+  }
+
+  private runChunkInternal(code: string): void {
+    const script = code.endsWith("\n") ? code : code + "\n";
+    const ast = parse(script);
+
+    // Prior chunks' global names are passed as the resolver's module-level
+    // names (its REPL parameter), exactly how the PVML evaluator seeds
+    // analyzeWithEnvironments from its persistent globalEnv.
+    const priorGlobals = Object.keys(this.rt.globals);
+    const resolver = new Resolver(
+      script,
+      ast,
+      makeValidatorsForChapter(this.variant),
+      [],
+      Object.keys(this.rt.builtins),
+      priorGlobals,
+    );
+    const errors = resolver.resolve(ast);
+    if (errors.length > 0) throw errors[0];
+
+    const js = compileProgram(ast, Object.keys(this.rt.builtins), {
+      mode: "sync",
+      repl: { priorGlobals },
+    });
+    new Function("__py", js)(this.rt);
+  }
+}

--- a/src/engines/py2js/runtime.ts
+++ b/src/engines/py2js/runtime.ts
@@ -243,6 +243,50 @@ function complexBinop(op: string, l: PyValue, r: PyValue): PyComplexNumber {
 export class Py2JsRuntime {
   output: string[] = [];
 
+  /**
+   * Called once per print() with the formatted line (no trailing newline) —
+   * the conductor evaluator streams these to the frontend as they happen;
+   * `output` above still accumulates regardless.
+   */
+  onOutput?: (line: string) => void;
+
+  /**
+   * Persistent module-level bindings for REPL-mode chunks (see compiler.ts's
+   * REPL-mode doc): every top-level binding of every chunk lives here, so a
+   * later chunk — and functions from earlier chunks, via gref's late lookup —
+   * see the current binding, as with the CSE machine's global environment.
+   * Object.create(null): plain dictionary, no prototype pollution concerns
+   * with student-chosen names like "constructor".
+   */
+  readonly globals: Record<string, PyValue> = Object.create(null) as Record<string, PyValue>;
+
+  /** Guarded read of a module-level binding: a name whose binding statement
+   * never executed (e.g. defined only in a not-taken branch) is a NameError,
+   * as in Python — undefined is not a PyValue, so the check is exact. */
+  gref(name: string): PyValue {
+    const v = this.globals[name];
+    if (v === undefined) {
+      this.nameErr(name);
+    }
+    return v;
+  }
+
+  /** A module-level name whose binding never executed (compiled reads guard
+   * with `=== undefined`; see emitName in compiler.ts). */
+  nameErr(name: string): never {
+    throw new Py2JsRuntimeError("NameError", `name '${name}' is not defined`);
+  }
+
+  /** A function-local read before its assignment executed — CPython's
+   * UnboundLocalError (the CSE machine raises the same; compiled reads of
+   * non-parameter locals guard with `=== undefined`). */
+  unboundErr(name: string): never {
+    throw new Py2JsRuntimeError(
+      "UnboundLocalError",
+      `local variable '${name}' referenced before assignment`,
+    );
+  }
+
   /** None singleton alias so compiled code can say __py.None. */
   readonly None = null;
 
@@ -507,7 +551,9 @@ export class Py2JsRuntime {
     print: this.builtin("print", -1, (...args) => {
       // Same formatting as the stdlib's print: str() of each argument,
       // space-joined, one trailing newline (pyStr mirrors toPythonString).
-      this.output.push(args.map(pyStr).join(" ") + "\n");
+      const line = args.map(pyStr).join(" ");
+      this.output.push(line + "\n");
+      this.onOutput?.(line);
       return null;
     }),
     input: this.builtin("input", -1, () => {

--- a/src/tests/Py2JsEvaluator.test.ts
+++ b/src/tests/Py2JsEvaluator.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Conductor-evaluator tests for py2js (mirrors PyPvmlEvaluator.test.ts).
+ *
+ * The interesting py2js-specific behavior is chunk persistence through the
+ * runtime's module-level globals table (REPL compile mode): later chunks see
+ * earlier bindings, earlier functions see later *redefinitions* (late
+ * binding, as with the CSE machine's global environment), and reading a name
+ * whose binding never executed raises NameError.
+ */
+import type { IRunnerPlugin } from "@sourceacademy/conductor/runner";
+import { Py2JsEvaluator1 } from "../conductor/Py2JsEvaluator";
+
+/** Minimal IRunnerPlugin mock: the evaluator only ever calls sendResult/
+ * sendError/sendOutput on its `conductor`. */
+function makeMockConductor() {
+  const results: unknown[] = [];
+  const errors: { name: string; message: string }[] = [];
+  const outputs: string[] = [];
+  const conductor = {
+    sendResult: (r: unknown) => results.push(r),
+    sendError: (e: unknown) => errors.push(e as { name: string; message: string }),
+    sendOutput: (m: string) => outputs.push(m),
+  } as unknown as IRunnerPlugin;
+  return { conductor, results, errors, outputs };
+}
+
+describe("Py2JsEvaluator1", () => {
+  test("persists a global variable across evaluateChunk calls", async () => {
+    const { conductor, results, errors, outputs } = makeMockConductor();
+    const evaluator = new Py2JsEvaluator1(conductor);
+
+    await evaluator.evaluateChunk("x = 5\n");
+    await evaluator.evaluateChunk("print(x + 1)\n");
+
+    expect(errors).toEqual([]);
+    // Exec-style: chunks never report a result value; print() is the way to
+    // surface one (same convention as the PVML-in-browser evaluator).
+    expect(results).toEqual([undefined, undefined]);
+    expect(outputs).toEqual(["6"]);
+  });
+
+  test("persists a function definition across evaluateChunk calls", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new Py2JsEvaluator1(conductor);
+
+    await evaluator.evaluateChunk("def f(x):\n    return x * 2\n");
+    await evaluator.evaluateChunk("print(f(21))\n");
+
+    expect(errors).toEqual([]);
+    expect(outputs).toEqual(["42"]);
+  });
+
+  test("earlier functions see later redefinitions (late binding, CSE parity)", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new Py2JsEvaluator1(conductor);
+
+    await evaluator.evaluateChunk("def g():\n    return 1\ndef f():\n    return g()\n");
+    await evaluator.evaluateChunk("print(f())\n");
+    await evaluator.evaluateChunk("def g():\n    return 2\n");
+    await evaluator.evaluateChunk("print(f())\n");
+
+    expect(errors).toEqual([]);
+    expect(outputs).toEqual(["1", "2"]);
+  });
+
+  test("an erroring chunk reports through sendError and does not kill the session", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new Py2JsEvaluator1(conductor);
+
+    await evaluator.evaluateChunk("x = 10\n");
+    await evaluator.evaluateChunk("print(1 / 0)\n");
+    await evaluator.evaluateChunk("print(x)\n");
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].name).toBe("ZeroDivisionError");
+    expect(outputs).toEqual(["10"]);
+  });
+
+  test("undefined names are analysis errors; never-executed bindings are NameErrors", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new Py2JsEvaluator1(conductor);
+
+    // Statically unknown name: rejected by the resolver.
+    await evaluator.evaluateChunk("print(nope)\n");
+    expect(errors).toHaveLength(1);
+
+    // Bound at top level but only in a not-taken branch: known to the
+    // resolver within the chunk, but reading it at runtime is a NameError.
+    await evaluator.evaluateChunk("if 1 > 2:\n    y = 1\nprint(y)\n");
+    expect(errors).toHaveLength(2);
+    expect(errors[1].name).toBe("NameError");
+    expect(outputs).toEqual([]);
+  });
+
+  test("deep tail recursion works across chunks (trampoline in REPL mode)", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new Py2JsEvaluator1(conductor);
+
+    await evaluator.evaluateChunk(
+      "def count(n, acc):\n    return acc if n == 0 else count(n - 1, acc + n)\n",
+    );
+    await evaluator.evaluateChunk("print(count(1000000, 0))\n");
+
+    expect(errors).toEqual([]);
+    expect(outputs).toEqual(["500000500000"]);
+  });
+
+  test("bridged stdlib and chapter-1 validators are active per chunk", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new Py2JsEvaluator1(conductor);
+
+    await evaluator.evaluateChunk("print(abs(complex(-3, 4)))\n");
+    // `is` is rejected at chapter 1 by the validators.
+    await evaluator.evaluateChunk("print(1 is 1)\n");
+
+    expect(outputs).toEqual(["5.0"]);
+    expect(errors).toHaveLength(1);
+  });
+
+  test("multi-line prints stream one sendOutput per print call", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new Py2JsEvaluator1(conductor);
+
+    await evaluator.evaluateChunk('print(1)\nprint("a", "b")\nprint()\n');
+
+    expect(errors).toEqual([]);
+    expect(outputs).toEqual(["1", "a b", ""]);
+  });
+});

--- a/src/tests/py2js-unbound.test.ts
+++ b/src/tests/py2js-unbound.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unbound-name semantics parity: Python's environments grow dynamically (no
+ * TDZ), but reading a binding whose assignment never executed is an error —
+ * UnboundLocalError for function locals, NameError at module level. The CSE
+ * machine implements this; py2js compiles guarded reads (see emitName in
+ * engines/py2js/compiler.ts) because JS `let` would otherwise leak a silent
+ * `undefined`. Each case runs on both engines and must agree on
+ * success-vs-error; the error kind is asserted on the py2js side.
+ */
+import { Py2JsRunError, runCodePy2Js } from "../engines/py2js";
+import { RunError, runCode } from "../runner";
+
+async function cseErrors(code: string): Promise<boolean> {
+  try {
+    await runCode(code, 1);
+    return false;
+  } catch (e) {
+    if (e instanceof RunError) return true;
+    throw e;
+  }
+}
+
+function py2jsOutcome(code: string): { error: string } | { output: string } {
+  try {
+    return { output: runCodePy2Js(code, 1).output };
+  } catch (e) {
+    if (e instanceof Py2JsRunError) return { error: e.message };
+    throw e;
+  }
+}
+
+test("local read before assignment is an UnboundLocalError (CSE parity)", async () => {
+  const code = `def f():
+    y = x
+    x = 1
+    return y
+x = 5
+print(f())`;
+  expect(await cseErrors(code)).toBe(true);
+  const outcome = py2jsOutcome(code);
+  expect(outcome).toHaveProperty("error");
+  expect((outcome as { error: string }).error).toContain("UnboundLocalError");
+});
+
+test("local bound only in a not-taken branch is an UnboundLocalError (CSE parity)", async () => {
+  const code = `def f(c):
+    if c:
+        x = 1
+    return x
+print(f(False))`;
+  expect(await cseErrors(code)).toBe(true);
+  const outcome = py2jsOutcome(code);
+  expect(outcome).toHaveProperty("error");
+  expect((outcome as { error: string }).error).toContain("UnboundLocalError");
+});
+
+test("module-level name bound only in a not-taken branch is a NameError (CSE parity)", async () => {
+  const code = `if 1 > 2:
+    y = 1
+print(y)`;
+  expect(await cseErrors(code)).toBe(true);
+  const outcome = py2jsOutcome(code);
+  expect(outcome).toHaveProperty("error");
+  expect((outcome as { error: string }).error).toContain("NameError");
+});
+
+test("assigning the same local in both if/else arms is NameReassignmentError at §1 (CSE parity)", async () => {
+  // Source §1's no-reassignment rule is const-like: the second arm's
+  // assignment counts as a reassignment even though the arms are exclusive.
+  // Both engines run the same validators, so both reject identically.
+  const code = `def f(c):
+    if c:
+        x = 1
+    else:
+        x = 2
+    return x
+print(f(True), f(False))`;
+  expect(await cseErrors(code)).toBe(true);
+  const outcome = py2jsOutcome(code);
+  expect(outcome).toHaveProperty("error");
+  expect((outcome as { error: string }).error).toContain("NameReassignmentError");
+});
+
+test("the taken branch binds normally on both engines", async () => {
+  const code = `def f(c):
+    if c:
+        x = 1
+    return x
+print(f(True))`;
+  expect(await cseErrors(code)).toBe(false);
+  expect(py2jsOutcome(code)).toEqual({ output: "1\n" });
+});
+
+test("closures reading enclosing locals stay unguarded-correct", async () => {
+  const code = `def outer():
+    n = 10
+    def inner():
+        return n + 1
+    return inner()
+print(outer())`;
+  expect(await cseErrors(code)).toBe(false);
+  expect(py2jsOutcome(code)).toEqual({ output: "11\n" });
+});

--- a/src/tests/py2js-unbound.test.ts
+++ b/src/tests/py2js-unbound.test.ts
@@ -54,6 +54,22 @@ print(f(False))`;
   expect((outcome as { error: string }).error).toContain("UnboundLocalError");
 });
 
+test("calling a function before the module-level global it reads is assigned is a NameError (CSE parity)", async () => {
+  // Pure temporal ordering, no branch involved: f() runs before `x = 5` has
+  // ever executed. Python resolves a function's global reads dynamically at
+  // call time (not at def time), so this is a runtime NameError, not a
+  // static one — the resolver already knows `x` is a module-level name (it
+  // is bound later in this same chunk), it just hasn't been written yet.
+  const code = `def f():
+    return x
+print(f())
+x = 5`;
+  expect(await cseErrors(code)).toBe(true);
+  const outcome = py2jsOutcome(code);
+  expect(outcome).toHaveProperty("error");
+  expect((outcome as { error: string }).error).toContain("NameError");
+});
+
 test("module-level name bound only in a not-taken branch is a NameError (CSE parity)", async () => {
   const code = `if 1 > 2:
     y = 1


### PR DESCRIPTION
## Summary

Stacked on #282. Step 2 of the chapter-1 depth work: py2js gets a conductor evaluator, mirroring `PyPvmlEvaluatorBase`'s persistence model.

- **`Py2JsSession`** (`engines/py2js/index.ts`) — a persistent session: chunks share one runtime and one module-level globals table; group preludes (none at chapter 1) compile into the same session on first use. `runChunk` throws underlying errors raw so `EvaluatorError` keeps names and source locations.
- **REPL compile mode** (`compiler.ts`) — chunk top-level bindings live in the runtime's globals *dictionary* (direct stores, guarded reads via `__py.gref`) instead of `let` declarations. Like Python's globals dict — and unlike JS script scope — there is **no TDZ**: the table grows dynamically and reads are late-bound, so a function defined in chunk 1 sees a helper *redefined* in chunk 3, matching the CSE machine's global environment. (Freezing values into per-chunk consts, as js-slang's transpiler does, would silently diverge from CSE semantics on redefinition.) Reading a name whose binding statement never executed raises `NameError`.
- **Unbound-read guards** (both compile modes) — found while answering the TDZ question: JS `let` initializes to `undefined` where Python raises, so a function local read before its assignment executed leaked a silent `undefined` (printed as `None`) where the CSE machine raises `UnboundLocalError`. Every read of a non-parameter local (and of program-mode top-level names) now compiles to an inline `=== undefined` guard raising `UnboundLocalError` / `NameError`; `undefined` is not a `PyValue`, so the check is exact, and parameters (always bound) stay unguarded — the hot paths (`fib` etc.) are unaffected.
- **`Py2JsEvaluator1`** (`conductor/Py2JsEvaluator.ts`) — exec-style like the PVML-in-browser evaluator: chunks report no result value; `print()` streams one `sendOutput` per line via the session's `onOutput` hook. Exported from `conductor/index.ts` and registered in `scripts/build.ts`; the rollup bundles (`dist/Py2JsEvaluator1.{js,cjs}`) build cleanly.

## Test plan

- `Py2JsEvaluator.test.ts` (new, mirrors `PyPvmlEvaluator.test.ts`): variable/function persistence across chunks, late-binding redefinition, error recovery within a session, analysis-vs-runtime `NameError` distinction, cross-chunk tail recursion at depth 1 000 000, bridged stdlib + §1 validators per chunk, per-print output streaming
- `py2js-unbound.test.ts` (new): `UnboundLocalError`/`NameError` parity against the CSE machine, including Source §1's const-like `NameReassignmentError` when both `if`/`else` arms assign the same local
- Full suite green: 44 suites, 15 799 tests (operator + stdlib sweeps re-verified against the guarded codegen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbExZBaxgeUL4oi1t7PG93