### PR TITLE
py2js: fix negative list-index wraparound, implement list * int repetition

### DIFF
--- a/src/engines/py2js/runtime.ts
+++ b/src/engines/py2js/runtime.ts
@@ -614,6 +614,24 @@ export class Py2JsRuntime {
         return (op === "is not") !== pyIdentical(l, r);
     }
 
+    // List repetition: `list * int` / `int * list` (chapter 3+) — Source has
+    // no array constructor, so this doubles as the idiomatic way to build a
+    // list of a given size (see python-spec issue #299). Only `*` with
+    // exactly one list operand participates; anything else involving a list
+    // (including list * list) falls through to unsupported() below.
+    if (op === "*" && Array.isArray(l) !== Array.isArray(r)) {
+      const list = (Array.isArray(l) ? l : r) as PyList;
+      const factor = Array.isArray(l) ? r : l;
+      if (typeof factor !== "bigint") {
+        throw new Py2JsRuntimeError("TypeError", "can't multiply list by non-integer");
+      }
+      const n = Number(factor);
+      if (n <= 0) return [];
+      const result: PyList = [];
+      for (let i = 0; i < n; i++) result.push(...list);
+      return result;
+    }
+
     if (isComplex(l) || isComplex(r)) {
       return complexBinop(op, l, r);
     }
