### PR TITLE
py2js: chapter 4 support (tokenize, parse, apply_in_underlying_python, __program__)

### DIFF
--- a/src/engines/py2js/index.ts
+++ b/src/engines/py2js/index.ts
@@ -22,6 +22,7 @@ import list from "../../stdlib/list";
 import math from "../../stdlib/math";
 import misc from "../../stdlib/misc";
 import pairmutator from "../../stdlib/pairmutator";
+import parser from "../../stdlib/parser";
 import stream from "../../stdlib/stream";
 import type { Group } from "../../stdlib/utils";
 import { makeValidatorsForChapter } from "../../validator";
@@ -30,17 +31,18 @@ import { hasImports, loadChunkImports } from "./moduleInterop";
 import { annotateHostFunction, Py2JsRuntime, Py2JsRuntimeError, PyValue } from "./runtime";
 import { bridgeStdlibGroups } from "./stdlibBridge";
 
-const SUPPORTED_CHAPTERS = [1, 2, 3];
+const SUPPORTED_CHAPTERS = [1, 2, 3, 4];
 
 /**
  * Stdlib groups per chapter, bridged into the runtime by prepare(). Mirrors
  * runner.ts's VARIANT_GROUPS (kept separate so the engine does not pull in
- * the runner's conductor plumbing); extend as chapter 4 lands.
+ * the runner's conductor plumbing).
  */
 const PY2JS_GROUPS: Record<number, Group[]> = {
   1: [misc, math],
   2: [misc, math, linkedList],
   3: [misc, math, linkedList, list, pairmutator, stream],
+  4: [misc, math, linkedList, list, pairmutator, stream, parser],
 };
 
 export { Py2JsCompileError, Py2JsRuntime, Py2JsRuntimeError };
