### PR TITLE
py2js: from X import y module loading (dual mode + real conductor channels)

### DIFF
--- a/src/conductor/GenericDataHandler.ts
+++ b/src/conductor/GenericDataHandler.ts
@@ -392,9 +392,15 @@ export function asInterfacableEvaluator(
 ): IInterfacableEvaluator {
   return new Proxy(evaluator, {
     get(target, prop, receiver) {
-      return prop in dataHandler
-        ? Reflect.get(dataHandler, prop, dataHandler)
-        : Reflect.get(target, prop, receiver);
+      if (prop in dataHandler) {
+        // Bind so stateful methods (this.uniqueId++ in pair_make etc.) read
+        // and write dataHandler, not the proxy — a plain Reflect.get returns
+        // the method unbound, so calling it here would set `this` to the
+        // proxy and (absent a `set` trap) silently write to `evaluator`.
+        const value = Reflect.get(dataHandler, prop, dataHandler);
+        return typeof value === "function" ? value.bind(dataHandler) : value;
+      }
+      return Reflect.get(target, prop, receiver);
     },
   }) as unknown as IInterfacableEvaluator;
 }

--- a/src/conductor/GenericDataHandler.ts
+++ b/src/conductor/GenericDataHandler.ts
@@ -1,0 +1,400 @@
+import type { IEvaluator, IInterfacableEvaluator } from "@sourceacademy/conductor/runner";
+import {
+  ArrayIdentifier,
+  ClosureIdentifier,
+  DataType,
+  ExternCallable,
+  IDataHandler,
+  IFunctionSignature,
+  OpaqueIdentifier,
+  PairIdentifier,
+  TypedValue,
+} from "@sourceacademy/conductor/types";
+
+/**
+ * A conductor `IDataHandler` implementation with no engine-specific logic:
+ * pairs, arrays, closures and opaques are all just bookkeeping over plain
+ * Maps keyed by an incrementing id, and the list helpers (`list`/`is_list`/
+ * `list_to_vec`/`accumulate`/`length`) walk that pair structure generically.
+ * The only place an engine's own semantics enter the picture is the
+ * `ExternCallable` passed to `closure_make` (authored by that engine's own
+ * module-interop layer) and the arguments/results flowing through
+ * `closure_call`/`closure_call_unchecked` — this class never inspects them.
+ *
+ * Originally written inline in PyCseEvaluatorBase (see PyCseEvaluator.ts);
+ * extracted so every evaluator that talks to conductor modules (CSE, py2js,
+ * and eventually WASM/PVML) shares one implementation instead of
+ * re-deriving the same identifier-table bookkeeping per engine. An evaluator
+ * holds one instance (`private dataHandler = new GenericDataHandler()`) and
+ * hands it to both `context.evaluator` (or the engine's equivalent) and
+ * `conductor.registerPlugin(ModuleLoaderRunnerPlugin, conductor, dataHandler)`.
+ */
+export class GenericDataHandler implements IDataHandler {
+  hasDataInterface = true as const;
+  private pairMap = new Map<
+    PairIdentifier,
+    { head: TypedValue<DataType>; tail: TypedValue<DataType> }
+  >();
+  private arrayMap = new Map<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ArrayIdentifier<any>,
+    { type: DataType; elements: TypedValue<DataType>[] }
+  >();
+  private closureMap = new Map<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ClosureIdentifier<any>,
+    {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sig: IFunctionSignature<any, any>;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      func: ExternCallable<any, any>;
+      dependsOn?: (TypedValue<DataType> | null)[];
+      isVararg?: boolean;
+    }
+  >();
+  private opaqueMap = new Map<OpaqueIdentifier, { value: unknown; immutable: boolean }>();
+  private uniqueId = 0;
+  pair_make(
+    head: TypedValue<DataType>,
+    tail: TypedValue<DataType>,
+  ): Promise<TypedValue<DataType.PAIR>> {
+    this.pairMap.set(this.uniqueId++ as PairIdentifier, { head, tail });
+    return Promise.resolve({ type: DataType.PAIR, value: (this.uniqueId - 1) as PairIdentifier });
+  }
+  pair_head(p: TypedValue<DataType.PAIR>): Promise<TypedValue<DataType>> {
+    const pair = this.pairMap.get(p.value);
+    if (!pair) {
+      throw new Error(`Invalid pair identifier: ${p.value}`);
+    }
+    return Promise.resolve(pair.head);
+  }
+  pair_sethead(p: TypedValue<DataType.PAIR>, tv: TypedValue<DataType>): Promise<void> {
+    const pair = this.pairMap.get(p.value);
+    if (!pair) {
+      throw new Error(`Invalid pair identifier: ${p.value}`);
+    }
+    pair.head = tv;
+    return Promise.resolve();
+  }
+  pair_tail(p: TypedValue<DataType.PAIR>): Promise<TypedValue<DataType>> {
+    const pair = this.pairMap.get(p.value);
+    if (!pair) {
+      throw new Error(`Invalid pair identifier: ${p.value}`);
+    }
+    return Promise.resolve(pair.tail);
+  }
+  pair_settail(p: TypedValue<DataType.PAIR>, tv: TypedValue<DataType>): Promise<void> {
+    const pair = this.pairMap.get(p.value);
+    if (!pair) {
+      throw new Error(`Invalid pair identifier: ${p.value}`);
+    }
+    pair.tail = tv;
+    return Promise.resolve();
+  }
+  pair_assert(
+    p: TypedValue<DataType.PAIR>,
+    headType?: DataType,
+    tailType?: DataType,
+  ): Promise<void> {
+    const pair = this.pairMap.get(p.value);
+    if (!pair) {
+      throw new Error(`Invalid pair identifier: ${p.value}`);
+    }
+    if (headType && pair.head.type !== headType) {
+      throw new Error(`Expected head of type ${headType}, got ${pair.head.type}`);
+    }
+    if (tailType && pair.tail.type !== tailType) {
+      throw new Error(`Expected tail of type ${tailType}, got ${pair.tail.type}`);
+    }
+    return Promise.resolve();
+  }
+  array_make<T extends DataType>(
+    t: T,
+    len: number,
+    init?: TypedValue<NoInfer<T>>,
+  ): Promise<TypedValue<DataType.ARRAY, NoInfer<T>>> {
+    const elements = new Array(len).fill(init ?? { type: t, value: undefined }) as TypedValue<
+      NoInfer<T>
+    >[];
+    const arrayValue: TypedValue<DataType.ARRAY, NoInfer<T>> = {
+      type: DataType.ARRAY,
+      value: this.uniqueId++ as ArrayIdentifier<typeof t>,
+    };
+    this.arrayMap.set(arrayValue.value, { type: t, elements });
+    return Promise.resolve(arrayValue);
+  }
+  array_length(a: TypedValue<DataType.ARRAY>): Promise<number> {
+    const array = this.arrayMap.get(a.value);
+    if (!array) {
+      throw new Error(`Invalid array identifier: ${a.value}`);
+    }
+    return Promise.resolve(array.elements.length);
+  }
+  array_get<T extends DataType>(
+    a: TypedValue<DataType.ARRAY, T>,
+    idx: number,
+  ): Promise<TypedValue<NoInfer<T>>>;
+  array_get(
+    a: TypedValue<DataType.ARRAY, DataType.VOID>,
+    idx: number,
+  ): Promise<TypedValue<DataType>> {
+    const array = this.arrayMap.get(a.value);
+
+    if (!array) {
+      throw new Error(`Invalid array identifier: ${a.value}`);
+    }
+
+    if (idx < 0 || idx >= array.elements.length) {
+      throw new Error(`Index out of bounds: ${idx}`);
+    }
+
+    const value = array.elements[idx];
+
+    if (!value) {
+      throw new Error(`Missing element at index ${idx}`);
+    }
+
+    return Promise.resolve(value);
+  }
+
+  array_type<T extends DataType>(a: TypedValue<DataType.ARRAY, T>): Promise<NoInfer<T>> {
+    const array = this.arrayMap.get(a.value);
+    if (array === undefined) {
+      throw new Error(`Invalid array identifier: ${a.value}`);
+    }
+    return Promise.resolve(array.type as NoInfer<T>);
+  }
+  array_set(
+    a: TypedValue<DataType.ARRAY, DataType.VOID>,
+    idx: number,
+    tv: TypedValue<DataType>,
+  ): Promise<void>;
+  array_set<T extends DataType>(
+    a: TypedValue<DataType.ARRAY, T>,
+    idx: number,
+    tv: TypedValue<NoInfer<T>>,
+  ): Promise<void> {
+    const array = this.arrayMap.get(a.value) as
+      | { type: T; elements: TypedValue<NoInfer<T>>[] }
+      | undefined;
+
+    if (!array) {
+      throw new Error(`Invalid array identifier: ${a.value}`);
+    }
+
+    if (idx < 0 || idx >= array.elements.length) {
+      throw new Error(`Index out of bounds: ${idx}`);
+    }
+
+    array.elements[idx] = tv;
+
+    return Promise.resolve();
+  }
+  array_assert<T extends DataType>(
+    a: TypedValue<DataType.ARRAY>,
+    type?: T,
+    length?: number,
+  ): Promise<void> {
+    const array = this.arrayMap.get(a.value);
+    if (!array) {
+      throw new Error(`Invalid array identifier: ${a.value}`);
+    }
+    if (type !== undefined && array.type !== type) {
+      throw new Error(`Expected array of type ${type}, got ${array.type}`);
+    }
+    if (length !== undefined && array.elements.length !== length) {
+      throw new Error(`Expected array of length ${length}, got ${array.elements.length}`);
+    }
+    return Promise.resolve();
+  }
+  closure_make<const Arg extends readonly DataType[], const Ret extends DataType>(
+    sig: IFunctionSignature<Arg, Ret>,
+    func: ExternCallable<Arg, Ret>,
+    dependsOn?: (TypedValue<DataType> | null)[],
+  ): Promise<TypedValue<DataType.CLOSURE, Ret>> {
+    const closureValue: TypedValue<DataType.CLOSURE, Ret> = {
+      type: DataType.CLOSURE,
+      value: this.uniqueId++ as ClosureIdentifier<Ret>,
+    };
+    this.closureMap.set(closureValue.value, { sig, func, dependsOn });
+    return Promise.resolve(closureValue);
+  }
+  closure_is_vararg(c: TypedValue<DataType.CLOSURE>): Promise<boolean> {
+    return Promise.resolve(this.closureMap.get(c.value)?.isVararg ?? false);
+  }
+  closure_arity(c: TypedValue<DataType.CLOSURE>): Promise<number> {
+    return Promise.resolve(this.closureMap.get(c.value)?.sig.args.length ?? 0);
+  }
+  closure_call<T extends DataType>(
+    c: TypedValue<DataType.CLOSURE, T>,
+    args: TypedValue<DataType>[],
+    returnType: T,
+  ): AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined> {
+    const closure = this.closureMap.get(c.value);
+    if (closure === undefined) {
+      throw new Error(`Invalid closure identifier: ${c.value}`);
+    }
+    if (closure.sig.returnType !== returnType) {
+      throw new Error(`Expected return type ${returnType}, got ${closure.sig.returnType}`);
+    }
+    return closure.func(...args) as AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined>;
+  }
+  closure_call_unchecked<T extends DataType>(
+    c: TypedValue<DataType.CLOSURE, T>,
+    args: TypedValue<DataType>[],
+  ): AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined> {
+    return this.closureMap.get(c.value)?.func(...args) as AsyncGenerator<
+      void,
+      TypedValue<NoInfer<T>>,
+      undefined
+    >;
+  }
+  closure_arity_assert(c: TypedValue<DataType.CLOSURE>, arity: number): Promise<void> {
+    const closure = this.closureMap.get(c.value);
+    if (!closure) {
+      throw new Error(`Invalid closure identifier: ${c.value}`);
+    }
+    if (closure.sig.args.length !== arity && !closure.isVararg) {
+      throw new Error(`Expected closure of arity ${arity}, got ${closure.sig.args.length}`);
+    }
+    return Promise.resolve();
+  }
+  opaque_make(v: unknown, immutable?: boolean): Promise<TypedValue<DataType.OPAQUE>> {
+    const opaqueValue: TypedValue<DataType.OPAQUE> = {
+      type: DataType.OPAQUE,
+      value: this.uniqueId++ as OpaqueIdentifier,
+    };
+    this.opaqueMap.set(opaqueValue.value, { value: v, immutable: immutable || false });
+    return Promise.resolve(opaqueValue);
+  }
+  opaque_get(o: TypedValue<DataType.OPAQUE>): Promise<unknown> {
+    const opaque = this.opaqueMap.get(o.value);
+    if (!opaque) {
+      throw new Error(`Invalid opaque identifier: ${o.value}`);
+    }
+    return Promise.resolve(opaque.value);
+  }
+  opaque_update(o: TypedValue<DataType.OPAQUE>, v: unknown): Promise<void> {
+    const opaque = this.opaqueMap.get(o.value);
+    if (!opaque) {
+      throw new Error(`Invalid opaque identifier: ${o.value}`);
+    }
+    if (opaque.immutable) {
+      throw new Error(`Cannot update immutable opaque value with identifier: ${o.value}`);
+    }
+    opaque.value = v;
+    return Promise.resolve();
+  }
+  tie(_dependent: TypedValue<DataType>, _dependee: TypedValue<DataType> | null): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+  untie(_dependent: TypedValue<DataType>, _dependee: TypedValue<DataType> | null): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+  async list(...elements: TypedValue<DataType>[]): Promise<TypedValue<DataType.LIST>> {
+    const list = await elements.reduceRight(
+      async (acc, el) => {
+        return this.pair_make(el, await acc);
+      },
+      Promise.resolve({ type: DataType.EMPTY_LIST, value: null }) as Promise<
+        TypedValue<DataType.LIST>
+      >,
+    );
+    return list;
+  }
+  is_list(xs: TypedValue<DataType.LIST>): Promise<boolean> {
+    let current: TypedValue<DataType> = xs;
+    while (current.type !== DataType.EMPTY_LIST) {
+      if (current.type !== DataType.PAIR) {
+        return Promise.resolve(false);
+      }
+      const pair = this.pairMap.get(current.value);
+      if (pair === undefined) {
+        return Promise.resolve(false);
+      }
+      current = pair.tail;
+    }
+    return Promise.resolve(true);
+  }
+  list_to_vec(xs: TypedValue<DataType.LIST>): Promise<TypedValue<DataType>[]> {
+    return new Promise((resolve, reject) => {
+      const result: TypedValue<DataType>[] = [];
+      let current: TypedValue<DataType> = xs;
+      while (current.type !== DataType.EMPTY_LIST) {
+        if (current.type !== DataType.PAIR) {
+          reject(new Error(`Expected a list, got type ${current.type}`));
+          return;
+        }
+        const pair = this.pairMap.get(current.value);
+        if (!pair) {
+          reject(new Error(`Invalid pair identifier: ${current.value}`));
+          return;
+        }
+        result.push(pair.head);
+        current = pair.tail;
+      }
+      resolve(result);
+    });
+  }
+  async *accumulate<T extends Exclude<DataType, DataType.VOID>>(
+    op: TypedValue<DataType.CLOSURE, T>,
+    initial: TypedValue<T>,
+    sequence: TypedValue<DataType.LIST>,
+    _resultType: T,
+  ): AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined> {
+    let acc = initial;
+    let current: TypedValue<DataType> = sequence;
+    while (current.type !== DataType.EMPTY_LIST) {
+      if (current.type !== DataType.PAIR) {
+        throw new Error(`Expected a list, got type ${current.type}`);
+      }
+      const pair = this.pairMap.get(current.value);
+      if (!pair) {
+        throw new Error(`Invalid pair identifier: ${current.value}`);
+      }
+      acc = yield* this.closure_call_unchecked(op, [acc, pair.head]);
+      current = pair.tail;
+    }
+    return acc;
+  }
+  length(xs: TypedValue<DataType.LIST>): Promise<number> {
+    let length = 0;
+    let current: TypedValue<DataType> = xs;
+    while (current.type !== DataType.EMPTY_LIST) {
+      if (current.type !== DataType.PAIR) {
+        throw new Error(`Expected a list, got type ${current.type}`);
+      }
+      const pair = this.pairMap.get(current.value);
+      if (!pair) {
+        throw new Error(`Invalid pair identifier: ${current.value}`);
+      }
+      length++;
+      current = pair.tail;
+    }
+    return Promise.resolve(length);
+  }
+}
+
+/**
+ * `ModuleLoaderRunnerPlugin`'s constructor requires a single object
+ * satisfying `IInterfacableEvaluator` (`IEvaluator & IDataHandler`) — but an
+ * evaluator built around `GenericDataHandler` has those two halves on two
+ * different objects (the evaluator itself, extending `BasicEvaluator`, is
+ * the `IEvaluator`; its `dataHandler` field is the `IDataHandler`). A Proxy
+ * combines them into the one object the registration call needs, so
+ * combining stays a one-line call at each registration site instead of ~20
+ * lines of per-evaluator forwarding methods duplicated alongside the
+ * bookkeeping this class already centralizes.
+ */
+export function asInterfacableEvaluator(
+  evaluator: IEvaluator,
+  dataHandler: GenericDataHandler,
+): IInterfacableEvaluator {
+  return new Proxy(evaluator, {
+    get(target, prop, receiver) {
+      return prop in dataHandler
+        ? Reflect.get(dataHandler, prop, dataHandler)
+        : Reflect.get(target, prop, receiver);
+    },
+  }) as unknown as IInterfacableEvaluator;
+}