@@ -678,10 +696,10 @@ export class Py2JsRuntime {
   }
 
   /**
-   * `expr[index]` (chapter 3+): mirrors the CSE machine's LIST_ACCESS
-   * instruction — a list or string subject, an int index, bounds-checked;
-   * negative indices are not supported (CSE's own LIST_ACCESS has no
-   * negative-index handling either, unlike list-assignment below).
+   * `expr[index]` (chapter 3+): a list or string subject, an int index,
+   * bounds-checked. Negative indices wrap around per Python semantics
+   * (-len(list) to -1 map to 0 to len(list)-1); an index still out of range
+   * after wrapping raises IndexError.
    */
   listAccess(list: PyValue, index: PyValue): PyValue {
     if (typeof list !== "string" && !Array.isArray(list)) {
@@ -698,19 +716,21 @@ export class Py2JsRuntime {
       // Spread rather than raw .length/[idx]: matches CSE's code-point-based
       // indexing (correct for astral characters), not UTF-16 code units.
       const chars = [...list];
-      if (idx >= chars.length) throw new Py2JsRuntimeError("IndexError", "string index out of range");
+      if (idx >= chars.length)
+        throw new Py2JsRuntimeError("IndexError", "string index out of range");
       return chars.at(idx) ?? "";
     }
-    if (idx >= list.length) throw new Py2JsRuntimeError("IndexError", "list index out of range");
-    return list[idx];
+    const i = idx < 0 ? idx + list.length : idx;
+    if (i < 0 || i >= list.length)
+      throw new Py2JsRuntimeError("IndexError", "list index out of range");
+    return list[i];
   }
 
   /**
-   * `expr[index] = value` (chapter 3+): mirrors evaluateListAssignment in
-   * src/engines/cse/utils.ts, including its negative-index handling (a
-   * modulo, not a true Python wraparound — kept bug-compatible with CSE
-   * rather than "fixed", since conformance with the reference engine is the
-   * goal here).
+   * `expr[index] = value` (chapter 3+): bounds-checked in-place assignment.
+   * Negative indices wrap around per Python semantics; out-of-range indices
+   * (before or after wrapping) raise IndexError rather than auto-extending
+   * the array the way raw JS array assignment would.
    */
   listAssign(list: PyValue, index: PyValue, value: PyValue): void {
     if (!Array.isArray(list)) {
@@ -725,12 +745,12 @@ export class Py2JsRuntime {
         `list indices must be integers, not '${pyTypeName(index)}'`,
       );
     }
-    let idx = Number(index);
-    if (idx < 0) idx = idx % list.length;
-    if (idx >= list.length) {
+    const idx = Number(index);
+    const i = idx < 0 ? idx + list.length : idx;
+    if (i < 0 || i >= list.length) {
       throw new Py2JsRuntimeError("IndexError", "list assignment index out of range");
     }
-    list[idx] = value;
+    list[i] = value;
   }
 
   /**
@@ -778,7 +798,10 @@ export class Py2JsRuntime {
    */
   whileCond(v: PyValue): boolean {
     if (typeof v !== "boolean") {
-      throw new Py2JsRuntimeError("TypeError", `while condition must be bool, not '${pyTypeName(v)}'`);
+      throw new Py2JsRuntimeError(
+        "TypeError",
+        `while condition must be bool, not '${pyTypeName(v)}'`,
+      );
     }
     return v;
   }

--- a/src/tests/operator-conformance-py2js.test.ts
+++ b/src/tests/operator-conformance-py2js.test.ts
@@ -115,6 +115,26 @@ for (const chapter of PY2JS_CHAPTERS) {
           for (const right of universe) {
             const code = `${literalFor(left, chapter)} ${op} ${literalFor(right, chapter)}`;
             test(code, async () => {
+              // py2js implements list * int / int * list repetition per spec
+              // issue #299; the CSE reference doesn't yet (a separate,
+              // already-planned fix), so this one combination is expected to
+              // diverge from CSE-parity until CSE catches up. Assert py2js's
+              // own spec-correct result directly instead of against CSE.
+              // chapter === 2's "list" literal is pair(1, 2), not a native
+              // array — py2js's list-repetition only handles native arrays
+              // (chapter 3+), so pair * int correctly still falls through to
+              // CSE-parity (both engines error on it) and must not match here.
+              const isListRepeat =
+                chapter >= 3 &&
+                op === "*" &&
+                ((left === "list" && right === "int") || (left === "int" && right === "list"));
+              if (isListRepeat) {
+                expect(py2jsOutcome(code, chapter)).toStrictEqual({
+                  kind: "value",
+                  text: "[1, 2, 1, 2]",
+                });
+                return;
+              }
               const wanted = await cseOutcome(code, chapter, groups);
               const actual = py2jsOutcome(code, chapter);
               expect(actual).toStrictEqual(wanted);

--- a/src/tests/py2js-lists.test.ts
+++ b/src/tests/py2js-lists.test.ts
@@ -40,10 +40,7 @@ test.each([
   ["print([1, 2, 3] == [1, 2])", "False\n"],
   ["print([1, [2, 3]] == [1, [2, 4]])", "False\n"],
   ["xs = [10, 20, 30]\nys = [10, 20, 30]\nprint(xs == ys)", "True\n"],
-  [
-    "xs = [[0, 1], [1, 2], [2, 3]]\nys = [[0, 1], [1, 2], [2, 3]]\nprint(xs == ys)",
-    "True\n",
-  ],
+  ["xs = [[0, 1], [1, 2], [2, 3]]\nys = [[0, 1], [1, 2], [2, 3]]\nprint(xs == ys)", "True\n"],
   ["xs = [0, 1, 2, 3]\nys = [1, 2, 3, 4]\nprint(xs == ys)", "False\n"],
 ])("structural == on lists: %s", (code, expected) => {
   expect(runCodePy2Js(code, 3).output).toBe(expected);
@@ -65,6 +62,45 @@ test("list subscript out of range is an IndexError (CSE parity)", async () => {
   const code = "xs = [1, 2, 3]\nxs[5]";
   await expect(runCode(code, 3)).rejects.toThrow();
   expect(() => runCodePy2Js(`${code}\nprint(1)`, 3)).toThrow(/IndexError/);
+});
+
+test.each([
+  ["xs = [10, 20, 30]\nprint(xs[-1])", "30\n"],
+  ["xs = [10, 20, 30]\nprint(xs[-3])", "10\n"],
+  ["xs = [10, 20, 30]\nxs[-1] = 99\nprint(xs)", "[10, 20, 99]\n"],
+  ["xs = [10, 20, 30]\nxs[-3] = 99\nprint(xs)", "[99, 20, 30]\n"],
+])("negative index wraparound: %s", (code, expected) => {
+  expect(runCodePy2Js(code, 3).output).toBe(expected);
+});
+
+test.each(["xs = [10, 20, 30]\nprint(xs[-4])", "xs = [10, 20, 30]\nxs[-4] = 1"])(
+  "negative index past the start of the list is still an IndexError: %s",
+  code => {
+    expect(() => runCodePy2Js(`${code}\nprint(1)`, 3)).toThrow(/IndexError/);
+  },
+);
+
+test.each([
+  ["print([1, 2] * 3)", "[1, 2, 1, 2, 1, 2]\n"],
+  ["print(3 * [1, 2])", "[1, 2, 1, 2, 1, 2]\n"],
+  ["print([1, 2] * 0)", "[]\n"],
+  ["print([1, 2] * -1)", "[]\n"],
+])("list multiplication: %s", (code, expected) => {
+  expect(runCodePy2Js(code, 3).output).toBe(expected);
+});
+
+test.each([
+  "print([1, 2] * 0.0)",
+  "print(0.0 * [1, 2])",
+  "print(True * [1, 2])",
+  "print([1, 2] * True)",
+])("list multiplication by a non-integer is a TypeError: %s", code => {
+  expect(() => runCodePy2Js(code, 3)).toThrow(/TypeError: can't multiply list by non-integer/);
+});
+
+test("list multiplication makes shallow copies (same nested-list identity)", () => {
+  const code = "x = [[1, 2]] * 4\nprint(x[0] is x[1])";
+  expect(runCodePy2Js(code, 3).output).toBe("True\n");
 });
 
 test("list assignment aliases: mutating through one reference is visible through another", () => {


### PR DESCRIPTION
## Summary
Part of working through #299's list spec across all three evaluators (py2js first, PVML and CSE to follow). Targets `py2js-chapter3` (#296) since that's where py2js's list support lives.

- `listAccess`/`listAssign` (`src/engines/py2js/runtime.ts`) had no negative-index handling for lists — negative indices now wrap into `[0, len)` per Python semantics, raising `IndexError` if still out of range after wrapping.
- `list * int` / `int * list` repetition was entirely unimplemented (fell through to a generic "unsupported operand" error). Implemented: non-positive → `[]`, positive `i` → duplicated `i` times, non-integer operand (including `bool`) → `TypeError: can't multiply list by non-integer`, and shallow-copy semantics for nested lists (`x = [[1,2]]*4; x[0] is x[1]` → `True`).

`operator-conformance-py2js.test.ts`'s CSE-parity sweep is adjusted for the two `list*int`/`int*list` cases: py2js is now ahead of the CSE reference on this one behavior (CSE's own #299 fix is a separate, already-planned follow-up), so those two cases assert py2js's own spec-correct output directly instead of parity with CSE.

## Test plan
- [x] `jest` — all py2js suites + `operator-conformance-py2js.test.ts` pass (2993 tests)
- [x] `eslint` clean on changed files
- [x] `prettier --write` applied

Fixes part of #299 (py2js side).