### PR TITLE
Remove default PVML instruction limit

### DIFF
--- a/src/engines/pvml/pvml-interpreter.ts
+++ b/src/engines/pvml/pvml-interpreter.ts
@@ -143,7 +143,12 @@ export class PVMLInterpreter {
   private callDepth: number = 0;
 
   private instructionCount: number = 0;
-  private maxInstructionLimit: number = 1000000;
+  /** No default cap — PVML runs in a webworker, so runaway code is stopped
+   * by terminating the worker from the frontend rather than by an internal
+   * step limit (unlike the transpiler/py2js path, which has no worker
+   * boundary to rely on). Callers that still want a cap can pass
+   * `maxInstructions` explicitly (e.g. tests). */
+  private maxInstructionLimit: number = Infinity;
 
   /** The SICPy chapter (1-4) `program` was compiled for — see Context.variant's
    * doc comment (src/engines/cse/context.ts) for why error construction needs


### PR DESCRIPTION
## Summary
- PVML runs in a webworker, so the frontend can already terminate runaway execution at any time — the previous hardcoded 1,000,000-instruction cap was outdated (unlike py2js/the transpiler path, which has no worker boundary to fall back on).
- `maxInstructionLimit` now defaults to `Infinity`; callers can still opt into a cap via the existing `maxInstructions` constructor option (used by the "exceeding maxInstructions throws" test).

Per Martin Henz's feedback in Telegram (2026-07-20): "we should not have a 1,000,000 step limit. This is outdated: It's running in a webworker so we can stop the worker any time from the frontend."

## Test plan
- [x] `yarn jest src/tests/pvml-interpreter.test.ts` — 226 passed
- [x] `npx tsc --noEmit`
- [x] `npx eslint` / `npx prettier --write` clean