--- a/src/conductor/Py2JsEvaluator.ts
+++ b/src/conductor/Py2JsEvaluator.ts
@@ -1,5 +1,7 @@
 import { BasicEvaluator, IRunnerPlugin } from "@sourceacademy/conductor/runner";
+import { ModuleLoaderRunnerPlugin } from "@sourceacademy/runner-module-loader";
 import { Py2JsSession } from "../engines/py2js";
+import { asInterfacableEvaluator, GenericDataHandler } from "./GenericDataHandler";
 import { EvaluatorError } from "./errors";
 
 /**
@@ -16,6 +18,15 @@ import { EvaluatorError } from "./errors";
  * environment. Group preludes (none at chapter 1) are compiled into the same
  * session by its first runChunk().
  *
+ * Module loading (`from X import y`): the session is handed a
+ * GenericDataHandler — the same engine-agnostic IDataHandler implementation
+ * PyCseEvaluatorBase uses — and this evaluator registers
+ * ModuleLoaderRunnerPlugin with that same instance, exactly mirroring
+ * PyCseEvaluatorBase's own registration. A chunk that imports something is
+ * loaded and converted (moduleInterop.ts) before it compiles, and compiles in
+ * dual mode so its imported module functions are callable via the session's
+ * async spine.
+ *
  * Exec-style, like the PVML-in-browser evaluator: every chunk reports no
  * result value; a chunk that wants to surface a value print()s it. Output
  * streams per print() line through the session's onOutput hook.
@@ -28,19 +39,25 @@ abstract class Py2JsEvaluatorBase extends BasicEvaluator {
 
   protected constructor(conductor: IRunnerPlugin, variant: number) {
     super(conductor);
+    const dataHandler = new GenericDataHandler();
+    this.conductor.registerPlugin(
+      ModuleLoaderRunnerPlugin,
+      this.conductor,
+      asInterfacableEvaluator(this, dataHandler),
+    );
     this.session = new Py2JsSession(variant, {
       onOutput: line => this.conductor.sendOutput(line),
+      dataHandler,
     });
   }
 
-  evaluateChunk(chunk: string): Promise<void> {
+  async evaluateChunk(chunk: string): Promise<void> {
     try {
-      this.session.runChunk(chunk);
+      await this.session.runChunk(chunk);
       this.conductor.sendResult(undefined);
     } catch (e) {
       this.conductor.sendError(new EvaluatorError(e));
     }
-    return Promise.resolve();
   }
 }
 

--- a/src/conductor/PyCseEvaluator.ts
+++ b/src/conductor/PyCseEvaluator.ts
@@ -1,16 +1,5 @@
 import { ErrorType } from "@sourceacademy/conductor/common";
 import { BasicEvaluator, IRunnerPlugin } from "@sourceacademy/conductor/runner";
-import {
-  ArrayIdentifier,
-  ClosureIdentifier,
-  DataType,
-  ExternCallable,
-  IDataHandler,
-  IFunctionSignature,
-  OpaqueIdentifier,
-  PairIdentifier,
-  TypedValue,
-} from "@sourceacademy/conductor/types";
 import { CseMachinePlugin } from "@sourceacademy/runner-cse-machine";
 import { ModuleLoaderRunnerPlugin } from "@sourceacademy/runner-module-loader";
 import { Context } from "../engines/cse/context";
@@ -34,6 +23,7 @@ import pairmutator from "../stdlib/pairmutator";
 import parser from "../stdlib/parser";
 import stream from "../stdlib/stream";
 import { Group } from "../stdlib/utils";
+import { asInterfacableEvaluator, GenericDataHandler } from "./GenericDataHandler";
 import { collectSnapshots } from "./plugins/PyCseMachinePlugin";
 
 function once<T>(fn: () => Promise<T>): () => Promise<T> {
@@ -45,13 +35,18 @@ function once<T>(fn: () => Promise<T>): () => Promise<T> {
  * The abstract class PyCseEvaluatorBase implements the common logic for all variants of
  * the CSE evaluator, which includes setting up the context, loading preludes, and evaluating chunks of code.
  */