@@ -142,6 +144,14 @@ function prepare(
   const rt = new Py2JsRuntime(variant >= 3);
   const script = code.endsWith("\n") ? code : code + "\n";
   const groups = PY2JS_GROUPS[variant] ?? [];
+
+  // Predeclared at every chapter, not just 4 — the CSE machine defines it
+  // unconditionally (interpreter.ts's pyDefineVariable("__program__", ...)),
+  // matching the spec's "the Source Academy frontend predeclares the name
+  // __program__ in all Python languages" (docs/specs/python_interpreter.tex).
+  // It's documented under chapter 4 only because that's where tokenize/parse
+  // are introduced, not because availability itself is chapter-gated.
+  rt.builtins.__program__ = code;
 
   // The chapter's stdlib groups, bridged to native values (stdlibBridge.ts).
   // The runtime's native core (print/input/arity) wins over same-named
@@ -250,6 +260,15 @@ export interface Py2JsSessionOptions extends RunPy2JsOptions {
    * object — see PyCseEvaluatorBase for the identical requirement).
    */
   dataHandler?: IDataHandler;
+  /**
+   * `__program__`'s value for this session — "the string representation of
+   * the editor content at the time when 'Run' was last pressed" per
+   * docs/specs/python_interpreter.tex, for the REPL case. Mirrors
+   * PVMLInterpreter's own `programText` option (pvml-interpreter.ts). Left
+   * unset (rather than defaulting to e.g. an empty string) if the caller
+   * never supplies one, matching PVML's own conditional-set behavior.
+   */
+  programText?: string;
 }
 
 /**
@@ -293,6 +312,9 @@ export class Py2JsSession {
     this.dataHandler = options.dataHandler ?? new GenericDataHandler();
     this.rt = new Py2JsRuntime(variant >= 3);
     this.rt.onOutput = options.onOutput;
+    if (options.programText !== undefined) {
+      this.rt.builtins.__program__ = options.programText;
+    }
 
     // Same builtin layering as prepare(): bridged stdlib under the native
     // core, extraBuiltins over everything. The bridge's source string is

--- a/src/engines/py2js/stdlibBridge.ts
+++ b/src/engines/py2js/stdlibBridge.ts
@@ -304,6 +304,53 @@ function nativeStream(rt: Py2JsRuntime): PyFunction {
 }
 
 /**
+ * apply_in_underlying_python(f, xs) (chapter 4's parser/"mce" group): calls
+ * `f` with the arguments in linked-list `xs`. CSE's own implementation
+ * (ParserBuiltins.apply_in_underlying_python in src/stdlib/parser.ts) pushes
+ * onto its own control/stash for the CSE step loop to pick up later, rather
+ * than returning a value — semantically incompatible with bridgeBuiltin's
+ * generic path, which expects a builtin to return a Value synchronously (a
+ * generic bridge attempt would silently no-op: it would run against a fresh,
+ * throwaway Context whose control/stash nothing ever steps). Reimplemented
+ * natively instead: walk the argument list exactly as permissively as CSE
+ * does (any 2-element list-shaped chain — PyPair or a native 2-element
+ * PyList, since CSE has no representational difference between the two —
+ * terminated by anything that isn't, not strictly requiring a None tail) and
+ * invoke `f` through the runtime's own synchronous call trampoline (the same
+ * one a TS module uses to call back into Python — see Py2JsRuntime.callSync).
+ *
+ * `parse`/`tokenize` need no such native treatment: both just transform a
+ * string into CSE's tagged parse tree (transform() in src/stdlib/parser.ts),
+ * built entirely out of 2-element cons cells, which the existing
+ * toTagged/fromTagged round-trip already reconstructs correctly as nested
+ * PyPairs — so they go through the ordinary generic bridge above unchanged.
+ */
+function walkArgList(xs: PyValue): PyValue[] {
+  const args: PyValue[] = [];
+  let current = xs;
+  for (;;) {
+    if (current instanceof PyPair) {
+      args.push(current.head);
+      current = current.tail;
+    } else if (Array.isArray(current) && current.length === 2) {
+      args.push(current[0]);
+      current = current[1];
+    } else {
+      return args;
+    }
+  }
+}
+
+function nativeApplyInUnderlyingPython(rt: Py2JsRuntime): PyFunction {
+  const f = ((...args: PyValue[]) => rt.callSync(args[0], walkArgList(args[1]))) as PyFunction;
+  f.pyName = "apply_in_underlying_python";
+  f.pyArity = 2;
+  f.pyBuiltin = true;
+  f.pyMinArgs = 2;
+  return f;
+}
+
+/**
  * Bridge every builtin (and constant) of the given stdlib groups into py2js
  * native values. `source` is the program text, used by stdlib error
  * constructors for their (currently synthetic) location info.
@@ -333,6 +380,9 @@ export function bridgeStdlibGroups(
     }
     if (group.name === GroupName.STREAMS) {
       out.stream = nativeStream(rt);
+    }
+    if (group.name === GroupName.MCE) {
+      out.apply_in_underlying_python = nativeApplyInUnderlyingPython(rt);
     }
   }
   return out;

--- a/src/engines/py2js/stdlibBridge.ts
+++ b/src/engines/py2js/stdlibBridge.ts
@@ -327,12 +327,28 @@ function nativeStream(rt: Py2JsRuntime): PyFunction {
  */
 function walkArgList(xs: PyValue): PyValue[] {
   const args: PyValue[] = [];
+  // Cycle guard: set_tail/set_head (chapter 3's pair mutators) can build a
+  // genuinely self-referential pair (`p = pair(1, 2); set_tail(p, p)`).
+  // Without this, a circular argument list would spin forever, growing
+  // `args` without bound until the process runs out of memory — visited
+  // tracks pair/list *nodes* by identity (not values), so only an actual
+  // cycle back to a node already on this walk trips it, not e.g. two
+  // separately-built pairs that happen to compare equal.
+  const visited = new Set<object>();
   let current = xs;
   for (;;) {
     if (current instanceof PyPair) {
+      if (visited.has(current)) {
+        throw new Py2JsRuntimeError("RuntimeError", "circular list structure in arguments");
+      }
+      visited.add(current);
       args.push(current.head);
       current = current.tail;
     } else if (Array.isArray(current) && current.length === 2) {
+      if (visited.has(current)) {
+        throw new Py2JsRuntimeError("RuntimeError", "circular list structure in arguments");
+      }
+      visited.add(current);
       args.push(current[0]);
       current = current[1];
     } else {

--- a/src/tests/py2js-interpreter-support.test.ts
+++ b/src/tests/py2js-interpreter-support.test.ts
@@ -69,6 +69,19 @@ print(apply_in_underlying_python(f, None))
   test("a non-callable first argument is a TypeError", () => {
     expect(() => runCodePy2Js("apply_in_underlying_python(1, None)", 4)).toThrow(/TypeError/);
   });
+
+  test("a circular argument list (built via set_tail) raises rather than exhausting memory", () => {
+    // p.tail === p: walking it naively (no cycle detection) would grow the
+    // argument array without bound instead of terminating.
+    const code = `
+def f(a, b):
+    return a
+p = pair(1, 2)
+set_tail(p, p)
+print(apply_in_underlying_python(f, p))
+`;
+    expect(() => runCodePy2Js(code, 4)).toThrow(/circular/);
+  });
 });
 
 describe("__program__", () => {

--- a/src/tests/py2js-interpreter-support.test.ts
+++ b/src/tests/py2js-interpreter-support.test.ts
@@ -1,0 +1,104 @@
+/**
+ * py2js chapter 4: `tokenize`, `parse`, `apply_in_underlying_python`, and the
+ * predeclared `__program__` global (docs/specs/python_4.tex,
+ * python_interpreter.tex).
+ *
+ * `tokenize`/`parse` need no py2js-specific implementation at all: both are
+ * bridged through the ordinary generic stdlib bridge (stdlibBridge.ts),
+ * exactly like misc/math/list — CSE's own `transform()` (src/stdlib/
+ * parser.ts, reused directly by both `parse` and PVML's own parser support)
+ * builds the entire tagged parse tree out of 2-element cons cells, which the
+ * bridge's existing toTagged/fromTagged round-trip already reconstructs
+ * correctly as nested PyPairs. `apply_in_underlying_python` needed a native
+ * implementation instead (see stdlibBridge.ts's doc comment on
+ * nativeApplyInUnderlyingPython): CSE's own version pushes onto its own
+ * control/stash for the CSE step loop to process, which has no equivalent in
+ * a bridge that expects a builtin to return a value synchronously.
+ */
+import { runCodePy2Js, Py2JsSession, Py2JsRunError } from "../engines/py2js";
+import { runCode } from "../runner";
+
+describe("tokenize (bridged generically, no py2js-specific code)", () => {
+  test.each([["x = 1 + 2"], ["def f(x):\n    return x\n"], ["# a comment\nx = 1\n"]])(
+    "matches CSE exactly: %s",
+    async src => {
+      const code = `print_llist(tokenize(${JSON.stringify(src)}))`;
+      const cse = await runCode(code, 4);
+      expect(runCodePy2Js(code, 4).output).toBe(cse);
+    },
+  );
+});
+
+describe("parse (bridged generically, no py2js-specific code)", () => {
+  test.each([
+    ["x = 1 + 2"],
+    ["def f(x, y):\n    return x * y\n"],
+    ["if x > 0:\n    y = 1\nelse:\n    y = 2\n"],
+    ["for i in range(3):\n    print(i)\n"],
+    ["while x < 5:\n    x = x + 1\n"],
+    ["[1, 2, 3]"],
+    ["lambda x: x + 1"],
+    ["x[0] = 1"],
+    ["global x"],
+  ])("matches CSE's tagged-linked-list parse tree byte-for-byte: %s", async src => {
+    const code = `print_llist(parse(${JSON.stringify(src)}))`;
+    const cse = await runCode(code, 4);
+    expect(runCodePy2Js(code, 4).output).toBe(cse);
+  });
+});
+
+describe("apply_in_underlying_python", () => {
+  test("calls f with the arguments in the linked list", () => {
+    const code = `
+def times(x, y):
+    return x * y
+print(apply_in_underlying_python(times, llist(2, 3)))
+`;
+    expect(runCodePy2Js(code, 4).output).toBe("6\n");
+  });
+
+  test("an empty argument list (None) calls f with no arguments", () => {
+    const code = `
+def f():
+    return 42
+print(apply_in_underlying_python(f, None))
+`;
+    expect(runCodePy2Js(code, 4).output).toBe("42\n");
+  });
+
+  test("a non-callable first argument is a TypeError", () => {
+    expect(() => runCodePy2Js("apply_in_underlying_python(1, None)", 4)).toThrow(/TypeError/);
+  });
+});
+
+describe("__program__", () => {
+  test("holds the raw source text, at every chapter, not just chapter 4", () => {
+    const code = "print(__program__)";
+    for (const variant of [1, 2, 3, 4]) {
+      expect(runCodePy2Js(code, variant).output).toBe(code + "\n");
+    }
+  });
+
+  test("a REPL/conductor session uses the caller-supplied programText", async () => {
+    const lines: string[] = [];
+    const session = new Py2JsSession(4, {
+      onOutput: l => lines.push(l),
+      programText: "the editor content at the time Run was last pressed",
+    });
+    await session.runChunk("print(__program__)\n");
+    expect(lines).toEqual(["the editor content at the time Run was last pressed"]);
+  });
+
+  test("a REPL/conductor session with no programText leaves __program__ unbound (NameError)", async () => {
+    const session = new Py2JsSession(4);
+    await expect(session.runChunk("print(__program__)\n")).rejects.toThrow();
+  });
+});
+
+test("chapters 1-3 also support tokenize/parse/apply_in_underlying_python once bridged (engine-level, not spec-gated by chapter)", () => {
+  // The resolver predeclares __program__ (and, generally, whatever's in the
+  // chapter's stdlib groups) independent of chapter; py2js's own
+  // PY2JS_GROUPS is what actually withholds the parser group before chapter
+  // 4 — confirms that withholding, not a runtime crash, is what's happening.
+  expect(() => runCodePy2Js("print(tokenize('x'))", 3)).toThrow(Py2JsRunError);
+});


### PR DESCRIPTION
## Summary

Stacks on #296 (chapter 3) — targets `py2js-chapter3` directly since it depends on that work; retarget to `py2js-engine` once #296 merges.

Extends py2js to SICPy chapter 4's "Interpreter Support" (`docs/specs/python_4.tex`, `python_interpreter.tex`): `tokenize(x)`, `parse(x)`, `apply_in_underlying_python(f, xs)`, and the predeclared `__program__` global.

### tokenize/parse — no py2js-specific implementation needed

CSE's own `transform()` (`src/stdlib/parser.ts` — already exported and reused as-is by PVML's own parser support) builds the entire tagged parse tree out of 2-element cons cells. The existing generic stdlib bridge's `toTagged`/`fromTagged` round-trip already reconstructs arbitrary nesting of those correctly as `PyPair` chains, so both builtins just needed the `parser` group added to `PY2JS_GROUPS[4]` — zero new bridging code.

Verified byte-for-byte against a live CSE reference across 9 program shapes (assignment, function def, if/else, while/for, list literal, lambda, subscript assignment, `global`).

### apply_in_underlying_python — needed a native implementation

CSE's own implementation (`ParserBuiltins.apply_in_underlying_python`) pushes onto its own control/stash for the CSE step loop to process later, rather than returning a value synchronously — incompatible with the generic bridge (which would silently no-op, running against a fresh throwaway `Context` nothing ever steps). Reimplemented directly against py2js's own `PyPair`/`PyFunction`/`PyList`: walks the argument list exactly as permissively as CSE does (any 2-element list-shaped chain, not strictly requiring a `None` tail), then calls through the existing `callSync` trampoline — the same one a TS module already uses to call back into Python synchronously.

### __program__ — turned out not to be chapter-4-specific

While implementing this I found the CSE reference defines it **unconditionally**, at every chapter (`interpreter.ts`'s `pyDefineVariable("__program__", ...)` has no variant gate), matching the spec's own wording: "the Source Academy frontend predeclares the name `__program__` in **all** Python languages." It's documented under chapter 4 only because that's where tokenize/parse are introduced, not because availability is gated. Made it available at chapters 1-4 in py2js accordingly (a small retroactive fix), plus a `programText` session option for the REPL/conductor case, mirroring `PVMLInterpreter`'s own `programText` option.

## Test plan

- `yarn jest src/tests/py2js-interpreter-support.test.ts` — 19 tests, including live CSE-reference `parse()`/`tokenize()` comparisons across 9 program shapes, `apply_in_underlying_python` (incl. empty-args and non-callable-argument error cases), and `__program__` across sync/REPL-session modes
- `yarn jest` — zero regressions

## Not in this PR

Nothing further planned for now — chapters 1-4 (the full SICPy language surface) are covered across #282/#291/#296/this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhrHrHQHramQhK5sNAVp9r