### PR TITLE
py2js: chapter 2 support (pairs, linked-list stdlib, prelude execution)

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -19,6 +19,7 @@ const allTargets = [
   "PyPvmlEvaluator4",
   "PyPvmlPynterEvaluator",
   "Py2JsEvaluator1",
+  "Py2JsEvaluator2",
   "PyStepperEvaluator1",
   "PyStepperEvaluator2",
 ] as const;

--- a/src/conductor/Py2JsEvaluator.ts
+++ b/src/conductor/Py2JsEvaluator.ts
@@ -20,7 +20,7 @@ import { EvaluatorError } from "./errors";
  * result value; a chunk that wants to surface a value print()s it. Output
  * streams per print() line through the session's onOutput hook.
  *
- * Chapter 1 only for now (the engine rejects other variants); Py2JsEvaluator2..4
+ * Chapters 1-2 for now (the engine rejects other variants); Py2JsEvaluator3/4
  * will follow the engine's chapter coverage.
  */
 abstract class Py2JsEvaluatorBase extends BasicEvaluator {
@@ -47,5 +47,11 @@ abstract class Py2JsEvaluatorBase extends BasicEvaluator {
 export class Py2JsEvaluator1 extends Py2JsEvaluatorBase {
   constructor(conductor: IRunnerPlugin) {
     super(conductor, 1);
+  }
+}
+
+export class Py2JsEvaluator2 extends Py2JsEvaluatorBase {
+  constructor(conductor: IRunnerPlugin) {
+    super(conductor, 2);
   }
 }

--- a/src/conductor/index.ts
+++ b/src/conductor/index.ts
@@ -12,7 +12,7 @@ export {
   PyPvmlEvaluator4,
 } from "./PyPvmlEvaluator";
 export { PyPvmlPynterEvaluator } from "./PyPvmlPynterEvaluator";
-export { Py2JsEvaluator1 } from "./Py2JsEvaluator";
+export { Py2JsEvaluator1, Py2JsEvaluator2 } from "./Py2JsEvaluator";
 export { PyStepperEvaluator1, PyStepperEvaluator2 } from "./PyStepperEvaluator";
 export {
   PyWasmEvaluator1,

--- a/src/engines/py2js/index.ts
+++ b/src/engines/py2js/index.ts
@@ -7,14 +7,15 @@
  * run against a fresh Py2JsRuntime, collecting print() output.
  *
  * Exec-style only, like the PVML-in-browser pathway: a program has no "final
- * value" — everything observable goes through print(). Currently chapter 1
- * only; the runtime's operator helpers implement the §1 typing rules
- * (docs/specs/python_typing_front.tex, python_typing_middle_12.tex,
+ * value" — everything observable goes through print(). Currently chapters
+ * 1-2 (identical operator typing rules at both — docs/specs/
+ * python_typing_front.tex, python_typing_middle_12.tex,
  * python_typing_back.tex), pinned against the CSE machine by
  * src/tests/operator-conformance-py2js.test.ts.
  */
 import { parse } from "../../parser";
 import { Resolver } from "../../resolver";
+import linkedList from "../../stdlib/linked-list";
 import math from "../../stdlib/math";
 import misc from "../../stdlib/misc";
 import type { Group } from "../../stdlib/utils";
@@ -23,13 +24,16 @@ import { CompileMode, compileProgram, Py2JsCompileError } from "./compiler";
 import { annotateHostFunction, Py2JsRuntime, Py2JsRuntimeError, PyValue } from "./runtime";
 import { bridgeStdlibGroups } from "./stdlibBridge";
 
+const SUPPORTED_CHAPTERS = [1, 2];
+
 /**
  * Stdlib groups per chapter, bridged into the runtime by prepare(). Mirrors
- * runner.ts's VARIANT_GROUPS[1] (kept separate so the engine does not pull
- * in the runner's conductor plumbing); extend as chapters 2+ land.
+ * runner.ts's VARIANT_GROUPS (kept separate so the engine does not pull in
+ * the runner's conductor plumbing); extend as chapters 3+ land.
  */
 const PY2JS_GROUPS: Record<number, Group[]> = {
   1: [misc, math],
+  2: [misc, math, linkedList],
 };
 
 export { Py2JsCompileError, Py2JsRuntime, Py2JsRuntimeError };
@@ -65,23 +69,77 @@ const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as
   ...args: string[]
 ) => (rt: Py2JsRuntime) => Promise<void>;
 
+/**
+ * Compiles `script` against `rt`'s current builtins/globals and returns the
+ * generated JS — REPL mode always, with `priorGlobals` as whatever
+ * module-level names already exist (empty for the prelude itself; the
+ * prelude's own names for the main script). REPL mode's globals *table* is
+ * what lets a prelude define names a separately-compiled later script can
+ * see; program mode's per-call `let` locals cannot span two compilations
+ * (see compiler.ts's mode doc) — the reason `prepare()` uses REPL mode
+ * unconditionally rather than only when a chapter actually has a prelude.
+ */
+function compileScript(
+  rt: Py2JsRuntime,
+  script: string,
+  variant: number,
+  mode: CompileMode,
+): string {
+  let ast;
+  try {
+    ast = parse(script);
+  } catch (e: unknown) {
+    throw new Py2JsRunError("parse", String((e as { message?: string })?.message ?? e));
+  }
+
+  const priorGlobals = Object.keys(rt.globals);
+  // Same static pipeline as the other engines: the Resolver checks names and
+  // enforces the chapter's feature validators. The runtime's builtin names
+  // are passed as prelude names (its own term for names resolvable without a
+  // binding statement) so they resolve without a stdlib group; priorGlobals
+  // are real module-level bindings an earlier compilation (the prelude) made.
+  const resolver = new Resolver(
+    script,
+    ast,
+    makeValidatorsForChapter(variant),
+    [],
+    Object.keys(rt.builtins),
+    priorGlobals,
+  );
+  const errors = resolver.resolve(ast);
+  if (errors.length > 0) {
+    throw new Py2JsRunError("analysis", errors.map(e => e.message).join("\n"));
+  }
+
+  try {
+    return compileProgram(ast, Object.keys(rt.builtins), { mode, repl: { priorGlobals } });
+  } catch (e: unknown) {
+    if (e instanceof Py2JsCompileError) throw new Py2JsRunError("analysis", e.message);
+    throw e;
+  }
+}
+
 function prepare(
   code: string,
   variant: number,
   mode: CompileMode,
   options: RunPy2JsOptions,
 ): { rt: Py2JsRuntime; js: string } {
-  if (variant !== 1) {
-    throw new Py2JsRunError("parse", `py2js currently supports chapter 1 only (got ${variant})`);
+  if (!SUPPORTED_CHAPTERS.includes(variant)) {
+    throw new Py2JsRunError(
+      "parse",
+      `py2js currently supports chapters ${SUPPORTED_CHAPTERS.join("-")} only (got ${variant})`,
+    );
   }
 
   const rt = new Py2JsRuntime();
   const script = code.endsWith("\n") ? code : code + "\n";
+  const groups = PY2JS_GROUPS[variant] ?? [];
 
   // The chapter's stdlib groups, bridged to native values (stdlibBridge.ts).
   // The runtime's native core (print/input/arity) wins over same-named
   // bridged entries; extraBuiltins (module bindings etc.) override anything.
-  const bridged = bridgeStdlibGroups(rt, PY2JS_GROUPS[variant] ?? [], script, variant);
+  const bridged = bridgeStdlibGroups(rt, groups, script, variant);
   for (const [name, value] of Object.entries(bridged)) {
     if (!(name in rt.builtins)) rt.builtins[name] = value;
   }
@@ -94,35 +152,28 @@ function prepare(
     rt.builtins[name] = annotateHostFunction(name, value);
   }
 
-  let ast;
-  try {
-    ast = parse(script);
-  } catch (e: unknown) {
-    throw new Py2JsRunError("parse", String((e as { message?: string })?.message ?? e));
+  // Group preludes (SICPy source defining higher-level functions in terms of
+  // the group's own primitives — e.g. linked-list.prelude.ts's map/filter/
+  // reduce) run once, always in sync mode: nothing at chapter 1-2 imports
+  // anything, so there is no reason for the prelude itself to need the async
+  // spine even when the main script below is compiled in dual mode.
+  const preludeText = groups
+    .map(g => g.prelude ?? "")
+    .filter(p => p.trim())
+    .join("\n");
+  if (preludeText.trim()) {
+    const preludeJs = compileScript(rt, preludeText + "\n", variant, "sync");
+    try {
+      new Function("__py", preludeJs)(rt);
+    } catch (e: unknown) {
+      throw new Py2JsRunError(
+        "runtime",
+        e instanceof Error ? `${e.name}: ${e.message}` : String(e),
+      );
+    }
   }
 
-  // Same static pipeline as the other engines: the Resolver checks names and
-  // enforces the chapter's feature validators. The runtime's builtin names
-  // are passed as prelude names so they resolve without a stdlib group.
-  const resolver = new Resolver(
-    script,
-    ast,
-    makeValidatorsForChapter(variant),
-    [],
-    Object.keys(rt.builtins),
-  );
-  const errors = resolver.resolve(ast);
-  if (errors.length > 0) {
-    throw new Py2JsRunError("analysis", errors.map(e => e.message).join("\n"));
-  }
-
-  let js;
-  try {
-    js = compileProgram(ast, Object.keys(rt.builtins), { mode });
-  } catch (e: unknown) {
-    if (e instanceof Py2JsCompileError) throw new Py2JsRunError("analysis", e.message);
-    throw e;
-  }
+  const js = compileScript(rt, script, variant, mode);
   return { rt, js };
 }
 
@@ -206,8 +257,11 @@ export class Py2JsSession {
   private preludeLoaded = false;
 
   constructor(variant: number, options: Py2JsSessionOptions = {}) {
-    if (variant !== 1) {
-      throw new Py2JsRunError("parse", `py2js currently supports chapter 1 only (got ${variant})`);
+    if (!SUPPORTED_CHAPTERS.includes(variant)) {
+      throw new Py2JsRunError(
+        "parse",
+        `py2js currently supports chapters ${SUPPORTED_CHAPTERS.join("-")} only (got ${variant})`,
+      );
     }
     this.variant = variant;
     this.groups = PY2JS_GROUPS[variant] ?? [];

--- a/src/engines/py2js/runtime.ts
+++ b/src/engines/py2js/runtime.ts
@@ -192,6 +192,11 @@ function toDisplayValue(v: PyValue): Value {
       if (v instanceof PyPair) {
         return { type: "list", value: [toDisplayValue(v.head), toDisplayValue(v.tail)] };
       }
+      // stringify()'s convert() has no dedicated "opaque" case — it falls to
+      // the generic `<${type} object>` fallback, matching pyStr's own
+      // "<opaque object>" rendering, so this is just as accurate as a
+      // dedicated case would be.
+      if (v instanceof PyOpaque) return { type: "opaque", value: v.typed };
       return { type: "complex", value: v };
   }
 }
@@ -221,10 +226,16 @@ export function pyStr(v: PyValue): string {
 
 /** Whether `v` is a proper linked list: a chain of pairs terminated by None,
  * as opposed to an arbitrary pair — mirrors isProperList in
- * src/stdlib/linked-list.ts (the distinction print_llist uses below). */
+ * src/stdlib/linked-list.ts (the distinction print_llist uses below).
+ * Iterative rather than (tail-)recursive: JS engines don't guarantee TCO, so
+ * a long list would otherwise risk a stack overflow — the same failure mode
+ * printLlist's own outer list-walking `while` loop below already avoids. */
 function isProperList(v: PyValue): boolean {
-  if (v === null) return true;
-  return v instanceof PyPair && isProperList(v.tail);
+  let current = v;
+  while (current instanceof PyPair) {
+    current = current.tail;
+  }
+  return current === null;
 }
 
 /**

--- a/src/engines/py2js/runtime.ts
+++ b/src/engines/py2js/runtime.ts
@@ -1,24 +1,33 @@
 /**
  * py2js engine — runtime library.
  *
- * Native (unboxed) JS value model for SICPy chapter 1:
+ * Native (unboxed) JS value model for SICPy chapters 1-2:
  *   int      -> bigint
  *   float    -> number
  *   bool     -> boolean
  *   str      -> string
  *   None     -> null
  *   complex  -> PyComplexNumber (src/types)
+ *   list     -> PyPair (chapter 2's "list" is always a 2-element cons cell
+ *               built by pair()/llist(); see stdlibBridge.ts for the
+ *               conversion to/from CSE's flat 2-element list Value)
  *   function -> JS function carrying pyName/pyArity metadata
  *
  * User values stay unboxed so V8 can JIT the compiled program; the Python
- * chapter-1 operator semantics live in the helpers below, which mirror
+ * operator semantics live in the helpers below, which mirror
  * evaluateBinaryExpression / evaluateUnaryExpression in
  * src/engines/cse/operators.ts (the reference implementation) — same dispatch
- * order, same §1 restrictions. The operator typing rules themselves are
- * specified in docs/specs/python_typing_front.tex, python_typing_middle_12.tex
- * and python_typing_back.tex; conformance against them is pinned by
- * src/tests/operator-conformance-py2js.test.ts, which sweeps the full
- * operator × type × type cross product against the CSE machine.
+ * order, same §1/§2 restrictions (identical at these two chapters — see
+ * docs/specs/python_typing_middle_12.tex). The operator typing rules
+ * themselves are specified in docs/specs/python_typing_front.tex,
+ * python_typing_middle_12.tex and python_typing_back.tex; conformance against
+ * them is pinned by src/tests/operator-conformance-py2js.test.ts, which
+ * sweeps the full operator × type × type cross product against the CSE
+ * machine. pyEquals's bool/function exclusion checks re-apply on every
+ * recursive call into a pair's head/tail, matching CSE's structuralEquals
+ * threading `restrictChapter12` through its own list recursion — since py2js
+ * only supports chapters 1-2 so far, that check is simply unconditional here;
+ * a chapter 3/4 PR will need to parameterize it the same way CSE does.
  *
  * Proper tail calls: compiled functions return a TailCall marker from return
  * statements in tail position; `call` runs the trampoline. In dual mode every
@@ -27,10 +36,33 @@
  * through callSync — see compiler.ts's mode documentation.
  */
 import { numericCompare, pythonMod } from "../cse/utils";
-import { toPythonFloat } from "../../stdlib/utils";
+import type { Value } from "../cse/stash";
+import { toPythonFloat, toPythonString } from "../../stdlib/utils";
 import { PyComplexNumber } from "../../types";
+import { stringify } from "../../utils/stringify";
 
-export type PyValue = bigint | number | boolean | string | null | PyComplexNumber | PyFunction;
+export type PyValue =
+  | bigint
+  | number
+  | boolean
+  | string
+  | null
+  | PyComplexNumber
+  | PyPair
+  | PyFunction;
+
+/**
+ * Chapter 2's pair: a 2-element cons cell built by pair()/llist(), the same
+ * shape the CSE machine represents as a 2-element list Value. Mutable fields
+ * to match that representation exactly, though nothing at chapter 2 can
+ * actually mutate one — pairmutator (set_head/set_tail) is chapter 3+.
+ */
+export class PyPair {
+  constructor(
+    public head: PyValue,
+    public tail: PyValue,
+  ) {}
+}
 
 export interface PyFunction {
   (...args: PyValue[]): PyValue | TailCall;
@@ -97,7 +129,10 @@ export function pyTypeName(v: PyValue): string {
     case "function":
       return "function";
     case "object":
-      return v === null ? "NoneType" : "complex";
+      if (v === null) return "NoneType";
+      // Matches CPython's type(...).__name__ via typeTranslator in the CSE
+      // machine (engines/cse/types.ts): a 2-element pair is always "list".
+      return v instanceof PyPair ? "list" : "complex";
     default:
       return "NoneType";
   }
@@ -109,6 +144,39 @@ function unsupported(op: string, l: PyValue, r?: PyValue): never {
     "UnsupportedOperandTypeError",
     `unsupported operand type(s) for ${op}: '${pyTypeName(l)}'${rhs}`,
   );
+}
+
+/**
+ * Converts a PyValue into the minimal CSE Value shape src/utils/stringify.ts
+ * needs, so pyStr's pair rendering (bracket notation, and recursively for
+ * anything nested inside) is pixel-identical to the CSE machine's own
+ * structured print — by reusing the actual algorithm, not a second
+ * hand-written copy that could quietly drift. Only reached for pairs (and
+ * whatever they contain); every other pyStr case keeps its own fast path.
+ */
+function toDisplayValue(v: PyValue): Value {
+  if (v === null) return { type: "none" };
+  switch (typeof v) {
+    case "bigint":
+      return { type: "bigint", value: v };
+    case "number":
+      return { type: "number", value: v };
+    case "boolean":
+      return { type: "bool", value: v };
+    case "string":
+      return { type: "string", value: v };
+    case "function":
+      // stringify's convert() only reads `.name` for these two Value kinds —
+      // the rest of BuiltinValue/FunctionValue's shape is irrelevant here.
+      return (
+        v.pyBuiltin ? { type: "builtin", name: v.pyName } : { type: "function", name: v.pyName }
+      ) as Value;
+    default:
+      if (v instanceof PyPair) {
+        return { type: "list", value: [toDisplayValue(v.head), toDisplayValue(v.tail)] };
+      }
+      return { type: "complex", value: v };
+  }
 }
 
 export function pyStr(v: PyValue): string {
@@ -124,10 +192,43 @@ export function pyStr(v: PyValue): string {
     case "function":
       return v.pyBuiltin ? `<built-in function ${v.pyName}>` : `<function ${v.pyName}>`;
     case "object":
-      return v === null ? "None" : v.toString();
+      if (v === null) return "None";
+      if (v instanceof PyPair) return stringify(toDisplayValue(v));
+      return v.toString();
     default:
       return "None";
   }
+}
+
+/** Whether `v` is a proper linked list: a chain of pairs terminated by None,
+ * as opposed to an arbitrary pair — mirrors isProperList in
+ * src/stdlib/linked-list.ts (the distinction print_llist uses below). */
+function isProperList(v: PyValue): boolean {
+  if (v === null) return true;
+  return v instanceof PyPair && isProperList(v.tail);
+}
+
+/**
+ * print_llist's box-and-pointer rendering — ports the CSE machine's
+ * _print_llist/_is_llist (src/stdlib/linked-list.ts): a proper list renders
+ * as `llist(a, b, c)`, any other pair as bracket notation `[a, b]`
+ * (recursively), and a non-pair leaf via toPythonString's repr mode (reused
+ * directly, via toDisplayValue, rather than re-implementing string escaping)
+ * — same as CSE's `toPythonString(value, true)` leaf case.
+ */
+function printLlist(v: PyValue): string {
+  if (!isProperList(v)) {
+    if (!(v instanceof PyPair)) return toPythonString(toDisplayValue(v), true);
+    return `[${printLlist(v.head)}, ${printLlist(v.tail)}]`;
+  }
+  let s = "llist(";
+  let current: PyValue = v;
+  while (current instanceof PyPair) {
+    s += printLlist(current.head) + ", ";
+    current = current.tail;
+  }
+  if (s.endsWith(", ")) s = s.slice(0, -2);
+  return s + ")";
 }
 
 const isNum = (v: PyValue): v is bigint | number => typeof v === "bigint" || typeof v === "number";
@@ -170,7 +271,16 @@ function pyEquals(l: PyValue, r: PyValue): boolean {
   }
   if (isNum(l) && isNum(r)) return numericCompare(l, r) === 0;
   if (l === null && r === null) return true;
-  return l === r; // strings by value; mixed types are simply unequal
+  if (l instanceof PyPair && r instanceof PyPair) {
+    // Identity shortcut first (mirrors CSE's structuralEquals — also lets a
+    // self-referential pair compare equal to itself without recursing
+    // forever, though chapter 2 has no pairmutator to build a cycle with).
+    // The recursive pyEquals calls re-run this function's own bool/function
+    // exclusion checks on each element, matching CSE's restrictChapter12
+    // re-check at every level of list recursion.
+    return l === r || (pyEquals(l.head, r.head) && pyEquals(l.tail, r.tail));
+  }
+  return l === r; // strings by value; mixed types (incl. pair vs non-pair) are simply unequal
 }
 
 /**
@@ -434,7 +544,11 @@ export class Py2JsRuntime {
       case "function":
         return true;
       case "object":
-        return v === null ? false : v.real !== 0 || v.imag !== 0;
+        if (v === null) return false;
+        // Pairs are always truthy — Python has no "empty pair" concept
+        // (isFalsy's default in cse/operators.ts: all other objects are
+        // truthy); None is the empty *list*, already handled above.
+        return v instanceof PyPair ? true : v.real !== 0 || v.imag !== 0;
       default:
         return false;
     }
@@ -561,6 +675,14 @@ export class Py2JsRuntime {
         "RuntimeError",
         "input() is not supported by the py2js engine yet",
       );
+    }),
+    // Native rather than bridged: CSE's print_llist (stdlib/linked-list.ts)
+    // is async (writes to the output stream directly), like print/input.
+    print_llist: this.builtin("print_llist", 1, v => {
+      const line = printLlist(v);
+      this.output.push(line + "\n");
+      this.onOutput?.(line);
+      return null;
     }),
     arity: this.builtin("arity", 1, f => {
       if (typeof f !== "function") {

--- a/src/engines/py2js/stdlibBridge.ts
+++ b/src/engines/py2js/stdlibBridge.ts
@@ -101,9 +101,7 @@ function toTagged(v: PyValue): Value {
     }
     default:
       if (v === null) return { type: "none" };
-      if (v instanceof PyPair) {
-        return { type: "list", value: [toTagged(v.head), toTagged(v.tail)] };
-      }
+      if (v instanceof PyPair) return toTaggedPair(v);
       // No chapter-1/2 stdlib builtin accepts an opaque module value as an
       // argument (abs/math_sqrt/etc. all type-check against "opaque" being
       // absent from their accepted types), so this just needs to produce
@@ -112,6 +110,33 @@ function toTagged(v: PyValue): Value {
       if (v instanceof PyOpaque) return { type: "opaque", value: v.typed };
       return { type: "complex", value: v };
   }
+}
+
+/**
+ * Converts a PyPair chain to CSE's nested list Value, iterating along the
+ * `.tail` spine instead of recursing: a long proper list (enum_llist,
+ * reverse, map, …) has its length entirely along that spine, so a naive
+ * `{ type: "list", value: [toTagged(v.head), toTagged(v.tail)] }` would cost
+ * one JS stack frame per *element* just to convert a single argument for one
+ * bridged call — a list of a few thousand elements already overflows the
+ * stack, regardless of how tail-recursive the user's own Python is (its own
+ * tail calls go through py2js's trampoline; this bridge conversion does not).
+ * `.head` is still converted via the ordinary (recursive) toTagged, since a
+ * head is normally a scalar leaf; a list-of-lists nested arbitrarily deep
+ * through `.head` remains a (much rarer) recursion, same as before.
+ */
+function toTaggedPair(pair: PyPair): Value {
+  const heads: PyValue[] = [];
+  let current: PyValue = pair;
+  while (current instanceof PyPair) {
+    heads.push(current.head);
+    current = current.tail;
+  }
+  let tail = toTagged(current);
+  for (let i = heads.length - 1; i >= 0; i--) {
+    tail = { type: "list", value: [toTagged(heads[i]), tail] };
+  }
+  return tail;
 }
 
 function fromTagged(name: string, v: Value): PyValue {

--- a/src/engines/py2js/stdlibBridge.ts
+++ b/src/engines/py2js/stdlibBridge.ts
@@ -9,13 +9,22 @@
  * stdlib semantics can never drift between them. Conformance is pinned by
  * src/tests/stdlib-conformance-py2js.test.ts.
  *
- * What crosses the boundary at chapter 1: int/float/bool/str/None/complex
- * round-trip losslessly (complex is a PyComplexNumber on both sides).
- * Functions cross one way only (as arguments — no chapter-1 stdlib builtin
- * returns a function): a user function becomes a minimal FunctionValue (so
- * is_function answers True and error messages say 'function'), a py2js
- * builtin becomes a stub BuiltinValue. Neither is callable from stdlib code,
- * which no chapter-1 builtin attempts.
+ * What crosses the boundary at chapters 1-2: int/float/bool/str/None/complex
+ * round-trip losslessly (complex is a PyComplexNumber on both sides); a pair
+ * (PyPair) round-trips recursively to/from CSE's flat 2-element list Value —
+ * chapter 2 has no list-literal syntax and no list.ts group, so pair()/
+ * llist() (the only way to construct one) always produce exactly that shape.
+ * A function crosses one way *as a value a builtin inspects* (a user function
+ * becomes a minimal FunctionValue, so is_function answers True and error
+ * messages say 'function'; a py2js builtin becomes a stub BuiltinValue —
+ * neither is callable from stdlib code, which no chapter-1/2 builtin
+ * attempts) — but it can still flow back out *unchanged*, e.g.
+ * `head(pair(1, f))` or `llist(f)`, since no chapter-1/2 builtin fabricates a
+ * genuinely new function value, only passes an argument through structurally
+ * (into/out of a pair). `functionOrigin` (a WeakMap from the synthetic tagged
+ * stand-in back to the real PyFunction) is what makes that round-trip
+ * lossless without reconstructing a function from its printable stand-in,
+ * which is impossible in general.
  *
  * Error handling: stdlib builtins raise through handleRuntimeError, which
  * records on the bridge's Context and throws the error class — the throw
@@ -39,7 +48,7 @@ import type { Group } from "../../stdlib/utils";
 import { Context } from "../cse/context";
 import type { Environment } from "../cse/environment";
 import type { BuiltinValue, Value } from "../cse/stash";
-import { Py2JsRuntime, Py2JsRuntimeError, PyFunction, PyValue } from "./runtime";
+import { Py2JsRuntime, Py2JsRuntimeError, PyFunction, PyPair, PyValue } from "./runtime";
 
 function syntheticCallNode(name: string): ExprNS.Call {
   const token = new Token(TokenType.NAME, name, 1, 0, 0);
@@ -47,6 +56,10 @@ function syntheticCallNode(name: string): ExprNS.Call {
   const callee = new ExprNS.Variable(token, token, token);
   return new ExprNS.Call(token, token, callee, []);
 }
+
+/** Maps a synthetic tagged stand-in (built below) back to the real PyFunction
+ * it stands in for — see the file header's note on lossless pass-through. */
+const functionOrigin = new WeakMap<object, PyFunction>();
 
 function toTagged(v: PyValue): Value {
   switch (typeof v) {
@@ -64,7 +77,7 @@ function toTagged(v: PyValue): Value {
       // annotateHostFunction (index.ts establishes the metadata invariant
       // for extraBuiltins; Function#name can be "", hence || not ??).
       const name = v.pyName ?? (v.name || "(anonymous)");
-      return v.pyBuiltin
+      const tagged: Value = v.pyBuiltin
         ? {
             type: "builtin",
             name,
@@ -83,9 +96,14 @@ function toTagged(v: PyValue): Value {
             body: [],
             env: undefined as unknown as Environment,
           };
+      functionOrigin.set(tagged, v);
+      return tagged;
     }
     default:
       if (v === null) return { type: "none" };
+      if (v instanceof PyPair) {
+        return { type: "list", value: [toTagged(v.head), toTagged(v.tail)] };
+      }
       return { type: "complex", value: v };
   }
 }
@@ -101,9 +119,36 @@ function fromTagged(name: string, v: Value): PyValue {
       return v.value;
     case "none":
       return null;
+    case "list":
+      // Chapter 2 has no list-literal syntax and no list.ts group (chapter
+      // 3+), so pair()/llist() — the only way to construct one — always
+      // produce exactly a 2-element cons cell; anything else would mean
+      // list.ts got bridged ahead of chapter-3 support actually landing.
+      if (v.value.length !== 2) {
+        throw new Py2JsRuntimeError(
+          "SystemError",
+          `stdlib bridge: ${name}() returned a non-pair list value (length ${v.value.length}), not yet supported`,
+        );
+      }
+      return new PyPair(fromTagged(name, v.value[0]), fromTagged(name, v.value[1]));
+    case "function":
+    case "builtin": {
+      // A function value only ever flows back out as one of THIS bridge's
+      // own synthetic stand-ins passed through unchanged (see file header;
+      // e.g. head(pair(1, f)) or llist(f)) — never a genuinely new closure a
+      // builtin fabricated, which no chapter-1/2 builtin does. Recover the
+      // original PyFunction rather than trying to reconstruct one.
+      const original = functionOrigin.get(v);
+      if (original !== undefined) return original;
+      throw new Py2JsRuntimeError(
+        "SystemError",
+        `stdlib bridge: ${name}() returned a function value the bridge did not itself produce`,
+      );
+    }
     default:
-      // No chapter-1 stdlib builtin returns a function/closure/list; reaching
-      // this means the bridge needs extending, not that user code is wrong.
+      // No chapter-1/2 stdlib builtin returns a closure or list-family value
+      // other than a pair; reaching this means the bridge needs extending,
+      // not that user code is wrong.
       throw new Py2JsRuntimeError(
         "SystemError",
         `stdlib bridge: ${name}() returned an unbridgeable '${v.type}' value`,

--- a/src/tests/Py2JsEvaluator.test.ts
+++ b/src/tests/Py2JsEvaluator.test.ts
@@ -8,7 +8,7 @@
  * whose binding never executed raises NameError.
  */
 import type { IRunnerPlugin } from "@sourceacademy/conductor/runner";
-import { Py2JsEvaluator1 } from "../conductor/Py2JsEvaluator";
+import { Py2JsEvaluator1, Py2JsEvaluator2 } from "../conductor/Py2JsEvaluator";
 
 /** Minimal IRunnerPlugin mock: the evaluator only ever calls sendResult/
  * sendError/sendOutput on its `conductor`. */
@@ -125,5 +125,30 @@ describe("Py2JsEvaluator1", () => {
 
     expect(errors).toEqual([]);
     expect(outputs).toEqual(["1", "a b", ""]);
+  });
+});
+
+describe("Py2JsEvaluator2", () => {
+  test("the linked-list prelude is available from the first chunk, and pairs persist across chunks", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new Py2JsEvaluator2(conductor);
+
+    await evaluator.evaluateChunk("xs = pair(1, pair(2, pair(3, None)))\n");
+    await evaluator.evaluateChunk("print(length(xs))\n");
+    await evaluator.evaluateChunk("print(reverse(xs))\n");
+
+    expect(errors).toEqual([]);
+    expect(outputs).toEqual(["3", "[3, [2, [1, None]]]"]);
+  });
+
+  test("a function defined in one chunk works as a callback passed to a later chunk's map", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new Py2JsEvaluator2(conductor);
+
+    await evaluator.evaluateChunk("def double(x):\n    return x * 2\n");
+    await evaluator.evaluateChunk("print(map(double, pair(1, pair(2, None))))\n");
+
+    expect(errors).toEqual([]);
+    expect(outputs).toEqual(["[2, [4, None]]"]);
   });
 });

--- a/src/tests/operator-conformance-py2js.test.ts
+++ b/src/tests/operator-conformance-py2js.test.ts
@@ -19,8 +19,9 @@
  * underlying value is guaranteed to agree on text too — no float-tolerance
  * machinery needed (both sides do plain JS `number` arithmetic).
  *
- * Chapter 1 only for now: the py2js runtime implements the §1 operator
- * typing rules; extend the chapter list as the engine grows into §2+.
+ * Chapters 1-2 (identical operator typing rules at both — python_typing_*.tex
+ * doesn't distinguish them); extend the chapter list as the engine grows
+ * into §3+.
  */
 import { StmtNS } from "../ast-types";
 import { Context } from "../engines/cse/context";
@@ -35,7 +36,7 @@ import { makeValidatorsForChapter } from "../validator";
 import { BINARY_OPS_12, literalFor, universeForChapter } from "./operator-spec";
 import { generateMockStreams } from "./utils";
 
-const PY2JS_CHAPTERS = [1];
+const PY2JS_CHAPTERS = [1, 2];
 
 type Outcome = { kind: "value"; text: string } | { kind: "error" };
 

--- a/src/tests/stdlib-conformance-py2js.test.ts
+++ b/src/tests/stdlib-conformance-py2js.test.ts
@@ -4,28 +4,34 @@
  * The py2js engine runs the *same* stdlib builtin implementations as the CSE
  * machine, through the value-conversion bridge in
  * src/engines/py2js/stdlibBridge.ts. This suite pins that bridge: every
- * chapter-1 builtin and constant of the misc/math groups is swept over
- * representative argument tuples drawn from the chapter-1 type universe, and
+ * builtin and constant of the chapter's stdlib groups is swept over
+ * representative argument tuples drawn from the chapter's type universe, and
  * the outcome (printed text, or error) is compared against the CSE machine
  * evaluating the identical program via runner.ts's runCode — the reference
  * implementation, computed fresh, exactly as the operator conformance sweeps
  * do.
  *
- * Argument tuples per builtin: the empty call, one argument of each
- * chapter-1 type, and int/float pairs — enough to exercise every @Validate
- * arity gate, every per-type dispatch arm, and the bridge's conversions in
- * both directions. Value outcomes compare full printed text (both engines
- * format through toPythonString/pyStr conventions); error outcomes compare
- * that both engines raised.
+ * Argument tuples per builtin: the empty call, one argument of each type in
+ * the chapter's universe, and int/float pairs — enough to exercise every
+ * @Validate arity gate, every per-type dispatch arm, and the bridge's
+ * conversions in both directions. Value outcomes compare full printed text
+ * (both engines format through toPythonString/pyStr conventions); error
+ * outcomes compare that both engines raised.
  *
  * Exclusions:
  *  - input: stream-based; py2js deliberately raises "not supported yet"
  *    while the CSE runner blocks on (closed) stdin — no comparable outcome.
  *  - random_random / time_time: nondeterministic values; success-vs-error
  *    only (KIND_ONLY).
+ *  - print_llist on a *proper* list (llist(...) rendering, as opposed to the
+ *    bracket-notation rendering a flat single-literal call already reaches):
+ *    no flat argument tuple builds one, so that path — and the rest of the
+ *    linked-list prelude (map/filter/reduce/append/…) — is covered by the
+ *    directed cases below instead.
  */
 import { Py2JsRunError, runCodePy2Js } from "../engines/py2js";
 import { RunError, runCode } from "../runner";
+import linkedList from "../stdlib/linked-list";
 import math from "../stdlib/math";
 import misc from "../stdlib/misc";
 import type { Group } from "../stdlib/utils";
@@ -34,32 +40,35 @@ import type { Group } from "../stdlib/utils";
  * list, which chapter 1 rejects). */
 const LITERALS = ["2", "2.5", "(1+2j)", "True", "'ab'", "None", "(lambda x: x)"];
 
+/** Chapter 2 adds "list" — always a pair, per operator-spec.ts's literalFor. */
+const CH2_LITERALS = [...LITERALS, "pair(1, 2)"];
+
 const SKIP = new Set(["input"]);
 const KIND_ONLY = new Set(["random_random", "time_time"]);
 
 type Outcome = { kind: "value"; text: string } | { kind: "error" };
 
-async function cseOutcome(code: string): Promise<Outcome> {
+async function cseOutcome(code: string, variant: number): Promise<Outcome> {
   try {
-    return { kind: "value", text: await runCode(code, 1) };
+    return { kind: "value", text: await runCode(code, variant) };
   } catch (e) {
     if (e instanceof RunError) return { kind: "error" };
     throw e;
   }
 }
 
-function py2jsOutcome(code: string): Outcome {
+function py2jsOutcome(code: string, variant: number): Outcome {
   try {
-    return { kind: "value", text: runCodePy2Js(code, 1).output };
+    return { kind: "value", text: runCodePy2Js(code, variant).output };
   } catch (e) {
     if (e instanceof Py2JsRunError) return { kind: "error" };
     throw e;
   }
 }
 
-async function expectParity(code: string, kindOnly = false): Promise<void> {
-  const wanted = await cseOutcome(code);
-  const actual = py2jsOutcome(code);
+async function expectParity(code: string, variant = 1, kindOnly = false): Promise<void> {
+  const wanted = await cseOutcome(code, variant);
+  const actual = py2jsOutcome(code, variant);
   if (kindOnly) {
     expect(actual.kind).toBe(wanted.kind);
   } else {
@@ -67,32 +76,37 @@ async function expectParity(code: string, kindOnly = false): Promise<void> {
   }
 }
 
-const argTuples: string[][] = [
-  [],
-  ...LITERALS.map(l => [l]),
-  ["2", "2"],
-  ["2", "2.5"],
-  ["2.5", "2"],
-  ["2.5", "2.5"],
+function argTuplesFor(literals: string[]): string[][] {
+  return [[], ...literals.map(l => [l]), ["2", "2"], ["2", "2.5"], ["2.5", "2"], ["2.5", "2.5"]];
+}
+
+const SWEEPS: { chapter: number; groups: Group[]; literals: string[] }[] = [
+  { chapter: 1, groups: [misc, math], literals: LITERALS },
+  { chapter: 2, groups: [misc, math, linkedList], literals: CH2_LITERALS },
 ];
 
-for (const group of [misc, math] as Group[]) {
-  describe(`[py2js] stdlib parity: ${group.name}`, () => {
-    for (const [name, value] of group.builtins) {
-      if (SKIP.has(name)) continue;
+for (const { chapter, groups, literals } of SWEEPS) {
+  const argTuples = argTuplesFor(literals);
+  describe(`[py2js] stdlib parity: chapter ${chapter}`, () => {
+    for (const group of groups) {
+      describe(group.name, () => {
+        for (const [name, value] of group.builtins) {
+          if (SKIP.has(name)) continue;
 
-      if (value.type !== "builtin") {
-        test(`constant ${name}`, async () => {
-          await expectParity(`print(${name})`);
-        });
-        continue;
-      }
+          if (value.type !== "builtin") {
+            test(`constant ${name}`, async () => {
+              await expectParity(`print(${name})`, chapter);
+            });
+            continue;
+          }
 
-      describe(name, () => {
-        for (const args of argTuples) {
-          const code = `print(${name}(${args.join(", ")}))`;
-          test(code, async () => {
-            await expectParity(code, KIND_ONLY.has(name));
+          describe(name, () => {
+            for (const args of argTuples) {
+              const code = `print(${name}(${args.join(", ")}))`;
+              test(code, async () => {
+                await expectParity(code, chapter, KIND_ONLY.has(name));
+              });
+            }
           });
         }
       });
@@ -125,6 +139,53 @@ describe("[py2js] stdlib parity: directed cases", () => {
   for (const code of cases) {
     test(JSON.stringify(code), async () => {
       await expectParity(code);
+    });
+  }
+});
+
+describe("[py2js] stdlib parity: chapter 2 directed cases", () => {
+  const cases = [
+    // print_llist's "llist(...)" branch (a *proper* list) vs. the bracket
+    // notation the flat-literal sweep above already reaches for a bare pair.
+    `print_llist(pair(1, pair(2, pair(3, None))))`,
+    `print_llist(pair(1, 2))`,
+    `print(is_llist(pair(1, pair(2, None))))`,
+    `print(is_llist(pair(1, 2)))`,
+    `print(is_llist(None))`,
+    // the linked-list prelude (SICPy source, compiled and run — not bridged)
+    `print(length(pair(1, pair(2, pair(3, None)))))`,
+    `xs = pair(1, pair(2, pair(3, None)))\nprint(map(lambda x: x * 2, xs))`,
+    `xs = pair(1, pair(2, pair(3, None)))\nprint(filter(lambda x: x > 1, xs))`,
+    `xs = pair(1, pair(2, pair(3, None)))\nprint(reduce(lambda a, b: a + b, 0, xs))`,
+    `print(build_llist(lambda i: i * i, 5))`,
+    `xs = pair(1, pair(2, None))\nfor_each(print, xs)`,
+    `print(llist_to_string(pair(1, pair(2, None))))`,
+    `xs = pair(1, pair(2, pair(3, None)))\nprint(reverse(xs))`,
+    `print(append(pair(1, pair(2, None)), pair(3, pair(4, None))))`,
+    `xs = pair(1, pair(2, pair(3, None)))\nprint(member(2, xs))`,
+    `xs = pair(1, pair(2, pair(3, None)))\nprint(member(9, xs))`,
+    `xs = pair(1, pair(2, pair(3, None)))\nprint(remove(2, xs))`,
+    `xs = pair(2, pair(2, pair(3, None)))\nprint(remove_all(2, xs))`,
+    `print(enum_llist(1, 5))`,
+    `print(llist_ref(pair(10, pair(20, pair(30, None))), 1))`,
+    `print(llist(1, 2, 3))`,
+    `print(llist())`,
+    // a function value round-trips through pair()/head()/llist() as the
+    // exact original, callable object — not just a printable stand-in
+    `f = pair(1, lambda x: x + 1)\nprint(head(f), tail(f)(41))`,
+    `xs = llist(lambda x: x * 2)\nprint(head(xs)(21))`,
+    // pair equality: structural, recursive, identity shortcut, and the §1/§2
+    // bool exclusion re-applying inside nested elements (also swept
+    // exhaustively by operator-conformance-py2js.test.ts; these are just a
+    // couple of composed, human-legible cases here too)
+    `print(pair(1, pair(2, None)) == pair(1, pair(2, None)))`,
+    `print(pair(1, 2) == pair(1, 3))`,
+    `xs = pair(1, 2)\nprint(xs == xs)`,
+    `print(pair(True, 1) == pair(True, 1))`,
+  ];
+  for (const code of cases) {
+    test(JSON.stringify(code), async () => {
+      await expectParity(code, 2);
     });
   }
 });


### PR DESCRIPTION
## Summary

Stacked on #282. First step of the depth-vs-breadth split we agreed on: chapter 2 before chapter 3, since chapter 2 uses **identical operator typing rules and validators** to chapter 1 (no `global`/`nonlocal`, no loops, no reassignment) — its only new surface is chapter 2's "list" (always a pair, built by `pair()`/`llist()`) and the linked-list stdlib. Chapter 3's `global`/`nonlocal` scoping is intentionally deferred to its own follow-up PR, as discussed.

### `PyPair` and operators (`runtime.ts`)

A native 2-element cons cell (`head`/`tail`) joins `PyValue`. Structural equality mirrors the CSE machine's `structuralEquals` exactly: identity shortcut, recursive element comparison, and the §1/§2 bool/function exclusion **re-applying on every recursive call into head/tail** (matching `structuralEquals`'s own `restrictChapter12` threading through its list recursion) — this falls out for free since `pyEquals`'s exclusion check is already unconditional at the top and the recursion calls `pyEquals` itself. Pairs are always truthy (Python has no "empty pair" — `None` is the empty *list*). Every other operator (`+`, `<`, unary `-`, etc.) needed **no new dispatch code at all** — pairs simply don't match any of the existing type-check helpers (`isNum`, `isComplex`, `typeof === "string"`), so they fall through to the existing "unsupported operand type" errors unchanged.

`print()` renders a pair by converting to the CSE machine's own tagged `Value` shape and calling the **actual shared `stringify()`** utility (`src/utils/stringify.ts`) rather than reimplementing its line-wrapping/memoization/circular-detection logic — so output for nested, long, or otherwise non-trivial pairs is pixel-identical to the CSE machine by construction, not merely by the conformance sweep happening not to exercise the cases where a hand-rolled clone would drift.

### Stdlib bridge extension + a real bug found (`stdlibBridge.ts`)

`pair()`/`head()`/`tail()`/`is_pair()`/`llist()` all come from the **real** `linked-list.ts` builtins, via a `PyPair`↔CSE-list conversion extension to the existing bridge. While extending the conformance sweep, this surfaced a genuine gap: a function value passed into `pair()`/`llist()` and read back out via `head()`/`tail()` (or unwrapped from an `llist(...)`) has no way to reconstruct itself from the bridge's printable stand-in — `llist(some_lambda)` errored instead of round-tripping. Fixed with a `WeakMap` tracking each synthetic stand-in back to its original `PyFunction`, so the round-trip is lossless: the function that comes back out is the *exact original*, still callable (verified directly: `f = pair(1, lambda x: x + 1); tail(f)(41)` → `42`), not just printable.

`print_llist` is native rather than bridged (CSE's is stream-based/async, like `print`/`input` already are) but ports the actual `_print_llist`/`_is_llist` algorithm from `linked-list.ts`, reusing `stringify()` for its leaf case.

### Prelude execution (`index.ts`)

`linkedList` joins `PY2JS_GROUPS[2]`; the supported-chapter list is now `[1, 2]`. Group preludes (SICPy source defining `map`/`filter`/`reduce`/`append`/`reverse`/`member`/`remove`/`enum_llist`/`llist_ref`/`build_llist`/`for_each`/`is_llist`/`llist_to_string` in terms of `pair`/`head`/`tail`/`None`) now actually **run** for `runCodePy2Js`/`runCodePy2JsDual` — previously only `Py2JsSession` loaded preludes, and chapter 1's prelude happened to be empty, so this gap was invisible until chapter 2 introduced a real one. A prelude's definitions need to be visible to a *separately compiled* main script, which only REPL mode's globals table supports (program mode's per-call `let` locals can't span two compilations) — so `prepare()` now compiles unconditionally in REPL mode. `Py2JsSession` itself, which already worked this way, is untouched (its error-wrapping contract genuinely differs from `prepare()`'s, so I kept them separate rather than force a shared helper).

### Conductor evaluator

`Py2JsEvaluator2` added alongside `Py2JsEvaluator1`, registered in `conductor/index.ts` and `scripts/build.ts`; both bundles build cleanly.

## Test plan

- `operator-conformance-py2js.test.ts` extended to chapter 2 — **1725 cases** (up from 749), including every pair × any-type combination for `==`/`!=`/`and`/`or`/`not`/unary `-`
- `stdlib-conformance-py2js.test.ts` extended to chapter 2 — **1956 cases** (up from 896), plus a chapter-2 directed suite: every prelude function, `print_llist`'s proper-vs-improper-list branches, and the function round-trip through `pair()`/`llist()`
- `Py2JsEvaluator.test.ts`: two new `Py2JsEvaluator2` tests (prelude available from the first chunk; a function defined in one chunk works as a later chunk's callback)
- Differential smoke script (30 hand-written cases covering pairs, all prelude functions, equality, `print_llist`, and 3 error cases) — all correct
- `yarn jest` — full suite green (48 suites, 17 838 tests)
- `yarn tsx scripts/build.ts --evaluator Py2JsEvaluator1` / `--evaluator Py2JsEvaluator2` — both bundle cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbExZBaxgeUL4oi1t7PG93