-abstract class PyCseEvaluatorBase extends BasicEvaluator implements IDataHandler {
+abstract class PyCseEvaluatorBase extends BasicEvaluator {
   private context = new Context();
   private readonly variant: number;
   private readonly groups: Group[];
   private readonly preludeText: string;
   private readonly ensurePreludesLoaded: () => Promise<void>;
   private readonly csePlugin: CseMachinePlugin;
+  /** Conductor's module-interop protocol (pairs/arrays/closures/opaques) —
+   * see GenericDataHandler.ts. Engine-agnostic, so this is the same instance
+   * type py2js's evaluator uses; only the pythonToModule/moduleToPython
+   * conversion layer (modules.ts) is CSE-specific. */
+  private readonly dataHandler = new GenericDataHandler();
 
   protected constructor(conductor: IRunnerPlugin, variant: number, groups: Group[]) {
     super(conductor);
@@ -71,7 +66,11 @@ abstract class PyCseEvaluatorBase extends BasicEvaluator implements IDataHandler
         this.context.nativeStorage.builtins.set(name, value);
       }
     }
-    this.conductor.registerPlugin(ModuleLoaderRunnerPlugin, this.conductor, this);
+    this.conductor.registerPlugin(
+      ModuleLoaderRunnerPlugin,
+      this.conductor,
+      asInterfacableEvaluator(this, this.dataHandler),
+    );
 
     this.ensurePreludesLoaded = once(async () => {
       if (this.preludeText.trim()) {
@@ -99,7 +98,7 @@ abstract class PyCseEvaluatorBase extends BasicEvaluator implements IDataHandler
         flushStdout: () => flushOutput(this.conductor),
       };
       this.context.conductor = this.conductor;
-      this.context.evaluator = this;
+      this.context.evaluator = this.dataHandler;
       await this.ensurePreludesLoaded();
 
       const script = chunk + "\n";
@@ -172,349 +171,6 @@ abstract class PyCseEvaluatorBase extends BasicEvaluator implements IDataHandler
     } finally {
       await destroyStreams(this.context);
     }
-  }
-  hasDataInterface = true as const;
-  private pairMap = new Map<
-    PairIdentifier,
-    { head: TypedValue<DataType>; tail: TypedValue<DataType> }
-  >();
-  private arrayMap = new Map<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ArrayIdentifier<any>,
-    { type: DataType; elements: TypedValue<DataType>[] }
-  >();
-  private closureMap = new Map<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ClosureIdentifier<any>,
-    {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      sig: IFunctionSignature<any, any>;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      func: ExternCallable<any, any>;
-      dependsOn?: (TypedValue<DataType> | null)[];
-      isVararg?: boolean;
-    }
-  >();
-  private opaqueMap = new Map<OpaqueIdentifier, { value: unknown; immutable: boolean }>();
-  private uniqueId = 0;
-  pair_make(
-    head: TypedValue<DataType>,
-    tail: TypedValue<DataType>,
-  ): Promise<TypedValue<DataType.PAIR>> {
-    this.pairMap.set(this.uniqueId++ as PairIdentifier, { head, tail });
-    return Promise.resolve({ type: DataType.PAIR, value: (this.uniqueId - 1) as PairIdentifier });
-  }
-  pair_head(p: TypedValue<DataType.PAIR>): Promise<TypedValue<DataType>> {
-    const pair = this.pairMap.get(p.value);
-    if (!pair) {
-      throw new Error(`Invalid pair identifier: ${p.value}`);
-    }
-    return Promise.resolve(pair.head);
-  }
-  pair_sethead(p: TypedValue<DataType.PAIR>, tv: TypedValue<DataType>): Promise<void> {
-    const pair = this.pairMap.get(p.value);
-    if (!pair) {
-      throw new Error(`Invalid pair identifier: ${p.value}`);
-    }
-    pair.head = tv;
-    return Promise.resolve();
-  }
-  pair_tail(p: TypedValue<DataType.PAIR>): Promise<TypedValue<DataType>> {
-    const pair = this.pairMap.get(p.value);
-    if (!pair) {
-      throw new Error(`Invalid pair identifier: ${p.value}`);
-    }
-    return Promise.resolve(pair.tail);
-  }
-  pair_settail(p: TypedValue<DataType.PAIR>, tv: TypedValue<DataType>): Promise<void> {
-    const pair = this.pairMap.get(p.value);
-    if (!pair) {
-      throw new Error(`Invalid pair identifier: ${p.value}`);
-    }
-    pair.tail = tv;
-    return Promise.resolve();
-  }
-  pair_assert(
-    p: TypedValue<DataType.PAIR>,
-    headType?: DataType,
-    tailType?: DataType,
-  ): Promise<void> {
-    const pair = this.pairMap.get(p.value);
-    if (!pair) {
-      throw new Error(`Invalid pair identifier: ${p.value}`);
-    }
-    if (headType && pair.head.type !== headType) {
-      throw new Error(`Expected head of type ${headType}, got ${pair.head.type}`);
-    }
-    if (tailType && pair.tail.type !== tailType) {
-      throw new Error(`Expected tail of type ${tailType}, got ${pair.tail.type}`);
-    }
-    return Promise.resolve();
-  }
-  array_make<T extends DataType>(
-    t: T,
-    len: number,
-    init?: TypedValue<NoInfer<T>>,
-  ): Promise<TypedValue<DataType.ARRAY, NoInfer<T>>> {
-    const elements = new Array(len).fill(init ?? { type: t, value: undefined }) as TypedValue<
-      NoInfer<T>
-    >[];
-    const arrayValue: TypedValue<DataType.ARRAY, NoInfer<T>> = {
-      type: DataType.ARRAY,
-      value: this.uniqueId++ as ArrayIdentifier<typeof t>,
-    };
-    this.arrayMap.set(arrayValue.value, { type: t, elements });
-    return Promise.resolve(arrayValue);
-  }
-  array_length(a: TypedValue<DataType.ARRAY>): Promise<number> {
-    const array = this.arrayMap.get(a.value);
-    if (!array) {
-      throw new Error(`Invalid array identifier: ${a.value}`);
-    }
-    return Promise.resolve(array.elements.length);
-  }
-  array_get<T extends DataType>(
-    a: TypedValue<DataType.ARRAY, T>,
-    idx: number,
-  ): Promise<TypedValue<NoInfer<T>>>;
-  array_get(
-    a: TypedValue<DataType.ARRAY, DataType.VOID>,
-    idx: number,
-  ): Promise<TypedValue<DataType>> {
-    const array = this.arrayMap.get(a.value);
-
-    if (!array) {
-      throw new Error(`Invalid array identifier: ${a.value}`);
-    }
-
-    if (idx < 0 || idx >= array.elements.length) {
-      throw new Error(`Index out of bounds: ${idx}`);
-    }
-
-    const value = array.elements[idx];
-
-    if (!value) {
-      throw new Error(`Missing element at index ${idx}`);
-    }
-
-    return Promise.resolve(value);
-  }
-
-  array_type<T extends DataType>(a: TypedValue<DataType.ARRAY, T>): Promise<NoInfer<T>> {
-    const array = this.arrayMap.get(a.value);
-    if (array === undefined) {
-      throw new Error(`Invalid array identifier: ${a.value}`);
-    }
-    return Promise.resolve(array.type as NoInfer<T>);
-  }
-  array_set(
-    a: TypedValue<DataType.ARRAY, DataType.VOID>,
-    idx: number,
-    tv: TypedValue<DataType>,
-  ): Promise<void>;
-  array_set<T extends DataType>(
-    a: TypedValue<DataType.ARRAY, T>,
-    idx: number,
-    tv: TypedValue<NoInfer<T>>,
-  ): Promise<void> {
-    const array = this.arrayMap.get(a.value) as
-      | { type: T; elements: TypedValue<NoInfer<T>>[] }
-      | undefined;
-
-    if (!array) {
-      throw new Error(`Invalid array identifier: ${a.value}`);
-    }
-
-    if (idx < 0 || idx >= array.elements.length) {
-      throw new Error(`Index out of bounds: ${idx}`);
-    }
-
-    array.elements[idx] = tv;
-
-    return Promise.resolve();
-  }
-  array_assert<T extends DataType>(
-    a: TypedValue<DataType.ARRAY>,
-    type?: T,
-    length?: number,
-  ): Promise<void> {
-    const array = this.arrayMap.get(a.value);
-    if (!array) {
-      throw new Error(`Invalid array identifier: ${a.value}`);
-    }
-    if (type !== undefined && array.type !== type) {
-      throw new Error(`Expected array of type ${type}, got ${array.type}`);
-    }
-    if (length !== undefined && array.elements.length !== length) {
-      throw new Error(`Expected array of length ${length}, got ${array.elements.length}`);
-    }
-    return Promise.resolve();
-  }
-  closure_make<const Arg extends readonly DataType[], const Ret extends DataType>(
-    sig: IFunctionSignature<Arg, Ret>,
-    func: ExternCallable<Arg, Ret>,
-    dependsOn?: (TypedValue<DataType> | null)[],
-  ): Promise<TypedValue<DataType.CLOSURE, Ret>> {
-    const closureValue: TypedValue<DataType.CLOSURE, Ret> = {
-      type: DataType.CLOSURE,
-      value: this.uniqueId++ as ClosureIdentifier<Ret>,
-    };
-    this.closureMap.set(closureValue.value, { sig, func, dependsOn });
-    return Promise.resolve(closureValue);
-  }
-  closure_is_vararg(c: TypedValue<DataType.CLOSURE>): Promise<boolean> {
-    return Promise.resolve(this.closureMap.get(c.value)?.isVararg ?? false);
-  }
-  closure_arity(c: TypedValue<DataType.CLOSURE>): Promise<number> {
-    return Promise.resolve(this.closureMap.get(c.value)?.sig.args.length ?? 0);
-  }
-  closure_call<T extends DataType>(
-    c: TypedValue<DataType.CLOSURE, T>,
-    args: TypedValue<DataType>[],
-    returnType: T,
-  ): AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined> {
-    const closure = this.closureMap.get(c.value);
-    if (closure === undefined) {
-      throw new Error(`Invalid closure identifier: ${c.value}`);
-    }
-    if (closure.sig.returnType !== returnType) {
-      throw new Error(`Expected return type ${returnType}, got ${closure.sig.returnType}`);
-    }
-    return closure.func(...args) as AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined>;
-  }
-  closure_call_unchecked<T extends DataType>(
-    c: TypedValue<DataType.CLOSURE, T>,
-    args: TypedValue<DataType>[],
-  ): AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined> {
-    return this.closureMap.get(c.value)?.func(...args) as AsyncGenerator<
-      void,
-      TypedValue<NoInfer<T>>,
-      undefined
-    >;
-  }
-  closure_arity_assert(c: TypedValue<DataType.CLOSURE>, arity: number): Promise<void> {
-    const closure = this.closureMap.get(c.value);
-    if (!closure) {
-      throw new Error(`Invalid closure identifier: ${c.value}`);
-    }
-    if (closure.sig.args.length !== arity && !closure.isVararg) {
-      throw new Error(`Expected closure of arity ${arity}, got ${closure.sig.args.length}`);
-    }
-    return Promise.resolve();
-  }
-  opaque_make(v: unknown, immutable?: boolean): Promise<TypedValue<DataType.OPAQUE>> {
-    const opaqueValue: TypedValue<DataType.OPAQUE> = {
-      type: DataType.OPAQUE,
-      value: this.uniqueId++ as OpaqueIdentifier,
-    };
-    this.opaqueMap.set(opaqueValue.value, { value: v, immutable: immutable || false });
-    return Promise.resolve(opaqueValue);
-  }
-  opaque_get(o: TypedValue<DataType.OPAQUE>): Promise<unknown> {
-    const opaque = this.opaqueMap.get(o.value);
-    if (!opaque) {
-      throw new Error(`Invalid opaque identifier: ${o.value}`);
-    }
-    return Promise.resolve(opaque.value);
-  }
-  opaque_update(o: TypedValue<DataType.OPAQUE>, v: unknown): Promise<void> {
-    const opaque = this.opaqueMap.get(o.value);
-    if (!opaque) {
-      throw new Error(`Invalid opaque identifier: ${o.value}`);
-    }
-    if (opaque.immutable) {
-      throw new Error(`Cannot update immutable opaque value with identifier: ${o.value}`);
-    }
-    opaque.value = v;
-    return Promise.resolve();
-  }
-  tie(_dependent: TypedValue<DataType>, _dependee: TypedValue<DataType> | null): Promise<void> {
-    throw new Error("Method not implemented.");
-  }
-  untie(_dependent: TypedValue<DataType>, _dependee: TypedValue<DataType> | null): Promise<void> {
-    throw new Error("Method not implemented.");
-  }
-  async list(...elements: TypedValue<DataType>[]): Promise<TypedValue<DataType.LIST>> {
-    const list = await elements.reduceRight(
-      async (acc, el) => {
-        return this.pair_make(el, await acc);
-      },
-      Promise.resolve({ type: DataType.EMPTY_LIST, value: null }) as Promise<
-        TypedValue<DataType.LIST>
-      >,
-    );
-    return list;
-  }
-  is_list(xs: TypedValue<DataType.LIST>): Promise<boolean> {
-    let current: TypedValue<DataType> = xs;
-    while (current.type !== DataType.EMPTY_LIST) {
-      if (current.type !== DataType.PAIR) {
-        return Promise.resolve(false);
-      }
-      const pair = this.pairMap.get(current.value);
-      if (pair === undefined) {
-        return Promise.resolve(false);
-      }
-      current = pair.tail;
-    }
-    return Promise.resolve(true);
-  }
-  list_to_vec(xs: TypedValue<DataType.LIST>): Promise<TypedValue<DataType>[]> {
-    return new Promise((resolve, reject) => {
-      const result: TypedValue<DataType>[] = [];
-      let current: TypedValue<DataType> = xs;
-      while (current.type !== DataType.EMPTY_LIST) {
-        if (current.type !== DataType.PAIR) {
-          reject(new Error(`Expected a list, got type ${current.type}`));
-          return;
-        }
-        const pair = this.pairMap.get(current.value);
-        if (!pair) {
-          reject(new Error(`Invalid pair identifier: ${current.value}`));
-          return;
-        }
-        result.push(pair.head);
-        current = pair.tail;
-      }
-      resolve(result);
-    });
-  }
-  async *accumulate<T extends Exclude<DataType, DataType.VOID>>(
-    op: TypedValue<DataType.CLOSURE, T>,
-    initial: TypedValue<T>,
-    sequence: TypedValue<DataType.LIST>,
-    _resultType: T,
-  ): AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined> {
-    let acc = initial;
-    let current: TypedValue<DataType> = sequence;
-    while (current.type !== DataType.EMPTY_LIST) {
-      if (current.type !== DataType.PAIR) {
-        throw new Error(`Expected a list, got type ${current.type}`);
-      }
-      const pair = this.pairMap.get(current.value);
-      if (!pair) {
-        throw new Error(`Invalid pair identifier: ${current.value}`);
-      }
-      acc = yield* this.closure_call_unchecked(op, [acc, pair.head]);
-      current = pair.tail;
-    }
-    return acc;
-  }
-  length(xs: TypedValue<DataType.LIST>): Promise<number> {
-    let length = 0;
-    let current: TypedValue<DataType> = xs;
-    while (current.type !== DataType.EMPTY_LIST) {
-      if (current.type !== DataType.PAIR) {
-        throw new Error(`Expected a list, got type ${current.type}`);
-      }
-      const pair = this.pairMap.get(current.value);
-      if (!pair) {
-        throw new Error(`Invalid pair identifier: ${current.value}`);
-      }
-      length++;
-      current = pair.tail;
-    }
-    return Promise.resolve(length);
   }
 }
 

