### PR TITLE
Revert verbose builtin repr on CSE machine stash

### DIFF
--- a/src/conductor/plugins/PyCseMachinePlugin.ts
+++ b/src/conductor/plugins/PyCseMachinePlugin.ts
@@ -72,11 +72,8 @@ function formatValue(v: Value): string {
       return `[${items.join(", ")}${suffix}]`;
     }
     case "builtin":
-      // Just the name, matching how "closure" above shows funcName rather than
-      // Python's full repr() — this is a compact stash chip, not repr() output.
-      // The "this is a builtin" fact is carried separately via `label`
-      // (see serializeValue / typeTranslator), same pattern as closures.
-      return v.name;
+      // Matches CPython's repr() of a builtin, and what print(print) shows in the REPL.
+      return `<built-in function ${v.name}>`;
     case "opaque":
       return `<opaque value>`;
     default:

--- a/src/tests/PyCseMachinePlugin.test.ts
+++ b/src/tests/PyCseMachinePlugin.test.ts
@@ -106,7 +106,7 @@ describe("formatValue", () => {
   });
 
   it("formats builtin function", () => {
-    expect(formatValue(builtin("abs"))).toBe("abs");
+    expect(formatValue(builtin("abs"))).toBe("<built-in function abs>");
   });
 
   it("formats short list", () => {
@@ -186,7 +186,7 @@ describe("serializeValue", () => {
 
   it("serializes builtin", () => {
     const v = serializeValue(builtin("print"));
-    expect(v.displayValue).toBe("print");
+    expect(v.displayValue).toBe("<built-in function print>");
     expect(v.label).toBe("builtin_function_or_method");
     expect(v.label).not.toBe("function"); // "function" is what closures get
   });


### PR DESCRIPTION
Closes #298.

PR #230 changed how builtins show up on the CSE machine stash, from the verbose `<built-in function print>` down to just the bare name `print`, to match how closures get shown there. Turns out that was actually a step backward, this should read `<built-in function print>` like it used to, so it's consistent with what `print(print)` shows in the real REPL.

Only reverting the display string part of that PR here (the `formatValue` case in `PyCseMachinePlugin.ts`). Left the `typeTranslator` label change alone since that one's now load bearing for the wrong-type error message overhaul that landed later, pulling that out would break those error messages instead of fixing anything.

Updated the two tests in `PyCseMachinePlugin.test.ts` that had baked in the old bare-name expectation.

## Test plan
- `npx tsc --noEmit` clean
- `npx eslint` clean
- `npx jest src/tests/PyCseMachinePlugin.test.ts` passes
- `npx prettier --write` run on both changed files