--- a/src/engines/py2js/compiler.ts
+++ b/src/engines/py2js/compiler.ts
@@ -278,6 +278,10 @@ function boundNames(stmts: StmtNS.Stmt[], into: Set<string> = new Set()): Set<st
       if (target.kind === "Variable") into.add(target.name.lexeme);
     } else if (s.kind === "FunctionDef") {
       into.add((s as StmtNS.FunctionDef).name.lexeme);
+    } else if (s.kind === "FromImport") {
+      for (const spec of (s as StmtNS.FromImport).names) {
+        into.add((spec.alias ?? spec.name).lexeme);
+      }
     } else if (s.kind === "If") {
       const i = s as StmtNS.If;
       boundNames(i.body, into);
@@ -340,6 +344,23 @@ function emitStmt(s: StmtNS.Stmt, indent: string, a: boolean, ctx: EmitCtx): str
     }
     case "Assert":
       return `${indent}__py.assertCheck(${emitExpr((s as StmtNS.Assert).value, a, ctx)});\n`;
+    case "FromImport": {
+      // The imported values are resolved (module loaded, converted to
+      // native PyValues) in an async pre-pass before this chunk compiles —
+      // see moduleInterop.ts and Py2JsSession.runChunk in index.ts — and
+      // stashed on the runtime keyed by the bound (aliased) name. This
+      // statement's only job is the binding itself, through the same
+      // emitName(write=true) path an ordinary assignment uses, so it works
+      // identically in program mode (`let` local) and REPL mode (globals
+      // table) without a separate code path.
+      const imp = s as StmtNS.FromImport;
+      return imp.names
+        .map(spec => {
+          const bound = (spec.alias ?? spec.name).lexeme;
+          return `${indent}${emitName(bound, ctx, true)} = __py.importedValue(${JSON.stringify(bound)});\n`;
+        })
+        .join("");
+    }
     default:
       throw new Py2JsCompileError(`statement kind '${s.kind}'`);
   }

--- a/src/engines/py2js/index.ts
+++ b/src/engines/py2js/index.ts
@@ -13,6 +13,8 @@
  * python_typing_back.tex), pinned against the CSE machine by
  * src/tests/operator-conformance-py2js.test.ts.
  */
+import { IDataHandler } from "@sourceacademy/conductor/types";
+import { GenericDataHandler } from "../../conductor/GenericDataHandler";
 import { parse } from "../../parser";
 import { Resolver } from "../../resolver";
 import math from "../../stdlib/math";
@@ -20,6 +22,7 @@ import misc from "../../stdlib/misc";
 import type { Group } from "../../stdlib/utils";
 import { makeValidatorsForChapter } from "../../validator";
 import { CompileMode, compileProgram, Py2JsCompileError } from "./compiler";
+import { hasImports, loadChunkImports } from "./moduleInterop";
 import { annotateHostFunction, Py2JsRuntime, Py2JsRuntimeError, PyValue } from "./runtime";
 import { bridgeStdlibGroups } from "./stdlibBridge";
 
@@ -183,6 +186,15 @@ export interface Py2JsSessionOptions extends RunPy2JsOptions {
   /** Streams each print() line (no trailing newline) as it happens — the
    * conductor evaluator forwards these to the frontend. */
   onOutput?: (line: string) => void;
+  /**
+   * Conductor's module-interop protocol (pairs/arrays/closures/opaques) —
+   * see conductor/GenericDataHandler.ts. Defaults to a fresh
+   * GenericDataHandler; the conductor evaluator supplies its own instance so
+   * the same handler backs both `context.evaluator`-equivalent conversions
+   * and the ModuleLoaderRunnerPlugin registration (they must be the same
+   * object — see PyCseEvaluatorBase for the identical requirement).
+   */
+  dataHandler?: IDataHandler;
 }
 
 /**
@@ -198,11 +210,20 @@ export interface Py2JsSessionOptions extends RunPy2JsOptions {
  * throws the underlying errors raw — parse errors, the first resolver error,
  * or the runtime's Py2JsRuntimeError — so callers like the conductor
  * evaluator keep the error's name and any source location it carries.
+ *
+ * A chunk with `from X import y` is loaded (module requested, exports
+ * converted to native values — moduleInterop.ts's loadChunkImports) in an
+ * async pre-pass before it compiles, and that one chunk compiles in dual
+ * mode so its FromImport-bound module functions are callable via `acall`;
+ * every other chunk stays on the fast sync path (see compiler.ts's mode doc
+ * and the engine README's module-interop notes on why this crosses one
+ * unavoidable microtask per call regardless).
  */
 export class Py2JsSession {
   readonly rt: Py2JsRuntime;
   private readonly variant: number;
   private readonly groups: Group[];
+  private readonly dataHandler: IDataHandler;
   private preludeLoaded = false;
 
   constructor(variant: number, options: Py2JsSessionOptions = {}) {
@@ -211,6 +232,7 @@ export class Py2JsSession {
     }
     this.variant = variant;
     this.groups = PY2JS_GROUPS[variant] ?? [];
+    this.dataHandler = options.dataHandler ?? new GenericDataHandler();
     this.rt = new Py2JsRuntime();
     this.rt.onOutput = options.onOutput;
 
@@ -228,20 +250,20 @@ export class Py2JsSession {
     }
   }
 
-  /** Compile and run one chunk against the persistent globals (sync mode). */
-  runChunk(code: string): void {
+  /** Compile and run one chunk against the persistent globals. */
+  async runChunk(code: string): Promise<void> {
     if (!this.preludeLoaded) {
       this.preludeLoaded = true;
       const preludeText = this.groups
         .map(g => g.prelude ?? "")
         .filter(p => p.trim())
         .join("\n");
-      if (preludeText.trim()) this.runChunkInternal(preludeText);
+      if (preludeText.trim()) await this.runChunkInternal(preludeText);
     }
-    this.runChunkInternal(code);
+    await this.runChunkInternal(code);
   }
 
-  private runChunkInternal(code: string): void {
+  private async runChunkInternal(code: string): Promise<void> {
     const script = code.endsWith("\n") ? code : code + "\n";
     const ast = parse(script);
 
@@ -259,6 +281,17 @@ export class Py2JsSession {
     );
     const errors = resolver.resolve(ast);
     if (errors.length > 0) throw errors[0];
+
+    if (hasImports(ast.statements)) {
+      const bindings = await loadChunkImports(this.rt, this.dataHandler, ast.statements);
+      this.rt.setPendingImports(bindings);
+      const js = compileProgram(ast, Object.keys(this.rt.builtins), {
+        mode: "dual",
+        repl: { priorGlobals },
+      });
+      await new AsyncFunction("__py", js)(this.rt);
+      return;
+    }
 
     const js = compileProgram(ast, Object.keys(this.rt.builtins), {
       mode: "sync",

--- a/src/engines/py2js/moduleInterop.ts
+++ b/src/engines/py2js/moduleInterop.ts
@@ -208,25 +208,27 @@ export async function loadChunkImports(
     ),
   );
 
+  // Modules are already pre-loaded above concurrently; binding itself runs
+  // sequentially in source order so that two imports binding the same name
+  // (e.g. `from a import x` then `from b import x`) resolve deterministically
+  // — last one in source order wins, matching plain reassignment — rather
+  // than racing on whichever moduleToPython() conversion happens to finish
+  // last under concurrent Promise.all.
   const bindings: Record<string, PyValue> = Object.create(null) as Record<string, PyValue>;
-  await Promise.all(
-    imports.map(async node => {
-      const moduleName = node.module.lexeme;
-      const exports = new Map(plugins.get(moduleName)!.exports.map(e => [e.symbol, e.value]));
-      await Promise.all(
-        node.names.map(async spec => {
-          const exportValue = exports.get(spec.name.lexeme);
-          if (exportValue === undefined) {
-            throw new Py2JsRuntimeError(
-              "ImportError",
-              `cannot import name '${spec.name.lexeme}' from '${moduleName}'`,
-            );
-          }
-          const bound = (spec.alias ?? spec.name).lexeme;
-          bindings[bound] = await moduleToPython(rt, dh, exportValue, spec.name.lexeme);
-        }),
-      );
-    }),
-  );
+  for (const node of imports) {
+    const moduleName = node.module.lexeme;
+    const exports = new Map(plugins.get(moduleName)!.exports.map(e => [e.symbol, e.value]));
+    for (const spec of node.names) {
+      const exportValue = exports.get(spec.name.lexeme);
+      if (exportValue === undefined) {
+        throw new Py2JsRuntimeError(
+          "ImportError",
+          `cannot import name '${spec.name.lexeme}' from '${moduleName}'`,
+        );
+      }
+      const bound = (spec.alias ?? spec.name).lexeme;
+      bindings[bound] = await moduleToPython(rt, dh, exportValue, spec.name.lexeme);
+    }
+  }
   return bindings;
 }

--- a/src/engines/py2js/moduleInterop.ts
+++ b/src/engines/py2js/moduleInterop.ts
@@ -1,0 +1,232 @@
+/**
+ * py2js engine — module interop.
+ *
+ * Conversion layer between py2js's native (unboxed) values and conductor's
+ * module protocol (`TypedValue<DataType>`/`IDataHandler`) — the py2js
+ * analogue of src/engines/cse/modules.ts, mirroring the same value mapping
+ * (NUMBER<->float, none<->EMPTY_LIST, OPAQUE<->PyOpaque, CLOSURE<->function)
+ * so a module behaves identically whichever engine the student runs on.
+ * `IDataHandler` itself (the pair/array/closure/opaque bookkeeping) is
+ * `GenericDataHandler` — engine-agnostic, shared with the CSE evaluator; see
+ * conductor/GenericDataHandler.ts.
+ *
+ * Closures crossing the module boundary, in EITHER direction, are
+ * async-generator calls by conductor's own contract (`ExternCallable` is
+ * `(...args) => AsyncGenerator<...>`) — not an implementation choice of any
+ * particular engine. Concretely:
+ *
+ *  - Python calling an imported module function (`from math import sqrt`):
+ *    wrapped as a `PyFunction` whose body runs `dh.closure_call_unchecked`
+ *    and iterates the generator. `.next()` on an async generator always
+ *    resolves via microtask, so this is unavoidably async — the function is
+ *    `asyncOnly` (see runtime.ts), callable only through `acall`/dual mode,
+ *    never through a sync module callback.
+ *  - A module calling a Python-defined function (the sound-module scenario:
+ *    `play(wave, duration)` samples `wave` many times): the Python closure is
+ *    wrapped via `dh.closure_make(sig, func, ...)`, where conductor requires
+ *    `func` itself to be an async generator. Its *body*, though, is authored
+ *    here, and does a single direct, synchronous `rt.callSync` — no
+ *    interpreter re-entry (unlike the CSE machine's `modules.ts`, whose
+ *    equivalent closure wrapper pushes onto `control`/`stash` and resumes the
+ *    whole step loop per call). One microtask per call is unavoidable
+ *    (conductor's contract, not py2js's), but the work inside it is a plain
+ *    JS function call — see the engine README's module-interop notes for the
+ *    measured cost.
+ *
+ * Chapter 1 has no list/pair type (NoListsValidator) and no way to construct
+ * or consume one, so DataType.PAIR/ARRAY module values are rejected with a
+ * clear error rather than represented — there is nothing chapter-1 code
+ * could do with one anyway. Complex numbers are likewise not supported
+ * crossing the boundary (matching the CSE converter's identical restriction).
+ */
+import { DataType, IDataHandler, TypedValue } from "@sourceacademy/conductor/types";
+import { ModuleLoaderRunnerPlugin } from "@sourceacademy/runner-module-loader";
+import { StmtNS } from "../../ast-types";
+import { Py2JsRuntime, Py2JsRuntimeError, PyOpaque, PyValue } from "./runtime";
+
+/** Converts a py2js native value into a conductor TypedValue, for passing
+ * INTO a module — as a call argument, or the value a module holds after
+ * receiving it. Mirrors pythonToModule in src/engines/cse/modules.ts. */
+export async function pythonToModule(
+  rt: Py2JsRuntime,
+  dh: IDataHandler,
+  value: PyValue,
+): Promise<TypedValue<DataType>> {
+  switch (typeof value) {
+    case "bigint":
+      // Module signatures only know NUMBER; crosses as a float, same as
+      // every other engine's converter (CSE's modules.ts, WASM's
+      // moduleInterop.ts).
+      return { type: DataType.NUMBER, value: Number(value) };
+    case "number":
+      return { type: DataType.NUMBER, value };
+    case "boolean":
+      return { type: DataType.BOOLEAN, value };
+    case "string":
+      return { type: DataType.CONST_STRING, value };
+    case "function": {
+      const fn = value;
+      async function* pyClosureFunc(
+        ...args: TypedValue<DataType>[]
+      ): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+        const nativeArgs = await Promise.all(args.map(a => moduleToPython(rt, dh, a)));
+        const result = rt.callSync(fn, nativeArgs);
+        return pythonToModule(rt, dh, result);
+      }
+      const arity = Math.max(0, fn.pyArity);
+      return dh.closure_make(
+        { returnType: DataType.VOID, args: Array(arity).fill(DataType.VOID) },
+        pyClosureFunc,
+      );
+    }
+    case "object":
+      if (value === null) return { type: DataType.EMPTY_LIST, value: null };
+      if (value instanceof PyOpaque) return value.typed;
+      throw new Py2JsRuntimeError(
+        "TypeError",
+        "complex values are not supported in module interop",
+      );
+    default:
+      throw new Py2JsRuntimeError("TypeError", "unsupported value in module interop");
+  }
+}
+
+/**
+ * Converts a conductor TypedValue into a py2js native value, for a module
+ * export flowing into Python (FromImport bindings) or an argument a module
+ * passes to a Python closure it calls back. `name` is used to render an
+ * imported function nicely (`<built-in function sqrt>`); defaults to a
+ * generic label for values reached indirectly (e.g. one module function
+ * returning another as its result). Mirrors moduleToPython in
+ * src/engines/cse/modules.ts.
+ */
+export async function moduleToPython(
+  rt: Py2JsRuntime,
+  dh: IDataHandler,
+  value: TypedValue<DataType>,
+  name = "<module function>",
+): Promise<PyValue> {
+  switch (value.type) {
+    case DataType.NUMBER:
+      return value.value;
+    case DataType.BOOLEAN:
+      return value.value;
+    case DataType.CONST_STRING:
+      return value.value;
+    case DataType.VOID:
+    case DataType.EMPTY_LIST:
+      return null;
+    case DataType.OPAQUE:
+      return new PyOpaque(value);
+    case DataType.CLOSURE: {
+      const arity = await dh.closure_arity(value);
+      const f = rt.def(name, arity, () => {
+        // Defensive backstop: the asyncOnly guard in call()/checkCallable
+        // already rejects this before the body would run through the
+        // normal call path; this only fires on a direct raw invocation that
+        // bypasses the runtime (e.g. module code calling the JS function
+        // value itself instead of going through rt.call/rt.acall).
+        throw new Py2JsRuntimeError(
+          "TypeError",
+          `${name}() needs a frontend round-trip and cannot be called from a synchronous module callback`,
+        );
+      });
+      // Renders as a built-in function (matching the spirit of the CSE
+      // machine's own convention for module closures — see the file header
+      // comment on threading the real symbol name through, an improvement
+      // over CSE's literal "closure" placeholder name there).
+      f.pyBuiltin = true;
+      f.asyncOnly = true;
+      f.asyncBody = async (...args: PyValue[]) => {
+        const typedArgs = await Promise.all(args.map(a => pythonToModule(rt, dh, a)));
+        const gen = dh.closure_call_unchecked(value, typedArgs);
+        let step = await gen.next();
+        while (!step.done) step = await gen.next();
+        return moduleToPython(rt, dh, step.value);
+      };
+      return f;
+    }
+    case DataType.PAIR:
+    case DataType.ARRAY:
+      // See file header: chapter 1 has no list/pair type to represent this
+      // as, and no way to consume one anyway. Extend when py2js grows list
+      // support (chapter 3+), mirroring the CSE/WASM converters. (DataType
+      // also has a LIST member, but it's a type-level PAIR-or-EMPTY_LIST
+      // marker, not a tag any concrete TypedValue ever actually carries —
+      // TypeScript's own TypedValue<DataType> union excludes it, so there
+      // is no runtime case for it here.)
+      throw new Py2JsRuntimeError(
+        "TypeError",
+        `module values of type "${DataType[value.type]}" are not supported by py2js at chapter 1`,
+      );
+  }
+}
+
+/** True iff a chunk's top-level statements include at least one FromImport —
+ * the signal Py2JsSession uses to pick dual (async) compile mode; a chunk
+ * with none stays on the fast sync path (see index.ts, compiler.ts's mode
+ * doc). */
+export function hasImports(statements: StmtNS.Stmt[]): boolean {
+  return statements.some(s => s.kind === "FromImport");
+}
+
+/**
+ * Loads and converts every module this chunk imports, before compilation —
+ * mirroring src/engines/cse/modules.ts's loadModules/evaluateImports (module
+ * *loading* happens once per chunk, ahead of running the chunk's own code,
+ * matching every other py-slang evaluator's two-phase model). Returns the
+ * resolved bindings keyed by bound (aliased) name, ready for
+ * `rt.setPendingImports` — the compiled FromImport statement just reads them
+ * back via `__py.importedValue(name)`.
+ */
+export async function loadChunkImports(
+  rt: Py2JsRuntime,
+  dh: IDataHandler,
+  statements: StmtNS.Stmt[],
+): Promise<Record<string, PyValue>> {
+  const imports = statements.filter((s): s is StmtNS.FromImport => s.kind === "FromImport");
+  if (imports.length === 0) return {};
+
+  if (!ModuleLoaderRunnerPlugin.instance) {
+    throw new Py2JsRuntimeError(
+      "SystemError",
+      "py2js: ModuleLoaderRunnerPlugin is not initialized (no module loader registered)",
+    );
+  }
+  const loader = ModuleLoaderRunnerPlugin.instance;
+
+  const moduleNames = [...new Set(imports.map(node => node.module.lexeme))];
+  const plugins = new Map(
+    await Promise.all(
+      moduleNames.map(async moduleName => {
+        try {
+          return [moduleName, await loader.requestModule(moduleName)] as const;
+        } catch {
+          throw new Py2JsRuntimeError("ModuleNotFoundError", `Module "${moduleName}" not found.`);
+        }
+      }),
+    ),
+  );
+
+  const bindings: Record<string, PyValue> = Object.create(null) as Record<string, PyValue>;
+  await Promise.all(
+    imports.map(async node => {
+      const moduleName = node.module.lexeme;
+      const exports = new Map(plugins.get(moduleName)!.exports.map(e => [e.symbol, e.value]));
+      await Promise.all(
+        node.names.map(async spec => {
+          const exportValue = exports.get(spec.name.lexeme);
+          if (exportValue === undefined) {
+            throw new Py2JsRuntimeError(
+              "ImportError",
+              `cannot import name '${spec.name.lexeme}' from '${moduleName}'`,
+            );
+          }
+          const bound = (spec.alias ?? spec.name).lexeme;
+          bindings[bound] = await moduleToPython(rt, dh, exportValue, spec.name.lexeme);
+        }),
+      );
+    }),
+  );
+  return bindings;
+}

--- a/src/engines/py2js/runtime.ts
+++ b/src/engines/py2js/runtime.ts
@@ -9,6 +9,9 @@
  *   None     -> null
  *   complex  -> PyComplexNumber (src/types)
  *   function -> JS function carrying pyName/pyArity metadata
+ *   opaque   -> PyOpaque (a module value with no py2js-native representation
+ *               — e.g. a sound or image handle — held and passed around but
+ *               not otherwise inspectable; see moduleInterop.ts)
  *
  * User values stay unboxed so V8 can JIT the compiled program; the Python
  * chapter-1 operator semantics live in the helpers below, which mirror
@@ -26,11 +29,29 @@
  * async spine (acall), while TS modules call back into Python synchronously
  * through callSync — see compiler.ts's mode documentation.
  */
+import { DataType, TypedValue } from "@sourceacademy/conductor/types";
 import { numericCompare, pythonMod } from "../cse/utils";
 import { toPythonFloat } from "../../stdlib/utils";
 import { PyComplexNumber } from "../../types";
 
-export type PyValue = bigint | number | boolean | string | null | PyComplexNumber | PyFunction;
+export type PyValue =
+  | bigint
+  | number
+  | boolean
+  | string
+  | null
+  | PyComplexNumber
+  | PyOpaque
+  | PyFunction;
+
+/**
+ * An imported module value with no py2js-native representation (conductor's
+ * DataType.OPAQUE) — held and passed around opaquely, matching the CSE
+ * machine's "opaque" Value type. See moduleInterop.ts's moduleToPython.
+ */
+export class PyOpaque {
+  constructor(public readonly typed: TypedValue<DataType.OPAQUE>) {}
+}
 
 export interface PyFunction {
   (...args: PyValue[]): PyValue | TailCall;
@@ -97,7 +118,11 @@ export function pyTypeName(v: PyValue): string {
     case "function":
       return "function";
     case "object":
-      return v === null ? "NoneType" : "complex";
+      if (v === null) return "NoneType";
+      // Matches CPython's type(...).__name__ via typeTranslator's "opaque"
+      // passthrough in the CSE machine (engines/cse/types.ts) — an
+      // unrecognized value from a module has no more specific Python name.
+      return v instanceof PyOpaque ? "opaque" : "complex";
     default:
       return "NoneType";
   }
@@ -124,7 +149,10 @@ export function pyStr(v: PyValue): string {
     case "function":
       return v.pyBuiltin ? `<built-in function ${v.pyName}>` : `<function ${v.pyName}>`;
     case "object":
-      return v === null ? "None" : v.toString();
+      if (v === null) return "None";
+      // Matches the CSE machine's toPythonString default case (stdlib/
+      // utils.ts) for its "opaque" Value type.
+      return v instanceof PyOpaque ? "<opaque object>" : v.toString();
     default:
       return "None";
   }
@@ -287,6 +315,32 @@ export class Py2JsRuntime {
     );
   }
 
+  /**
+   * Values resolved by an async import-loading pre-pass (module loaded,
+   * converted to native PyValues — see moduleInterop.ts), keyed by the bound
+   * (aliased) name, for the compiled FromImport statement about to run to
+   * read via importedValue. Set fresh per chunk by whatever's running it
+   * (Py2JsSession.runChunk in index.ts); a chunk with no imports never
+   * touches this.
+   */
+  private pendingImports: Record<string, PyValue> = Object.create(null) as Record<string, PyValue>;
+
+  /** Called before running a chunk that contains FromImport statements. */
+  setPendingImports(bindings: Record<string, PyValue>): void {
+    this.pendingImports = bindings;
+  }
+
+  /** Reads a value the import-loading pre-pass resolved for a compiled
+   * FromImport statement (see compiler.ts). Missing here is an internal
+   * inconsistency (the loader and the compiler disagreeing on which names
+   * this chunk imports), not a user-facing error. */
+  importedValue(name: string): PyValue {
+    if (!(name in this.pendingImports)) {
+      throw new Py2JsRuntimeError("SystemError", `py2js: no pending import value for '${name}'`);
+    }
+    return this.pendingImports[name];
+  }
+
   /** None singleton alias so compiled code can say __py.None. */
   readonly None = null;
 
@@ -434,7 +488,10 @@ export class Py2JsRuntime {
       case "function":
         return true;
       case "object":
-        return v === null ? false : v.real !== 0 || v.imag !== 0;
+        if (v === null) return false;
+        // Opaque module values are always truthy, like functions (CSE's
+        // isFalsy default: "all other objects are considered truthy").
+        return v instanceof PyOpaque ? true : v.real !== 0 || v.imag !== 0;
       default:
         return false;
     }

--- a/src/engines/py2js/stdlibBridge.ts
+++ b/src/engines/py2js/stdlibBridge.ts
@@ -39,7 +39,7 @@ import type { Group } from "../../stdlib/utils";
 import { Context } from "../cse/context";
 import type { Environment } from "../cse/environment";
 import type { BuiltinValue, Value } from "../cse/stash";
-import { Py2JsRuntime, Py2JsRuntimeError, PyFunction, PyValue } from "./runtime";
+import { Py2JsRuntime, Py2JsRuntimeError, PyFunction, PyOpaque, PyValue } from "./runtime";
 
 function syntheticCallNode(name: string): ExprNS.Call {
   const token = new Token(TokenType.NAME, name, 1, 0, 0);
@@ -86,6 +86,12 @@ function toTagged(v: PyValue): Value {
     }
     default:
       if (v === null) return { type: "none" };
+      // No chapter-1 stdlib builtin accepts an opaque module value as an
+      // argument (abs/math_sqrt/etc. all type-check against "opaque" being
+      // absent from their accepted types), so this just needs to produce
+      // *some* CSE Value the builtin's own dispatch will reject cleanly —
+      // matching CSE's own opaque conversion shape (modules.ts).
+      if (v instanceof PyOpaque) return { type: "opaque", value: v.typed };
       return { type: "complex", value: v };
   }
 }

--- a/src/tests/GenericDataHandler.test.ts
+++ b/src/tests/GenericDataHandler.test.ts
@@ -1,0 +1,57 @@
+/**
+ * asInterfacableEvaluator combines an IEvaluator and a GenericDataHandler
+ * into the single object ModuleLoaderRunnerPlugin's constructor requires,
+ * via a Proxy. Nothing exercised this directly before: moduleInterop.ts and
+ * PyCseEvaluatorBase's own module-interop code call the GenericDataHandler
+ * instance straight, bypassing the proxy entirely, so a naive
+ * `Reflect.get(dataHandler, prop, dataHandler)` (unbound) would look correct
+ * in every existing test while still being broken for the one caller that
+ * actually goes through the proxy: conductor's ModuleLoaderRunnerPlugin
+ * itself. Unbound, `this` inside a proxied call is the proxy; stateful
+ * writes like `this.uniqueId++` in pair_make/array_make/closure_make/
+ * opaque_make then land on the proxy's target (the evaluator) instead of
+ * dataHandler, so every allocation through the proxy would read back
+ * uniqueId 0 forever and collide on the same identifier.
+ */
+import type { IEvaluator } from "@sourceacademy/conductor/runner";
+import { DataType } from "@sourceacademy/conductor/types";
+import { asInterfacableEvaluator, GenericDataHandler } from "../conductor/GenericDataHandler";
+
+function fakeEvaluator(): IEvaluator {
+  return { startEvaluator: () => Promise.resolve(undefined) };
+}
+
+test("repeated allocations through the proxy get distinct ids and land in dataHandler", async () => {
+  const dataHandler = new GenericDataHandler();
+  const proxied = asInterfacableEvaluator(fakeEvaluator(), dataHandler);
+
+  const first = await proxied.pair_make(
+    { type: DataType.NUMBER, value: 1 },
+    { type: DataType.NUMBER, value: 2 },
+  );
+  const second = await proxied.pair_make(
+    { type: DataType.NUMBER, value: 3 },
+    { type: DataType.NUMBER, value: 4 },
+  );
+
+  // The bug this guards against: both allocations silently returning id 0
+  // (uniqueId stuck because the write side of `this.uniqueId++` missed
+  // dataHandler) and the second pair overwriting the first in pairMap.
+  expect(second.value).not.toBe(first.value);
+
+  const firstHead = await proxied.pair_head(first);
+  const secondHead = await proxied.pair_head(second);
+  expect(firstHead).toEqual({ type: DataType.NUMBER, value: 1 });
+  expect(secondHead).toEqual({ type: DataType.NUMBER, value: 3 });
+
+  // Calling through the proxy must mutate the shared dataHandler, not some
+  // state stuck on the proxy/evaluator side.
+  const direct = await dataHandler.pair_head(first);
+  expect(direct).toEqual({ type: DataType.NUMBER, value: 1 });
+});
+
+test("non-dataHandler properties still resolve against the underlying evaluator", async () => {
+  const evaluator = fakeEvaluator();
+  const proxied = asInterfacableEvaluator(evaluator, new GenericDataHandler());
+  await expect(proxied.startEvaluator("entry")).resolves.toBeUndefined();
+});

--- a/src/tests/Py2JsEvaluator.test.ts
+++ b/src/tests/Py2JsEvaluator.test.ts
@@ -10,8 +10,10 @@
 import type { IRunnerPlugin } from "@sourceacademy/conductor/runner";
 import { Py2JsEvaluator1 } from "../conductor/Py2JsEvaluator";
 
-/** Minimal IRunnerPlugin mock: the evaluator only ever calls sendResult/
- * sendError/sendOutput on its `conductor`. */
+/** Minimal IRunnerPlugin mock: the evaluator calls sendResult/sendError/
+ * sendOutput on its `conductor`, plus registerPlugin once in its constructor
+ * (module-loader registration — see Py2JsEvaluator.ts); no test here imports
+ * anything, so the stub just needs to exist, not do anything real. */
 function makeMockConductor() {
   const results: unknown[] = [];
   const errors: { name: string; message: string }[] = [];
@@ -20,6 +22,7 @@ function makeMockConductor() {
     sendResult: (r: unknown) => results.push(r),
     sendError: (e: unknown) => errors.push(e as { name: string; message: string }),
     sendOutput: (m: string) => outputs.push(m),
+    registerPlugin: () => undefined,
   } as unknown as IRunnerPlugin;
   return { conductor, results, errors, outputs };
 }

--- a/src/tests/py2js-from-import.test.ts
+++ b/src/tests/py2js-from-import.test.ts
@@ -1,0 +1,231 @@
+/**
+ * End-to-end `from X import y` tests through Py2JsSession — the module
+ * loader (moduleInterop.ts's loadChunkImports), FromImport codegen
+ * (compiler.ts), and dual compile mode all wired together, against a fake
+ * conductor module (ModuleLoaderRunnerPlugin.instance mocked, matching how
+ * the real plugin resolves `requestModule`).
+ *
+ * The flagship scenario ("module calls a Python function it was handed") is
+ * exactly the sound-module case that motivated py2js's dual-compilation
+ * design (see experiments/py2js/README.md): a fake `play(wave, n)` module
+ * function samples a Python-defined `wave` function n times, calling back
+ * through conductor's own generic closure protocol (closure_call_unchecked)
+ * — never touching rt.callSync directly, since real module code is
+ * engine-agnostic; the fast synchronous path lives entirely inside
+ * moduleInterop.ts's own closure_make wrapper, invisible to the module.
+ */
+import { DataType, TypedValue } from "@sourceacademy/conductor/types";
+import { ModuleLoaderRunnerPlugin } from "@sourceacademy/runner-module-loader";
+import { GenericDataHandler } from "../conductor/GenericDataHandler";
+import { Py2JsSession } from "../engines/py2js";
+
+type FakeExport = { symbol: string; value: TypedValue<DataType> };
+
+/** A fake IModulePlugin exposing the given exports, installed as
+ * ModuleLoaderRunnerPlugin.instance so loadChunkImports's requestModule call
+ * resolves without a real conduit/plugin registration. */
+function installFakeModule(exportsByModule: Record<string, FakeExport[]>) {
+  ModuleLoaderRunnerPlugin.instance = {
+    requestModule: (name: string) => {
+      const exports = exportsByModule[name];
+      if (!exports) return Promise.reject(new Error(`no such module: ${name}`));
+      return Promise.resolve({ exports });
+    },
+  } as unknown as ModuleLoaderRunnerPlugin;
+}
+
+afterEach(() => {
+  ModuleLoaderRunnerPlugin.instance = null;
+});
+
+function makeSession(dh: GenericDataHandler) {
+  const outputs: string[] = [];
+  const session = new Py2JsSession(1, { onOutput: line => outputs.push(line), dataHandler: dh });
+  return { session, outputs };
+}
+
+test("imports a scalar constant and a simple function", async () => {
+  const dh = new GenericDataHandler();
+  async function* addFunc(
+    a: TypedValue<DataType>,
+    b: TypedValue<DataType>,
+  ): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+    await Promise.resolve(); // conductor's ExternCallable contract requires an async generator
+    return {
+      type: DataType.NUMBER,
+      value: (a as TypedValue<DataType.NUMBER>).value + (b as TypedValue<DataType.NUMBER>).value,
+    };
+  }
+  const add = await dh.closure_make(
+    { returnType: DataType.NUMBER, args: [DataType.NUMBER, DataType.NUMBER] },
+    addFunc,
+  );
+  installFakeModule({
+    physics: [
+      { symbol: "gravity", value: { type: DataType.NUMBER, value: 9.8 } },
+      { symbol: "add", value: add },
+    ],
+  });
+
+  const { session, outputs } = makeSession(dh);
+  await session.runChunk("from physics import gravity, add\nprint(gravity)\nprint(add(2, 3))\n");
+
+  expect(outputs).toEqual(["9.8", "5.0"]);
+});
+
+test("import with an alias binds under the aliased name", async () => {
+  const dh = new GenericDataHandler();
+  installFakeModule({
+    physics: [{ symbol: "gravity", value: { type: DataType.NUMBER, value: 9.8 } }],
+  });
+
+  const { session, outputs } = makeSession(dh);
+  await session.runChunk("from physics import gravity as g\nprint(g)\n");
+
+  expect(outputs).toEqual(["9.8"]);
+});
+
+test("a chunk with no imports still runs on the fast sync path", async () => {
+  const dh = new GenericDataHandler();
+  const { session, outputs } = makeSession(dh);
+  await session.runChunk("print(1 + 1)\n");
+  expect(outputs).toEqual(["2"]);
+});
+
+test("an imported binding persists to later chunks", async () => {
+  const dh = new GenericDataHandler();
+  installFakeModule({
+    physics: [{ symbol: "gravity", value: { type: DataType.NUMBER, value: 9.8 } }],
+  });
+
+  const { session, outputs } = makeSession(dh);
+  await session.runChunk("from physics import gravity\n");
+  await session.runChunk("print(gravity * 2)\n");
+
+  expect(outputs).toEqual(["19.6"]);
+});
+
+test("importing from an unknown module raises ModuleNotFoundError", async () => {
+  const dh = new GenericDataHandler();
+  installFakeModule({});
+  const { session } = makeSession(dh);
+  await expect(session.runChunk("from nonexistent import x\n")).rejects.toThrow(/not found/);
+});
+
+test("importing an unknown name raises with the CPython ImportError wording", async () => {
+  const dh = new GenericDataHandler();
+  installFakeModule({
+    physics: [{ symbol: "gravity", value: { type: DataType.NUMBER, value: 9.8 } }],
+  });
+  const { session } = makeSession(dh);
+  await expect(session.runChunk("from physics import nonexistent\n")).rejects.toThrow(
+    /cannot import name 'nonexistent' from 'physics'/,
+  );
+});
+
+test("calling an imported function needing a round-trip works on the async spine", async () => {
+  const dh = new GenericDataHandler();
+  async function* slowDouble(
+    x: TypedValue<DataType>,
+  ): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+    await new Promise(resolve => setTimeout(resolve, 0)); // simulates a real round-trip
+    return { type: DataType.NUMBER, value: (x as TypedValue<DataType.NUMBER>).value * 2 };
+  }
+  const closure = await dh.closure_make(
+    { returnType: DataType.NUMBER, args: [DataType.NUMBER] },
+    slowDouble,
+  );
+  installFakeModule({ physics: [{ symbol: "slow_double", value: closure }] });
+
+  const { session, outputs } = makeSession(dh);
+  await session.runChunk("from physics import slow_double\nprint(slow_double(21))\n");
+
+  expect(outputs).toEqual(["42.0"]);
+});
+
+test("the sound-module scenario: a module samples a Python-defined function via conductor's generic closure protocol", async () => {
+  const dh = new GenericDataHandler();
+
+  // The fake module's own implementation of play(wave, n): calls wave(i)
+  // for i in 0..n through dh.closure_call_unchecked — the same generic,
+  // engine-agnostic protocol any real module uses. It never touches
+  // rt.callSync; that fast path lives entirely inside moduleInterop.ts's
+  // own closure_make wrapper on the Python side.
+  async function* playFunc(
+    waveArg: TypedValue<DataType>,
+    nArg: TypedValue<DataType>,
+  ): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+    const wave = waveArg as TypedValue<DataType.CLOSURE>;
+    const n = (nArg as TypedValue<DataType.NUMBER>).value;
+    let total = 0;
+    for (let i = 0; i < n; i++) {
+      const gen = dh.closure_call_unchecked(wave, [{ type: DataType.NUMBER, value: i }]);
+      let step = await gen.next();
+      while (!step.done) step = await gen.next();
+      total += (step.value as TypedValue<DataType.NUMBER>).value;
+    }
+    return { type: DataType.NUMBER, value: total };
+  }
+  const play = await dh.closure_make(
+    { returnType: DataType.NUMBER, args: [DataType.CLOSURE, DataType.NUMBER] },
+    playFunc,
+  );
+  installFakeModule({ audio: [{ symbol: "play", value: play }] });
+
+  const { session, outputs } = makeSession(dh);
+  // wave(t) = t * 2; play samples it at t = 0, 1, 2 -> 0 + 2 + 4 = 6
+  await session.runChunk(
+    "from audio import play\n" +
+      "def wave(t):\n" +
+      "    return t * 2.0\n" +
+      "print(play(wave, 3))\n",
+  );
+
+  expect(outputs).toEqual(["6.0"]);
+});
+
+test("a synchronously-sampled Python callback cannot itself call an import needing a round-trip", async () => {
+  const dh = new GenericDataHandler();
+
+  async function* playFunc(
+    waveArg: TypedValue<DataType>,
+  ): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+    const wave = waveArg as TypedValue<DataType.CLOSURE>;
+    const gen = dh.closure_call_unchecked(wave, [{ type: DataType.NUMBER, value: 0 }]);
+    let step = await gen.next();
+    while (!step.done) step = await gen.next();
+    return step.value;
+  }
+  const play = await dh.closure_make(
+    { returnType: DataType.NUMBER, args: [DataType.CLOSURE] },
+    playFunc,
+  );
+
+  async function* slowHelper(
+    x: TypedValue<DataType>,
+  ): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+    await new Promise(resolve => setTimeout(resolve, 0));
+    return x;
+  }
+  const helper = await dh.closure_make(
+    { returnType: DataType.NUMBER, args: [DataType.NUMBER] },
+    slowHelper,
+  );
+
+  installFakeModule({
+    audio: [
+      { symbol: "play", value: play },
+      { symbol: "slow_helper", value: helper },
+    ],
+  });
+
+  const { session } = makeSession(dh);
+  await expect(
+    session.runChunk(
+      "from audio import play, slow_helper\n" +
+        "def wave(t):\n" +
+        "    return slow_helper(t)\n" +
+        "print(play(wave))\n",
+    ),
+  ).rejects.toThrow(/needs a frontend round-trip/);
+});

--- a/src/tests/py2js-from-import.test.ts
+++ b/src/tests/py2js-from-import.test.ts
@@ -73,6 +73,34 @@ test("imports a scalar constant and a simple function", async () => {
   expect(outputs).toEqual(["9.8", "5.0"]);
 });
 
+test("two imports binding the same name resolve in source order, last one wins", async () => {
+  // moduleToPython's CLOSURE branch awaits dh.closure_arity() before it can
+  // build the bound function — one more microtask hop than the NUMBER branch
+  // (a synchronous value, no internal await). That timing difference is real
+  // (not an artificial delay), so under the old concurrent-Promise.all
+  // binding this is a deterministic repro, not a flaky race: `slow`'s CLOSURE
+  // binding always resolves after `fast`'s NUMBER binding regardless of which
+  // import statement comes first in source, so the *first* import (being the
+  // slower one) would always win — backwards from Python's last-assignment-
+  // wins semantics. Binding sequentially in source order fixes that: `fast`
+  // (the textually-last import) must win here.
+  const dh = new GenericDataHandler();
+  async function* neverCalled(): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+    await Promise.resolve();
+    throw new Error("should never be invoked by this test");
+  }
+  const slowClosure = await dh.closure_make({ returnType: DataType.NUMBER, args: [] }, neverCalled);
+  installFakeModule({
+    slowmod: [{ symbol: "x", value: slowClosure }],
+    fastmod: [{ symbol: "x", value: { type: DataType.NUMBER, value: 42 } }],
+  });
+
+  const { session, outputs } = makeSession(dh);
+  await session.runChunk("from slowmod import x\nfrom fastmod import x\nprint(x)\n");
+
+  expect(outputs).toEqual(["42.0"]);
+});
+
 test("import with an alias binds under the aliased name", async () => {
   const dh = new GenericDataHandler();
   installFakeModule({

--- a/src/tests/py2js-module-interop.test.ts
+++ b/src/tests/py2js-module-interop.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for py2js's module-interop conversion layer
+ * (src/engines/py2js/moduleInterop.ts): pythonToModule/moduleToPython
+ * against a real GenericDataHandler (no need for a mock — the handler is
+ * fully generic bookkeeping, see conductor/GenericDataHandler.ts), mirroring
+ * how src/tests/modules.test.ts exercises the CSE machine's equivalent
+ * converters.
+ */
+import { DataType, TypedValue } from "@sourceacademy/conductor/types";
+import { GenericDataHandler } from "../conductor/GenericDataHandler";
+import { moduleToPython, pythonToModule } from "../engines/py2js/moduleInterop";
+import { Py2JsRuntime, Py2JsRuntimeError, PyOpaque } from "../engines/py2js/runtime";
+
+function makeRt() {
+  return new Py2JsRuntime();
+}
+
+describe("pythonToModule", () => {
+  test("scalars", async () => {
+    const dh = new GenericDataHandler();
+    const rt = makeRt();
+    expect(await pythonToModule(rt, dh, 5n)).toEqual({ type: DataType.NUMBER, value: 5 });
+    expect(await pythonToModule(rt, dh, 2.5)).toEqual({ type: DataType.NUMBER, value: 2.5 });
+    expect(await pythonToModule(rt, dh, true)).toEqual({ type: DataType.BOOLEAN, value: true });
+    expect(await pythonToModule(rt, dh, "hi")).toEqual({
+      type: DataType.CONST_STRING,
+      value: "hi",
+    });
+    expect(await pythonToModule(rt, dh, null)).toEqual({ type: DataType.EMPTY_LIST, value: null });
+  });
+
+  test("a PyOpaque round-trips back to its original typed value", async () => {
+    const dh = new GenericDataHandler();
+    const rt = makeRt();
+    const typed = await dh.opaque_make({ some: "handle" });
+    const opaque = new PyOpaque(typed);
+    expect(await pythonToModule(rt, dh, opaque)).toBe(typed);
+  });
+
+  test("complex values are rejected", async () => {
+    const dh = new GenericDataHandler();
+    const rt = makeRt();
+    const { PyComplexNumber } = await import("../types");
+    await expect(pythonToModule(rt, dh, new PyComplexNumber(1, 2))).rejects.toThrow(
+      Py2JsRuntimeError,
+    );
+  });
+
+  test("a Python function becomes a callable CLOSURE a module can invoke", async () => {
+    const dh = new GenericDataHandler();
+    const rt = makeRt();
+    // Conductor's NUMBER always maps to py2js's native `number` (float) —
+    // module signatures only know NUMBER, same convention as every engine's
+    // converter (see the file header).
+    const double = rt.def("double", 1, (x: unknown) => (x as number) * 2);
+    const typed = await pythonToModule(rt, dh, double);
+    expect(typed.type).toBe(DataType.CLOSURE);
+    if (typed.type !== DataType.CLOSURE) throw new Error("unreachable");
+
+    // The module's-eye view: call it through conductor's own generic
+    // closure protocol (closure_call_unchecked), exactly as a real module
+    // would — never touching rt.callSync directly.
+    const gen = dh.closure_call_unchecked(typed, [{ type: DataType.NUMBER, value: 21 }]);
+    let step = await gen.next();
+    while (!step.done) step = await gen.next();
+    expect(step.value).toEqual({ type: DataType.NUMBER, value: 42 });
+  });
+});
+
+describe("moduleToPython", () => {
+  test("scalars", async () => {
+    const dh = new GenericDataHandler();
+    const rt = makeRt();
+    expect(await moduleToPython(rt, dh, { type: DataType.NUMBER, value: 5 })).toBe(5);
+    expect(await moduleToPython(rt, dh, { type: DataType.BOOLEAN, value: false })).toBe(false);
+    expect(await moduleToPython(rt, dh, { type: DataType.CONST_STRING, value: "x" })).toBe("x");
+    expect(await moduleToPython(rt, dh, { type: DataType.EMPTY_LIST, value: null })).toBeNull();
+    expect(await moduleToPython(rt, dh, { type: DataType.VOID, value: undefined })).toBeNull();
+  });
+
+  test("OPAQUE becomes a PyOpaque wrapper", async () => {
+    const dh = new GenericDataHandler();
+    const rt = makeRt();
+    const typed = await dh.opaque_make("payload");
+    const result = await moduleToPython(rt, dh, typed);
+    expect(result).toBeInstanceOf(PyOpaque);
+    expect((result as PyOpaque).typed).toBe(typed);
+  });
+
+  test("PAIR/ARRAY are rejected at chapter 1", async () => {
+    const dh = new GenericDataHandler();
+    const rt = makeRt();
+    const pair = await dh.pair_make(
+      { type: DataType.NUMBER, value: 1 },
+      { type: DataType.NUMBER, value: 2 },
+    );
+    await expect(moduleToPython(rt, dh, pair)).rejects.toThrow(Py2JsRuntimeError);
+
+    const arr = await dh.array_make(DataType.NUMBER, 2);
+    await expect(moduleToPython(rt, dh, arr)).rejects.toThrow(Py2JsRuntimeError);
+  });
+
+  test("CLOSURE becomes an asyncOnly PyFunction", async () => {
+    const dh = new GenericDataHandler();
+    const rt = makeRt();
+    async function* addOne(
+      x: TypedValue<DataType>,
+    ): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+      await Promise.resolve(); // conductor's ExternCallable contract requires an async generator
+      return { type: DataType.NUMBER, value: (x as TypedValue<DataType.NUMBER>).value + 1 };
+    }
+    const closure = await dh.closure_make(
+      { returnType: DataType.NUMBER, args: [DataType.NUMBER] },
+      addOne,
+    );
+    const fn = await moduleToPython(rt, dh, closure, "add_one");
+    expect(typeof fn).toBe("function");
+    const f = fn as unknown as { pyName: string; asyncOnly?: boolean };
+    expect(f.pyName).toBe("add_one");
+    expect(f.asyncOnly).toBe(true);
+
+    // Sync call rejects: this is the guard that makes a hot, synchronously
+    // sampled module callback fail loudly instead of misbehaving if it tries
+    // to call an imported function that needs a real round-trip.
+    expect(() => rt.callSync(fn as never, [4n])).toThrow(/frontend round-trip/);
+
+    // Async call goes through and produces the right value.
+    expect(await rt.acall(fn as never, [4n])).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on #282 (and lands after #288's conductor evaluator). Step 3, and the last one in the depth-first chapter-1 sequence: py2js can import and use conductor modules, wired against the **real** `IDataHandler`/`ExternCallable` protocol — not the simulated module the original experiment (`experiments/py2js/module-bench.ts`) measured against.

### The finding that shaped this design

Before writing any interop code, I read conductor's actual contract rather than continuing to assume the earlier experiment's numbers held. The key fact: `ExternCallable<Arg, Ret> = (...args) => AsyncGenerator<void, TypedValue<Ret>, undefined>`. **Every closure crossing the module boundary, in either direction, is an async-generator call by conductor's own contract — not an implementation choice of any particular engine.** `.next()` on an async generator always resolves via microtask, even when the generator body does zero `yield`s.

Concretely:
- **Python calling an imported module function** (`from math import sqrt`): unavoidably async — wrapped as an `asyncOnly` `PyFunction`, callable only through `acall`/dual mode.
- **A module calling a Python-defined function** (the sound-module scenario): still crosses one microtask per call — but the work *inside* that call is a single direct `rt.callSync`, not the CSE machine's interpreter re-entry (pushing onto `control`/`stash`, resuming the whole step loop) per call. That's the real, honestly-measured value of dual compilation against the actual protocol.

I checked whether there's a bypass (`opaque_make(v: any)` can wrap a raw function) and deliberately didn't use it — it would only work for a py2js-specific module convention, breaking conductor's "any module works with any language" guarantee.

### A refactor this uncovered: `GenericDataHandler`

Reading `PyCseEvaluatorBase`'s `IDataHandler` implementation in full (~150 lines: pair/array/closure/opaque bookkeeping) showed it has **zero CSE-specific logic** — just `Map`s keyed by an incrementing id. py2js needs the identical implementation to interoperate with modules at all, so (per discussion) it's extracted to `src/conductor/GenericDataHandler.ts`; `PyCseEvaluatorBase` now holds an instance via composition instead of implementing `IDataHandler` itself — a pure extraction, no behavior change, its own bundle rebuilds cleanly and the full suite is green. One wrinkle this surfaced: `ModuleLoaderRunnerPlugin`'s constructor wants a single object satisfying `IEvaluator & IDataHandler` (`IInterfacableEvaluator`), which an evaluator-plus-separate-handler no longer is on one object — a small Proxy-based combinator (`asInterfacableEvaluator`) merges them at each registration site instead of ~20 lines of forwarding methods duplicated per evaluator.

### New in `src/engines/py2js/`

- **`moduleInterop.ts`** — `pythonToModule`/`moduleToPython`, mirroring `engines/cse/modules.ts`'s value mapping (NUMBER↔float, none↔EMPTY_LIST, OPAQUE↔`PyOpaque`, CLOSURE↔function) so a module behaves identically regardless of engine. Imported functions become `asyncOnly` `PyFunction`s; a Python closure crossing into a module wraps via `closure_make` with a body doing the synchronous `rt.callSync`. `PAIR`/`ARRAY` are rejected — chapter 1 has no list type and no way to consume one anyway (same reasoning as the WASM module-interop draft, #283). `loadChunkImports` orchestrates the per-chunk async pre-pass (request module, convert exports), mirroring `modules.ts`'s `evaluateImports`/`loadModules`.
- **`runtime.ts`** — `PyOpaque` added to `PyValue`, for module values with no py2js-native representation.
- **`compiler.ts`** — `FromImport` binds through the *same* `emitName(write=true)` path an ordinary assignment uses, so it works identically in program mode (`let` local) and REPL mode (globals table) with no separate code path; the resolved value is read back via `__py.importedValue(name)`, populated by the async pre-pass before the chunk runs.
- **`index.ts`** — `Py2JsSession` compiles a chunk with imports in dual mode automatically; import-free chunks stay on the fast sync path (no cost to programs that don't import anything).

`conductor/Py2JsEvaluator.ts` now registers `ModuleLoaderRunnerPlugin` with a `GenericDataHandler`, mirroring `PyCseEvaluatorBase`'s own registration.

## Test plan

- `py2js-module-interop.test.ts` (new) — unit-level conversions against a real `GenericDataHandler` (no mock needed, it's fully generic): scalars, `PyOpaque` round-trip, complex rejected, a Python function becomes a module-callable closure (verified via `closure_call_unchecked`, the module's-eye view), `PAIR`/`ARRAY` rejected, an imported `CLOSURE` becomes an `asyncOnly` `PyFunction` (sync call rejects, async call works)
- `py2js-from-import.test.ts` (new) — end-to-end through `Py2JsSession` with a mocked `ModuleLoaderRunnerPlugin.instance`: scalar/function imports, aliasing, cross-chunk persistence, `ModuleNotFoundError`/`ImportError` wording, an async-round-trip import, **the flagship sound-module scenario** (a fake `play(wave, n)` module samples a Python-defined `wave` via conductor's own `closure_call_unchecked` — never touching `rt.callSync` directly, since real module code is engine-agnostic), and the `asyncOnly` guard firing when a synchronously-sampled callback tries to call a round-trip-needing import from inside itself
- `yarn jest` — full suite green (50 suites, 15 817 tests)
- `yarn tsx scripts/build.ts --evaluator Py2JsEvaluator1` and `--evaluator PyCseEvaluator1` — both bundle cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbExZBaxgeUL4oi1t7PG93