### PR TITLE
Keep integers out of the module interface; unify pair/array; fix py2js DataType.ARRAY handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@sourceacademy/common-cse-machine": "^0.3.0",
     "@sourceacademy/common-stepper": "^0.0.1",
-    "@sourceacademy/conductor": "^0.7.0",
+    "@sourceacademy/conductor": "^0.7.2",
     "@sourceacademy/runner-cse-machine": "^3.0.0",
     "@sourceacademy/runner-module-loader": "^0.0.1",
     "@sourceacademy/runner-stepper": "^0.0.1",

--- a/src/conductor/GenericDataHandler.ts
+++ b/src/conductor/GenericDataHandler.ts
@@ -243,11 +243,11 @@ export class GenericDataHandler implements IDataHandler {
     c: TypedValue<DataType.CLOSURE, T>,
     args: TypedValue<DataType>[],
   ): AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined> {
-    return this.closureMap.get(c.value)?.func(...args) as AsyncGenerator<
-      void,
-      TypedValue<NoInfer<T>>,
-      undefined
-    >;
+    const closure = this.closureMap.get(c.value);
+    if (closure === undefined) {
+      throw new Error(`Invalid closure identifier: ${c.value}`);
+    }
+    return closure.func(...args) as AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined>;
   }
   /**
    * Fast path for a closure that provably never needs to leave the current

--- a/src/conductor/GenericDataHandler.ts
+++ b/src/conductor/GenericDataHandler.ts
@@ -61,34 +61,55 @@ export class GenericDataHandler implements IDataHandler {
     this.pairMap.set(this.uniqueId++ as PairIdentifier, { head, tail });
     return Promise.resolve({ type: DataType.PAIR, value: (this.uniqueId - 1) as PairIdentifier });
   }
-  pair_head(p: TypedValue<DataType.PAIR>): Promise<TypedValue<DataType>> {
+  /**
+   * Bridges pair_head/pair_tail/pair_sethead/pair_settail/pair_assert onto a DataType.ARRAY value
+   * too, not just a genuine PAIR: per Martin, a pair is just a 2-element array, and module code is
+   * free to keep calling pair_head/pair_tail for clarity even once the underlying value it's
+   * handed is array-backed (e.g. a value pythonToModule built directly as an ARRAY). Reads/writes
+   * index 0/1 directly; throws the same "Invalid pair identifier" a genuine dangling PAIR would,
+   * for a dangling/too-short array.
+   */
+  private resolvePairView(
+    p: TypedValue<DataType.PAIR>,
+  ): { head: TypedValue<DataType>; tail: TypedValue<DataType> } & (
+    | { kind: "pair"; pair: { head: TypedValue<DataType>; tail: TypedValue<DataType> } }
+    | { kind: "array"; array: { type: DataType; elements: TypedValue<DataType>[] } }
+  ) {
+    if ((p.type as DataType) === DataType.ARRAY) {
+      const array = this.arrayMap.get(p.value as unknown as ArrayIdentifier<DataType>);
+      if (!array || array.elements.length < 2) {
+        throw new Error(`Invalid pair identifier: ${p.value}`);
+      }
+      return { kind: "array", array, head: array.elements[0], tail: array.elements[1] };
+    }
     const pair = this.pairMap.get(p.value);
     if (!pair) {
       throw new Error(`Invalid pair identifier: ${p.value}`);
     }
-    return Promise.resolve(pair.head);
+    return { kind: "pair", pair, head: pair.head, tail: pair.tail };
+  }
+  pair_head(p: TypedValue<DataType.PAIR>): Promise<TypedValue<DataType>> {
+    return Promise.resolve(this.resolvePairView(p).head);
   }
   pair_sethead(p: TypedValue<DataType.PAIR>, tv: TypedValue<DataType>): Promise<void> {
-    const pair = this.pairMap.get(p.value);
-    if (!pair) {
-      throw new Error(`Invalid pair identifier: ${p.value}`);
+    const view = this.resolvePairView(p);
+    if (view.kind === "array") {
+      view.array.elements[0] = tv;
+    } else {
+      view.pair.head = tv;
     }
-    pair.head = tv;
     return Promise.resolve();
   }
   pair_tail(p: TypedValue<DataType.PAIR>): Promise<TypedValue<DataType>> {
-    const pair = this.pairMap.get(p.value);
-    if (!pair) {
-      throw new Error(`Invalid pair identifier: ${p.value}`);
-    }
-    return Promise.resolve(pair.tail);
+    return Promise.resolve(this.resolvePairView(p).tail);
   }
   pair_settail(p: TypedValue<DataType.PAIR>, tv: TypedValue<DataType>): Promise<void> {
-    const pair = this.pairMap.get(p.value);
-    if (!pair) {
-      throw new Error(`Invalid pair identifier: ${p.value}`);
+    const view = this.resolvePairView(p);
+    if (view.kind === "array") {
+      view.array.elements[1] = tv;
+    } else {
+      view.pair.tail = tv;
     }
-    pair.tail = tv;
     return Promise.resolve();
   }
   pair_assert(
@@ -96,15 +117,12 @@ export class GenericDataHandler implements IDataHandler {
     headType?: DataType,
     tailType?: DataType,
   ): Promise<void> {
-    const pair = this.pairMap.get(p.value);
-    if (!pair) {
-      throw new Error(`Invalid pair identifier: ${p.value}`);
+    const { head, tail } = this.resolvePairView(p);
+    if (headType && head.type !== headType) {
+      throw new Error(`Expected head of type ${headType}, got ${head.type}`);
     }
-    if (headType && pair.head.type !== headType) {
-      throw new Error(`Expected head of type ${headType}, got ${pair.head.type}`);
-    }
-    if (tailType && pair.tail.type !== tailType) {
-      throw new Error(`Expected tail of type ${tailType}, got ${pair.tail.type}`);
+    if (tailType && tail.type !== tailType) {
+      throw new Error(`Expected tail of type ${tailType}, got ${tail.type}`);
     }
     return Promise.resolve();
   }
@@ -332,39 +350,53 @@ export class GenericDataHandler implements IDataHandler {
     );
     return list;
   }
-  is_list(xs: TypedValue<DataType.LIST>): Promise<boolean> {
+  /**
+   * Reads every generic list helper's elements uniformly: an ARRAY is already flat (its elements
+   * read straight off array_get, no walking needed), while a PAIR/EMPTY_LIST chain is walked node
+   * by node the old way. Per Martin: a pair is just a 2-element array, not a distinct concept, so
+   * these helpers treat both shapes as equally valid "list" inputs rather than only recognizing
+   * the PAIR/EMPTY_LIST chain - this is what lets pythonToModule (CSE/PVML/py2js) freely encode a
+   * Python list as DataType.ARRAY without breaking a module that calls list_to_vec/is_list/length/
+   * accumulate on it (sound, midi, ...), with zero changes needed on the module's side. Throws the
+   * same "Expected a list, got type X" a caller relying on that message already handles.
+   */
+  private readListElements(xs: TypedValue<DataType>): TypedValue<DataType>[] {
+    if (xs.type === DataType.ARRAY) {
+      const array = this.arrayMap.get(xs.value);
+      if (!array) {
+        throw new Error(`Invalid array identifier: ${xs.value}`);
+      }
+      return array.elements;
+    }
+    const result: TypedValue<DataType>[] = [];
     let current: TypedValue<DataType> = xs;
     while (current.type !== DataType.EMPTY_LIST) {
       if (current.type !== DataType.PAIR) {
-        return Promise.resolve(false);
+        throw new Error(`Expected a list, got type ${current.type}`);
       }
       const pair = this.pairMap.get(current.value);
-      if (pair === undefined) {
-        return Promise.resolve(false);
+      if (!pair) {
+        throw new Error(`Invalid pair identifier: ${current.value}`);
       }
+      result.push(pair.head);
       current = pair.tail;
     }
-    return Promise.resolve(true);
+    return result;
+  }
+  is_list(xs: TypedValue<DataType.LIST>): Promise<boolean> {
+    try {
+      this.readListElements(xs);
+      return Promise.resolve(true);
+    } catch {
+      return Promise.resolve(false);
+    }
   }
   list_to_vec(xs: TypedValue<DataType.LIST>): Promise<TypedValue<DataType>[]> {
-    return new Promise((resolve, reject) => {
-      const result: TypedValue<DataType>[] = [];
-      let current: TypedValue<DataType> = xs;
-      while (current.type !== DataType.EMPTY_LIST) {
-        if (current.type !== DataType.PAIR) {
-          reject(new Error(`Expected a list, got type ${current.type}`));
-          return;
-        }
-        const pair = this.pairMap.get(current.value);
-        if (!pair) {
-          reject(new Error(`Invalid pair identifier: ${current.value}`));
-          return;
-        }
-        result.push(pair.head);
-        current = pair.tail;
-      }
-      resolve(result);
-    });
+    try {
+      return Promise.resolve(this.readListElements(xs));
+    } catch (e) {
+      return Promise.reject(e);
+    }
   }
   async *accumulate<T extends Exclude<DataType, DataType.VOID>>(
     op: TypedValue<DataType.CLOSURE, T>,
@@ -373,35 +405,13 @@ export class GenericDataHandler implements IDataHandler {
     _resultType: T,
   ): AsyncGenerator<void, TypedValue<NoInfer<T>>, undefined> {
     let acc = initial;
-    let current: TypedValue<DataType> = sequence;
-    while (current.type !== DataType.EMPTY_LIST) {
-      if (current.type !== DataType.PAIR) {
-        throw new Error(`Expected a list, got type ${current.type}`);
-      }
-      const pair = this.pairMap.get(current.value);
-      if (!pair) {
-        throw new Error(`Invalid pair identifier: ${current.value}`);
-      }
-      acc = yield* this.closure_call_unchecked(op, [acc, pair.head]);
-      current = pair.tail;
+    for (const element of this.readListElements(sequence)) {
+      acc = yield* this.closure_call_unchecked(op, [acc, element]);
     }
     return acc;
   }
   length(xs: TypedValue<DataType.LIST>): Promise<number> {
-    let length = 0;
-    let current: TypedValue<DataType> = xs;
-    while (current.type !== DataType.EMPTY_LIST) {
-      if (current.type !== DataType.PAIR) {
-        throw new Error(`Expected a list, got type ${current.type}`);
-      }
-      const pair = this.pairMap.get(current.value);
-      if (!pair) {
-        throw new Error(`Invalid pair identifier: ${current.value}`);
-      }
-      length++;
-      current = pair.tail;
-    }
-    return Promise.resolve(length);
+    return Promise.resolve(this.readListElements(xs).length);
   }
 }
 

--- a/src/engines/cse/environment.ts
+++ b/src/engines/cse/environment.ts
@@ -3,7 +3,6 @@ import { MissingRequiredPositionalError, TooManyPositionalArgumentsError } from 
 import { Closure } from "./closure";
 import { Context } from "./context";
 import { handleRuntimeError } from "./error";
-import { listLiteralValues } from "./modules";
 import { ListValue, Value } from "./stash";
 
 /**
@@ -85,11 +84,6 @@ export const createEnvironment = (
       // Spread flattening in the Application handler detects these via
       // val.type === "list" and expands val.value inline.
       const restArgs: ListValue = { type: "list", value: args.slice(index) };
-      // A flat, arbitrary-length collection - the same category as a bracket literal (visitListExpr/
-      // InstrType.LIST), not a pair()/llist() chain - so module interop (pythonToModule) needs the
-      // same tag to reconstruct it as a proper PAIR/EMPTY_LIST chain rather than misreading an
-      // exactly-2-arg case as a dotted pair. See listLiteralValues' definition in modules.ts.
-      listLiteralValues.add(restArgs);
       environment.head[paramName] = restArgs;
       consumed = true;
       return;

--- a/src/engines/cse/interpreter.ts
+++ b/src/engines/cse/interpreter.ts
@@ -26,7 +26,7 @@ import {
 } from "./environment";
 import { handleRuntimeError, UnknownEvaluatorError } from "./error";
 import * as instrCreator from "./instrCreator";
-import { listLiteralValues, loadModules, moduleToPython } from "./modules";
+import { loadModules, moduleToPython } from "./modules";
 import { evaluateBinaryExpression, evaluateUnaryExpression, isFalsy } from "./operators";
 import { Stash, Value } from "./stash";
 import { displayError } from "./streams";
@@ -1094,10 +1094,6 @@ const cmdEvaluators: CmdEvaluators = {
       }
     }
     const listValue: Value = { type: "list", value: elements };
-    // Tag as a genuine list literal so module interop (pythonToModule) can tell it apart from a
-    // pair()/llist()-built value or a module PAIR round-tripped through Python, none of which reach
-    // this instruction - see listLiteralValues' definition in modules.ts.
-    listLiteralValues.add(listValue);
     stash.push(listValue);
   },
 

--- a/src/engines/cse/modules.ts
+++ b/src/engines/cse/modules.ts
@@ -163,6 +163,12 @@ export async function moduleToPython(
   switch (value.type) {
     case DataType.NUMBER:
       return { type: "number", value: value.value }; // TODO: handle bigint
+    case DataType.INTEGER:
+      // py-slang never produces DataType.INTEGER itself (see pythonToModule's "bigint" case
+      // above) - per Martin, integers stay out of the module interface entirely, numbers crossing
+      // a module boundary are always floats. Only here for switch exhaustiveness over conductor's
+      // DataType enum.
+      return { type: "number", value: Number(value.value) };
     case DataType.BOOLEAN:
       return { type: "bool", value: value.value };
     case DataType.CONST_STRING:

--- a/src/engines/cse/modules.ts
+++ b/src/engines/cse/modules.ts
@@ -151,6 +151,25 @@ export async function pythonToModule(
   }
 }
 
+/**
+ * Reads a PAIR or ARRAY's elements uniformly: a PAIR is always exactly 2 (head, tail - whatever
+ * they are, not necessarily a proper list continuation - e.g. sound's Sound is (wave, duration),
+ * a dotted pair whose second element is a plain NUMBER), an ARRAY is however many array_length
+ * reports. Deliberately NOT list_to_vec: that walks a chain expecting it to terminate in
+ * EMPTY_LIST (a *proper list* invariant), which a raw dotted pair doesn't satisfy - this is a
+ * flat "give me this compound value's N elements" read, nothing more.
+ */
+async function readCompoundElements(
+  evaluator: NonNullable<Context["evaluator"]>,
+  value: TypedValue<DataType.ARRAY> | TypedValue<DataType.PAIR>,
+): Promise<TypedValue<DataType>[]> {
+  if (value.type === DataType.PAIR) {
+    return [await evaluator.pair_head(value), await evaluator.pair_tail(value)];
+  }
+  const length = await evaluator.array_length(value);
+  return Promise.all(Array.from({ length }, (_, i) => evaluator.array_get(value, i)));
+}
+
 export async function moduleToPython(
   context: Context,
   code: string,
@@ -176,26 +195,18 @@ export async function moduleToPython(
     case DataType.VOID:
     case DataType.EMPTY_LIST:
       return { type: "none" };
-    case DataType.ARRAY:
-      const length = await context.evaluator.array_length(value);
-      return {
-        type: "list",
-        value: await Promise.all(
-          Array.from({ length }, async (_, i) =>
-            moduleToPython(context, code, command, await context.evaluator!.array_get(value, i)),
-          ),
-        ),
-      };
     case DataType.OPAQUE:
       return { type: "opaque", value: value.value };
-    case DataType.PAIR:
+    case DataType.ARRAY:
+    case DataType.PAIR: {
+      // Untyped and recursive, uniformly for both: per Martin, a PAIR is just a 2-element array,
+      // not a distinct concept - one shared conversion, not a separate case per DataType.
+      const elements = await readCompoundElements(context.evaluator, value);
       return {
         type: "list",
-        value: [
-          await moduleToPython(context, code, command, await context.evaluator.pair_head(value)),
-          await moduleToPython(context, code, command, await context.evaluator.pair_tail(value)),
-        ],
+        value: await Promise.all(elements.map(el => moduleToPython(context, code, command, el))),
       };
+    }
     case DataType.CLOSURE:
       async function* builtinGenerator(
         args: Value[],

--- a/src/engines/cse/modules.ts
+++ b/src/engines/cse/modules.ts
@@ -10,17 +10,8 @@ import { RuntimeSourceError } from "../../errors";
 import { Context } from "./context";
 import { handleRuntimeError } from "./error";
 import { appInstr } from "./instrCreator";
-import { BuiltinValue, ListValue, Value } from "./stash";
+import { BuiltinValue, Value } from "./stash";
 import { ModuleFunctionGenerator } from "./types";
-
-/**
- * Marks a freshly-built list Value as a genuine Python list literal (as opposed to a value built by
- * pair()/llist(), or one round-tripped from a module's DataType.PAIR) - see the "list" case in
- * pythonToModule for why this distinction can't be made from shape alone. A side-tag rather than a
- * shape change so nothing else that already treats list literals as a flat array (indexing, len(),
- * iteration, etc.) needs to change.
- */
-export const listLiteralValues = new WeakSet<ListValue>();
 
 export class ModuleNotFoundError extends RuntimeSourceError {
   constructor(public readonly moduleName: string) {

--- a/src/engines/cse/modules.ts
+++ b/src/engines/cse/modules.ts
@@ -66,33 +66,35 @@ export async function pythonToModule(
     case "none":
       return { type: DataType.EMPTY_LIST, value: null };
     case "list": {
-      // A list literal (tagged at construction in the InstrType.LIST microcode) is unambiguously a
-      // Source list, of any length including 2 - fold it into a proper PAIR/EMPTY_LIST chain, or
-      // list-typed module parameters (e.g. sound's consecutively/simultaneously/stacking_adsr
-      // envelopes) would silently see zero (or the wrong) elements instead of the list the student
-      // actually wrote. The length !== 2 check is a defensive fallback only - pair()/llist()/module
-      // round-trips always produce exactly 2-element links, so an untagged value should never
-      // actually hit it, but building a chain is still the safer default if one somehow did.
-      if (listLiteralValues.has(value) || value.value.length !== 2) {
-        let chain: TypedValue<DataType> = { type: DataType.EMPTY_LIST, value: null };
-        for (let i = value.value.length - 1; i >= 0; i--) {
-          chain = await context.evaluator.pair_make(
-            await pythonToModule(context, code, command, value.value[i]),
-            chain,
-          );
-        }
-        return chain;
+      // Untyped and recursive: per Martin, a pair is just an array of length 2, not a distinct
+      // concept - build every Python list (of any length, 2 included, whether it's a fresh
+      // literal, a pair()/llist() result, or a module PAIR round-tripped back through Python) the
+      // same way, as a flat DataType.ARRAY, recursively converting each element. No more
+      // origin-tagging or length-based branching needed - list_to_vec/pair_head/pair_tail (see
+      // GenericDataHandler) already read an ARRAY the same as a PAIR/EMPTY_LIST chain, so a module
+      // declaring LIST or PAIR still works unchanged.
+      //
+      // An empty list is the one exception: it becomes EMPTY_LIST directly, matching what an
+      // empty ARRAY would mean anyway (module signatures never distinguish "empty array" from
+      // "empty list"/None) and what every other engine already does.
+      if (value.value.length === 0) {
+        return { type: DataType.EMPTY_LIST, value: null };
       }
-      // Otherwise this came from pair()/llist(), or a module PAIR round-tripped through
-      // moduleToPython - both always produce exactly 2-element links, reconstructed here as a single
-      // pair_make(head, tail) without requiring the chain to terminate in None, since a module PAIR
-      // need not be a proper list (e.g. sound's Sound is (wavesPair, duration), a dotted pair whose
-      // second element is a number, not another list link).
-      const [head, tail] = value.value;
-      return context.evaluator.pair_make(
-        await pythonToModule(context, code, command, head),
-        await pythonToModule(context, code, command, tail),
+      const elements = await Promise.all(
+        value.value.map(el => pythonToModule(context, code, command, el)),
       );
+      const array = await context.evaluator.array_make(DataType.ANY, elements.length, {
+        type: DataType.VOID,
+        value: undefined,
+      });
+      for (let i = 0; i < elements.length; i++) {
+        await context.evaluator.array_set(
+          array as unknown as TypedValue<DataType.ARRAY, DataType.VOID>,
+          i,
+          elements[i],
+        );
+      }
+      return array;
     }
     case "opaque":
       return { type: DataType.OPAQUE, value: value.value as OpaqueIdentifier };

--- a/src/engines/cse/modules.ts
+++ b/src/engines/cse/modules.ts
@@ -65,12 +65,11 @@ export async function pythonToModule(
       // GenericDataHandler) already read an ARRAY the same as a PAIR/EMPTY_LIST chain, so a module
       // declaring LIST or PAIR still works unchanged.
       //
-      // An empty list is the one exception: it becomes EMPTY_LIST directly, matching what an
-      // empty ARRAY would mean anyway (module signatures never distinguish "empty array" from
-      // "empty list"/None) and what every other engine already does.
-      if (value.value.length === 0) {
-        return { type: DataType.EMPTY_LIST, value: null };
-      }
+      // No empty-list special case: EMPTY_LIST is also what Python's None maps to (see
+      // moduleToPython's own EMPTY_LIST case), so returning it here for [] would make [] and None
+      // collide on the way back out - exactly the kind of ambiguity this whole redesign exists to
+      // remove. A genuine 0-length ARRAY round-trips back through moduleToPython's ARRAY case as a
+      // real [], not None.
       const elements = await Promise.all(
         value.value.map(el => pythonToModule(context, code, command, el)),
       );

--- a/src/engines/pvml/PVMLIRBuilder.ts
+++ b/src/engines/pvml/PVMLIRBuilder.ts
@@ -34,8 +34,6 @@ export class PVMLIRBuilder {
   /** Whether the last parameter is a rest param (`def f(a, *rest)`) — see
    * PVMLIR's `hasRestParam` doc comment. */
   private hasRestParam: boolean;
-  /** See PVMLIR's `listLiteralOffsets` doc comment. */
-  private listLiteralOffsets: Set<number> = new Set();
 
   private lastLabelId: number = 0;
 
@@ -164,13 +162,6 @@ export class PVMLIRBuilder {
     this.symbolCount++;
   }
 
-  /** Marks the most recently emitted instruction (the LDLG that pushes a just-built list
-   * literal's completed array — see PVMLCompiler's visitListExpr) as a list-literal completion
-   * site. See PVMLIR's `listLiteralOffsets` doc comment for why. */
-  markListLiteral(): void {
-    this.listLiteralOffsets.add(this.ops.length - 1);
-  }
-
   /**
    * Resolve labels, patch jump offsets, and produce an immutable PVMLIR.
    * Non-destructive: works on a copy of data, so the builder can be reused.
@@ -223,7 +214,6 @@ export class PVMLIRBuilder {
       this.functionName,
       this.complexes.slice(), // copy for builder reuse
       this.hasRestParam,
-      new Set(this.listLiteralOffsets), // copy for builder reuse, matching strings/bigints/complexes above
     );
   }
 }

--- a/src/engines/pvml/modules.ts
+++ b/src/engines/pvml/modules.ts
@@ -24,6 +24,25 @@ import {
  * types.ts) — so conversion needs no access to the interpreter itself.
  */
 
+/**
+ * Reads a PAIR or ARRAY's elements uniformly: a PAIR is always exactly 2 (head, tail - whatever
+ * they are, not necessarily a proper list continuation - e.g. sound's Sound is (wave, duration),
+ * a dotted pair whose second element is a plain NUMBER), an ARRAY is however many array_length
+ * reports. Deliberately NOT list_to_vec: that walks a chain expecting it to terminate in
+ * EMPTY_LIST (a *proper list* invariant), which a raw dotted pair doesn't satisfy - this is a
+ * flat "give me this compound value's N elements" read, nothing more.
+ */
+async function readCompoundElements(
+  dh: IDataHandler,
+  value: TypedValue<DataType.ARRAY> | TypedValue<DataType.PAIR>,
+): Promise<TypedValue<DataType>[]> {
+  if (value.type === DataType.PAIR) {
+    return [await dh.pair_head(value), await dh.pair_tail(value)];
+  }
+  const length = await dh.array_length(value);
+  return Promise.all(Array.from({ length }, (_, i) => dh.array_get(value, i)));
+}
+
 /** Converts a conductor module value into a PVML runtime value. `name` is
  * the module export's symbol, used only to label the resulting extern for
  * display/error messages. */
@@ -55,25 +74,18 @@ export async function moduleToPvml(
       // Matches CSE's moduleToPython: both a module function's void return
       // and the empty list map onto Python's None (SICPy's empty list).
       return null;
-    case DataType.PAIR:
-      // PVML represents a pair as a 2-element array — the same shape
-      // pair()/vectorToPvmlList build (see builtins.ts).
+    case DataType.ARRAY:
+    case DataType.PAIR: {
+      // Untyped and recursive, uniformly for both: per Martin, a PAIR is just a 2-element array,
+      // not a distinct concept - one shared conversion, not a separate case per DataType. PVML
+      // represents both the same way anyway (the shape pair()/vectorToPvmlList already build, see
+      // builtins.ts). Deliberately NOT list_to_vec: that expects a chain terminating in
+      // EMPTY_LIST (a *proper list*), which a raw dotted pair (e.g. Sound's (wave, duration))
+      // doesn't satisfy - this reads exactly the compound value's own elements, nothing more.
+      const elements = await readCompoundElements(dh, value);
       return {
         type: "array",
-        elements: [
-          await moduleToPvml(dh, await dh.pair_head(value), name),
-          await moduleToPvml(dh, await dh.pair_tail(value), name),
-        ],
-      };
-    case DataType.ARRAY: {
-      const length = await dh.array_length(value);
-      return {
-        type: "array",
-        elements: await Promise.all(
-          Array.from({ length }, async (_, i) =>
-            moduleToPvml(dh, await dh.array_get(value, i), name),
-          ),
-        ),
+        elements: await Promise.all(elements.map(el => moduleToPvml(dh, el, name))),
       };
     }
     case DataType.OPAQUE:

--- a/src/engines/pvml/modules.ts
+++ b/src/engines/pvml/modules.ts
@@ -41,6 +41,11 @@ export async function moduleToPvml(
   switch (value.type) {
     case DataType.NUMBER:
       return value.value;
+    case DataType.INTEGER:
+      // py-slang never produces DataType.INTEGER itself (see pvmlToModule's bigint case below) -
+      // per Martin, integers stay out of the module interface entirely, numbers crossing a module
+      // boundary are always floats. Only here for switch exhaustiveness over conductor's DataType.
+      return Number(value.value);
     case DataType.BOOLEAN:
       return value.value;
     case DataType.CONST_STRING:

--- a/src/engines/pvml/modules.ts
+++ b/src/engines/pvml/modules.ts
@@ -151,11 +151,11 @@ export async function pvmlToModule(
         // (see GenericDataHandler) already read an ARRAY the same as a PAIR/EMPTY_LIST chain, so a
         // module declaring LIST or PAIR still works unchanged.
         //
-        // An empty array is the one exception: it becomes EMPTY_LIST directly, matching what an
-        // empty ARRAY would mean anyway and what every other engine already does.
-        if (value.elements.length === 0) {
-          return { type: DataType.EMPTY_LIST, value: null };
-        }
+        // No empty-list special case: EMPTY_LIST is also what Python's None maps to (see
+        // moduleToPvml's own EMPTY_LIST case), so returning it here for [] would make [] and None
+        // collide on the way back out - exactly the kind of ambiguity this whole redesign exists
+        // to remove. A genuine 0-length ARRAY round-trips back through moduleToPvml's ARRAY case
+        // as a real [], not None.
         const elements = await Promise.all(
           value.elements.map(el => pvmlToModule(dh, el, callPvml)),
         );

--- a/src/engines/pvml/modules.ts
+++ b/src/engines/pvml/modules.ts
@@ -1,12 +1,5 @@
 import { DataType, IDataHandler, TypedValue } from "@sourceacademy/conductor/types";
-import {
-  PVMLBoxType,
-  PVMLExtern,
-  PVMLHostCall,
-  getPVMLType,
-  isPVMLObject,
-  pvmlListLiteralArrays,
-} from "./types";
+import { PVMLBoxType, PVMLExtern, PVMLHostCall, getPVMLType, isPVMLObject } from "./types";
 
 /**
  * Conversion layer between PVML runtime values and the conductor module
@@ -150,26 +143,34 @@ export async function pvmlToModule(
         // PVMLOpaque's doc comment for why `value` is typed unknown.
         return value.value as TypedValue<DataType.OPAQUE>;
       case "array": {
-        // A list literal (tagged at construction — see pvmlListLiteralArrays' doc comment in
-        // types.ts) is unambiguously a Source list, of any length including 2 — fold it into a
-        // proper PAIR/EMPTY_LIST chain, or list-typed module parameters (e.g. sound's
-        // consecutively/simultaneously/stacking_adsr envelopes) would silently see zero (or the
-        // wrong) elements instead of the list the student actually wrote. Otherwise, a 2-element
-        // array is PVML's pair (see moduleToPvml's PAIR case), reconstructed as a single
-        // pair_make(head, tail) — the chain need not terminate in None (e.g. sound's Sound is a
-        // dotted pair). Any other length is unambiguously a flat Python list either way.
-        if (!pvmlListLiteralArrays.has(value) && value.elements.length === 2) {
-          const [head, tail] = value.elements;
-          return dh.pair_make(
-            await pvmlToModule(dh, head, callPvml),
-            await pvmlToModule(dh, tail, callPvml),
+        // Untyped and recursive: per Martin, a pair is just an array of length 2, not a distinct
+        // concept - build every PVML array (of any length, 2 included, whether it's a fresh list
+        // literal, a pair()/vectorToPvmlList result, or a module PAIR round-tripped back through
+        // PVML) the same way, as a flat DataType.ARRAY, recursively converting each element. No
+        // more origin-tagging or length-based branching needed - list_to_vec/pair_head/pair_tail
+        // (see GenericDataHandler) already read an ARRAY the same as a PAIR/EMPTY_LIST chain, so a
+        // module declaring LIST or PAIR still works unchanged.
+        //
+        // An empty array is the one exception: it becomes EMPTY_LIST directly, matching what an
+        // empty ARRAY would mean anyway and what every other engine already does.
+        if (value.elements.length === 0) {
+          return { type: DataType.EMPTY_LIST, value: null };
+        }
+        const elements = await Promise.all(
+          value.elements.map(el => pvmlToModule(dh, el, callPvml)),
+        );
+        const array = await dh.array_make(DataType.ANY, elements.length, {
+          type: DataType.VOID,
+          value: undefined,
+        });
+        for (let i = 0; i < elements.length; i++) {
+          await dh.array_set(
+            array as unknown as TypedValue<DataType.ARRAY, DataType.VOID>,
+            i,
+            elements[i],
           );
         }
-        let chain: TypedValue<DataType> = { type: DataType.EMPTY_LIST, value: null };
-        for (let i = value.elements.length - 1; i >= 0; i--) {
-          chain = await dh.pair_make(await pvmlToModule(dh, value.elements[i], callPvml), chain);
-        }
-        return chain;
+        return array;
       }
       case "extern":
         // This extern already carries the exact conductor closure it was minted from (see

--- a/src/engines/pvml/pvml-compiler.ts
+++ b/src/engines/pvml/pvml-compiler.ts
@@ -576,11 +576,6 @@ export class PVMLCompiler
     }
 
     this.builder.emitUnary(OpCodes.LDLG, tmpSlot);
-    // Tags this specific load as a list-literal completion site (see PVMLIR's
-    // `listLiteralOffsets` doc comment) - a JS-side-only annotation, never encoded in the
-    // serialised binary format, so this is safe regardless of whether this compile targets native
-    // Pynter.
-    this.builder.markListLiteral();
 
     return { maxStackSize: 3 + 1 };
   }

--- a/src/engines/pvml/pvml-interpreter.ts
+++ b/src/engines/pvml/pvml-interpreter.ts
@@ -25,7 +25,6 @@ import {
   PVMLIterator,
   PVMLProgram,
   PVMLType,
-  pvmlListLiteralArrays,
 } from "./types";
 
 /** Whether a value is excluded from §1/§2's `==`/`!=` entirely: bool (avoiding
@@ -717,16 +716,6 @@ export class PVMLInterpreter {
       // Variable operations
       case OpCodes.LDLG:
         this.loadLocal(a1);
-        // A list literal's compiled shape ends with exactly this instruction pushing its
-        // completed array (see PVMLCompiler's visitListExpr) - tag it here so pvmlToModule can
-        // tell an exactly-2-element list literal apart from a dotted pair (see
-        // pvmlListLiteralArrays' doc comment in types.ts).
-        if (ir.listLiteralOffsets.has(pc)) {
-          const loaded = this.peek();
-          if (isPVMLObject(loaded) && loaded.type === "array") {
-            pvmlListLiteralArrays.add(loaded);
-          }
-        }
         break;
       case OpCodes.LDLF:
       case OpCodes.LDLB:
@@ -1693,11 +1682,6 @@ export class PVMLInterpreter {
     }
     if (funcDef.hasRestParam) {
       const restArgs: PVMLArray = { type: "array", elements: args.slice(numFixedParams) };
-      // A flat, arbitrary-length collection - the same category as a list literal, not a
-      // pair()/llist() chain - so module interop needs the same tag to reconstruct it as a proper
-      // list rather than misreading an exactly-2-arg case as a dotted pair. See
-      // pvmlListLiteralArrays' doc comment in types.ts.
-      pvmlListLiteralArrays.add(restArgs);
       newEnv.set(numFixedParams, restArgs);
       if (__DEBUG__)
         debug(
@@ -2035,10 +2019,6 @@ export class PVMLInterpreter {
       }
     }
     const repeated: PVMLArray = { type: "array", elements };
-    // A `[a, b]`-shaped result must still round-trip through a module
-    // boundary as a genuine list, not be misidentified as a dotted pair —
-    // see pvmlListLiteralArrays' doc comment in types.ts.
-    pvmlListLiteralArrays.add(repeated);
     return repeated;
   }
 

--- a/src/engines/pvml/types.ts
+++ b/src/engines/pvml/types.ts
@@ -73,17 +73,6 @@ export interface PVMLArray {
   elements: PVMLBoxType[];
 }
 
-/**
- * Marks a PVMLArray as a genuine Python list literal (`[a, b]`) or rest-param collection
- * (`def f(*rest)`), as opposed to a value that happens to also be a 2-element array (a dotted
- * pair built via pair()/llist(), or one round-tripped from a module's DataType.PAIR) - mirrors
- * the CSE machine's listLiteralValues (src/engines/cse/modules.ts) exactly, for the same reason:
- * pvmlToModule's "array" case can't tell a 2-element list literal apart from a dotted pair by
- * shape alone (see its own doc comment). A side-tag rather than a shape change so nothing else
- * that already treats these as flat arrays (indexing, len(), iteration, etc.) needs to change.
- */
-export const pvmlListLiteralArrays = new WeakSet<PVMLArray>();
-
 export interface PVMLIterator {
   type: "iterator";
   kind: "range" | "list";
@@ -261,10 +250,6 @@ export interface Instruction {
 
 import OpCodes from "./opcodes";
 
-/** Shared default for PVMLIR's listLiteralOffsets — avoids allocating a fresh empty Set for
- * every function that doesn't need it (the vast majority). */
-const EMPTY_OFFSET_SET: ReadonlySet<number> = new Set();
-
 /**
  * IR representation of a single compiled function.
  *
@@ -315,14 +300,6 @@ export class PVMLIR {
    * see pynter's vm.c. */
   readonly hasRestParam: boolean;
   /**
-   * Instruction offsets of the LDLG that pushes a just-built list literal's completed array (see
-   * PVMLCompiler's visitListExpr and PVMLIRBuilder's markListLiteral) — checked by step()'s LDLG
-   * case to tag the loaded value into pvmlListLiteralArrays. In-memory-only metadata, like
-   * `functionName`/`hasRestParam` — not encoded in the serialised binary format (native Pynter has
-   * no module-interop concept to disambiguate for in the first place, so it never needs this).
-   */
-  readonly listLiteralOffsets: ReadonlySet<number>;
-  /**
    * The function table of the PVMLProgram this function was compiled into —
    * stamped by PVMLProgram's constructor once every sibling PVMLIR exists,
    * so left empty here and populated after construction (the one
@@ -354,7 +331,6 @@ export class PVMLIR {
     functionName: string = "(anonymous)",
     complexes: PyComplexNumber[] = [],
     hasRestParam: boolean = false,
-    listLiteralOffsets: ReadonlySet<number> = EMPTY_OFFSET_SET,
   ) {
     this.opcodes = opcodes;
     this.arg1s = arg1s;
@@ -368,7 +344,6 @@ export class PVMLIR {
     this.numArgs = numArgs;
     this.functionName = functionName;
     this.hasRestParam = hasRestParam;
-    this.listLiteralOffsets = listLiteralOffsets;
   }
 
   /** Compatibility: reconstruct Instruction[] for assembler/debug (not hot path). */

--- a/src/engines/py2js/moduleInterop.ts
+++ b/src/engines/py2js/moduleInterop.ts
@@ -38,12 +38,14 @@
  * 2-element list are the same runtime value here (see runtime.ts's PyList
  * doc comment), so pythonToModule's array check below handles a chapter-2
  * pair() and a chapter-3+ literal list identically, mirroring the CSE
- * converter's "list" case, which makes exactly the same non-distinction —
- * while DataType.ARRAY module values are rejected with a clear error, since
- * no py-slang Python chapter has a native fixed-length array type the way
- * js-slang's Source does. Complex numbers are likewise not supported
- * crossing the boundary (matching the CSE converter's identical
- * restriction).
+ * converter's "list" case, which makes exactly the same non-distinction.
+ * DataType.ARRAY (an untyped, recursively-converted module array — e.g.
+ * scrabble's word lists) round-trips as a genuine PyValue[] on the way out,
+ * mirroring CSE's/PVML's identical DataType.ARRAY handling; there's no
+ * ARRAY-consuming direction yet (pythonToModule never constructs one - no
+ * module currently takes a Python list as an ARRAY-typed argument). Complex
+ * numbers are likewise not supported crossing the boundary (matching the CSE
+ * converter's identical restriction).
  */
 import { DataType, IDataHandler, TypedValue } from "@sourceacademy/conductor/types";
 import { ModuleLoaderRunnerPlugin } from "@sourceacademy/runner-module-loader";
@@ -275,18 +277,17 @@ export async function moduleToPython(
         await moduleToPython(rt, dh, await dh.pair_head(value)),
         await moduleToPython(rt, dh, await dh.pair_tail(value)),
       ];
-    case DataType.ARRAY:
-      // See file header: no py-slang Python chapter has a native
-      // fixed-length array/list-literal type to represent this as, and no
-      // way to consume one anyway, unlike DataType.PAIR above. (DataType
-      // also has a LIST member, but it's a type-level PAIR-or-EMPTY_LIST
-      // marker, not a tag any concrete TypedValue ever actually carries —
-      // TypeScript's own TypedValue<DataType> union excludes it, so there
-      // is no runtime case for it here.)
-      throw new Py2JsRuntimeError(
-        "TypeError",
-        `module values of type "${DataType[value.type]}" are not supported by py2js`,
-      );
+    case DataType.ARRAY: {
+      // Untyped and recursive - see this file's header and CSE's/PVML's identical
+      // DataType.ARRAY handling. A Python list here is just a plain PyValue[] (see runtime.ts's
+      // PyList doc comment), so this is a direct element-by-element conversion, no wrapper needed.
+      const length = await dh.array_length(value);
+      const elements: PyValue[] = [];
+      for (let i = 0; i < length; i++) {
+        elements.push(await moduleToPython(rt, dh, await dh.array_get(value, i), name));
+      }
+      return elements;
+    }
   }
 }
 

--- a/src/engines/py2js/moduleInterop.ts
+++ b/src/engines/py2js/moduleInterop.ts
@@ -104,9 +104,6 @@ export async function pythonToModule(
 ): Promise<TypedValue<DataType>> {
   switch (typeof value) {
     case "bigint":
-      // Module signatures only know NUMBER; crosses as a float, same as
-      // every other engine's converter (CSE's modules.ts, WASM's
-      // moduleInterop.ts).
       return { type: DataType.NUMBER, value: Number(value) };
     case "number":
       return { type: DataType.NUMBER, value };
@@ -220,6 +217,12 @@ export async function moduleToPython(
   switch (value.type) {
     case DataType.NUMBER:
       return value.value;
+    case DataType.INTEGER:
+      // py-slang never produces DataType.INTEGER itself (see pythonToModule's "bigint" case
+      // above) - per Martin, integers stay out of the module interface entirely, numbers crossing
+      // a module boundary are always floats. Only here for switch exhaustiveness over conductor's
+      // DataType enum.
+      return Number(value.value);
     case DataType.BOOLEAN:
       return value.value;
     case DataType.CONST_STRING:

--- a/src/engines/py2js/moduleInterop.ts
+++ b/src/engines/py2js/moduleInterop.ts
@@ -183,11 +183,11 @@ export async function pythonToModule(
         // an ARRAY the same as a PAIR/EMPTY_LIST chain, so a module declaring LIST or PAIR still
         // works unchanged.
         //
-        // An empty list is the one exception: it becomes EMPTY_LIST directly, matching what an
-        // empty ARRAY would mean anyway and what every other engine already does.
-        if (value.length === 0) {
-          return { type: DataType.EMPTY_LIST, value: null };
-        }
+        // No empty-list special case: EMPTY_LIST is also what Python's None maps to (see
+        // moduleToPython's own EMPTY_LIST case), so returning it here for [] would make [] and
+        // None collide on the way back out - exactly the kind of ambiguity this whole redesign
+        // exists to remove. A genuine 0-length ARRAY round-trips back through moduleToPython's
+        // ARRAY case as a real [], not None.
         const elements = await Promise.all(value.map(el => pythonToModule(rt, dh, el)));
         const array = await dh.array_make(DataType.ANY, elements.length, {
           type: DataType.VOID,

--- a/src/engines/py2js/moduleInterop.ts
+++ b/src/engines/py2js/moduleInterop.ts
@@ -175,22 +175,32 @@ export async function pythonToModule(
       if (value === null) return { type: DataType.EMPTY_LIST, value: null };
       if (value instanceof PyOpaque) return value.typed;
       if (Array.isArray(value)) {
-        // A 2-element PyList — chapter 2's pair()/llist() and chapter 3+'s
-        // `[a, b]` literal alike, no representational difference (see the
-        // file header) — round-trips as a module pair via dh.pair_make. Any
-        // other length has no module-side representation any more than a
-        // DataType.ARRAY does (see moduleToPython's DataType.ARRAY case);
-        // dh.pair_make itself is the arity check.
-        if (value.length !== 2) {
-          throw new Py2JsRuntimeError(
-            "TypeError",
-            "only a 2-element list (a pair) can cross into a module, not an arbitrary-length list",
+        // Untyped and recursive: per Martin, a pair is just an array of length 2, not a distinct
+        // concept - build every PyList (of any length, 2 included, whether it's a fresh literal, a
+        // pair()/llist() result, or a module PAIR round-tripped back through Python) the same way,
+        // as a flat DataType.ARRAY, recursively converting each element. No more length-based
+        // rejection needed - list_to_vec/pair_head/pair_tail (see GenericDataHandler) already read
+        // an ARRAY the same as a PAIR/EMPTY_LIST chain, so a module declaring LIST or PAIR still
+        // works unchanged.
+        //
+        // An empty list is the one exception: it becomes EMPTY_LIST directly, matching what an
+        // empty ARRAY would mean anyway and what every other engine already does.
+        if (value.length === 0) {
+          return { type: DataType.EMPTY_LIST, value: null };
+        }
+        const elements = await Promise.all(value.map(el => pythonToModule(rt, dh, el)));
+        const array = await dh.array_make(DataType.ANY, elements.length, {
+          type: DataType.VOID,
+          value: undefined,
+        });
+        for (let i = 0; i < elements.length; i++) {
+          await dh.array_set(
+            array as unknown as TypedValue<DataType.ARRAY, DataType.VOID>,
+            i,
+            elements[i],
           );
         }
-        return dh.pair_make(
-          await pythonToModule(rt, dh, value[0]),
-          await pythonToModule(rt, dh, value[1]),
-        );
+        return array;
       }
       throw new Py2JsRuntimeError(
         "TypeError",

--- a/src/engines/py2js/moduleInterop.ts
+++ b/src/engines/py2js/moduleInterop.ts
@@ -202,6 +202,25 @@ export async function pythonToModule(
 }
 
 /**
+ * Reads a PAIR or ARRAY's elements uniformly: a PAIR is always exactly 2 (head, tail - whatever
+ * they are, not necessarily a proper list continuation - e.g. sound's Sound is (wave, duration),
+ * a dotted pair whose second element is a plain NUMBER), an ARRAY is however many array_length
+ * reports. Deliberately NOT list_to_vec: that walks a chain expecting it to terminate in
+ * EMPTY_LIST (a *proper list* invariant), which a raw dotted pair doesn't satisfy - this is a
+ * flat "give me this compound value's N elements" read, nothing more.
+ */
+async function readCompoundElements(
+  dh: IDataHandler,
+  value: TypedValue<DataType.ARRAY> | TypedValue<DataType.PAIR>,
+): Promise<TypedValue<DataType>[]> {
+  if (value.type === DataType.PAIR) {
+    return [await dh.pair_head(value), await dh.pair_tail(value)];
+  }
+  const length = await dh.array_length(value);
+  return Promise.all(Array.from({ length }, (_, i) => dh.array_get(value, i)));
+}
+
+/**
  * Converts a conductor TypedValue into a py2js native value, for a module
  * export flowing into Python (FromImport bindings) or an argument a module
  * passes to a Python closure it calls back. `name` is used to render an
@@ -268,25 +287,19 @@ export async function moduleToPython(
       return f;
     }
     case DataType.PAIR:
-      // A module PAIR (e.g. sound's Sound, a (wave, duration) dotted pair)
-      // round-trips as a 2-element PyList — mirroring the CSE converter's
-      // "list" case for DataType.PAIR, which makes the same non-distinction
-      // (see the file header). Not necessarily a *proper* list: the second
-      // element need not itself be a pair or None, same as CSE's.
-      return [
-        await moduleToPython(rt, dh, await dh.pair_head(value)),
-        await moduleToPython(rt, dh, await dh.pair_tail(value)),
-      ];
     case DataType.ARRAY: {
-      // Untyped and recursive - see this file's header and CSE's/PVML's identical
-      // DataType.ARRAY handling. A Python list here is just a plain PyValue[] (see runtime.ts's
-      // PyList doc comment), so this is a direct element-by-element conversion, no wrapper needed.
-      const length = await dh.array_length(value);
-      const elements: PyValue[] = [];
-      for (let i = 0; i < length; i++) {
-        elements.push(await moduleToPython(rt, dh, await dh.array_get(value, i), name));
+      // Untyped and recursive, uniformly for both: per Martin, a PAIR is just a 2-element array,
+      // not a distinct concept - one shared conversion, not a separate case per DataType. A
+      // Python list here is just a plain PyValue[] (see runtime.ts's PyList doc comment).
+      // Deliberately NOT list_to_vec: that expects a chain terminating in EMPTY_LIST (a *proper
+      // list*), which a raw dotted pair (e.g. sound's Sound, a (wave, duration) pair) doesn't
+      // satisfy - this reads exactly the compound value's own elements, nothing more.
+      const elements = await readCompoundElements(dh, value);
+      const result: PyValue[] = [];
+      for (const el of elements) {
+        result.push(await moduleToPython(rt, dh, el, name));
       }
-      return elements;
+      return result;
     }
   }
 }

--- a/src/engines/wasm/moduleInterop.ts
+++ b/src/engines/wasm/moduleInterop.ts
@@ -96,6 +96,13 @@ async function typedToHostValue(
   switch (value.type) {
     case DataType.NUMBER:
       return { kind: "float", value: value.value };
+    case DataType.INTEGER:
+      // TODO: WASM's HostModuleValue has no integer kind yet (only
+      // "float"/"bool"/"string"/"none"/"pair"/"handle") - out of scope for
+      // this pass (CSE/py2js/PVML only), kept lossy like the other three
+      // engines were before their fix, just to stay exhaustive over DataType
+      // and keep this engine compiling against the new DataType.INTEGER.
+      return { kind: "float", value: Number(value.value) };
     case DataType.BOOLEAN:
       return { kind: "bool", value: value.value };
     case DataType.CONST_STRING:

--- a/src/tests/GenericDataHandler.test.ts
+++ b/src/tests/GenericDataHandler.test.ts
@@ -207,3 +207,73 @@ describe("list()/is_list/list_to_vec/length/accumulate — the generic pair-chai
     await expect(gen.next()).rejects.toThrow(/Expected a list, got type/);
   });
 });
+
+/**
+ * Per Martin: a pair is just a 2-element array, not a distinct concept. These pin down the two
+ * bridges that make that true without requiring any module to change: pair_head/pair_tail (etc.)
+ * work on an ARRAY-tagged value the same as a genuine PAIR, and the generic list helpers
+ * (is_list/list_to_vec/length/accumulate) accept ARRAY directly instead of only recognizing a
+ * PAIR/EMPTY_LIST chain.
+ */
+describe("PAIR and ARRAY are interchangeable, per Martin's 'pair is just a 2-element array'", () => {
+  test("pair_head/pair_tail read an ARRAY-tagged value's first two elements", async () => {
+    const dh = new GenericDataHandler();
+    const arr = await dh.array_make(DataType.NUMBER, 2, num(0));
+    await dh.array_set(arr as unknown as TypedValue<DataType.ARRAY, DataType.VOID>, 0, num(1));
+    await dh.array_set(arr as unknown as TypedValue<DataType.ARRAY, DataType.VOID>, 1, num(2));
+    const asPair = arr as unknown as TypedValue<DataType.PAIR>;
+
+    expect(await dh.pair_head(asPair)).toEqual(num(1));
+    expect(await dh.pair_tail(asPair)).toEqual(num(2));
+  });
+
+  test("pair_sethead/pair_settail write back into the underlying array", async () => {
+    const dh = new GenericDataHandler();
+    const arr = await dh.array_make(DataType.NUMBER, 2, num(0));
+    const asPair = arr as unknown as TypedValue<DataType.PAIR>;
+
+    await dh.pair_sethead(asPair, num(9));
+    await dh.pair_settail(asPair, num(8));
+
+    expect(await dh.array_get(arr, 0)).toEqual(num(9));
+    expect(await dh.array_get(arr, 1)).toEqual(num(8));
+  });
+
+  test("pair_assert checks an ARRAY-tagged value's element types the same as a genuine PAIR", async () => {
+    const dh = new GenericDataHandler();
+    const arr = await dh.array_make(DataType.NUMBER, 2, num(0));
+    const asPair = arr as unknown as TypedValue<DataType.PAIR>;
+
+    await expect(dh.pair_assert(asPair, DataType.NUMBER, DataType.NUMBER)).resolves.toBeUndefined();
+    expect(() => dh.pair_assert(asPair, DataType.CONST_STRING)).toThrow(/Expected head of type/);
+  });
+
+  test("pair_head throws on a too-short array (fewer than 2 elements), same as a dangling pair", async () => {
+    const dh = new GenericDataHandler();
+    const arr = await dh.array_make(DataType.NUMBER, 1, num(0));
+    expect(() => dh.pair_head(arr as unknown as TypedValue<DataType.PAIR>)).toThrow(
+      /Invalid pair identifier/,
+    );
+  });
+
+  test("is_list/list_to_vec/length/accumulate accept a DataType.ARRAY directly", async () => {
+    const dh = new GenericDataHandler();
+    const arr = await dh.array_make(DataType.NUMBER, 3, num(0));
+    await dh.array_set(arr as unknown as TypedValue<DataType.ARRAY, DataType.VOID>, 0, num(1));
+    await dh.array_set(arr as unknown as TypedValue<DataType.ARRAY, DataType.VOID>, 1, num(2));
+    await dh.array_set(arr as unknown as TypedValue<DataType.ARRAY, DataType.VOID>, 2, num(3));
+    const asList = arr as unknown as TypedValue<DataType.LIST>;
+
+    expect(await dh.is_list(asList)).toBe(true);
+    expect(await dh.list_to_vec(asList)).toEqual([num(1), num(2), num(3)]);
+    expect(await dh.length(asList)).toBe(3);
+
+    const add = makeAddClosure();
+    const op = await dh.closure_make(
+      { args: [DataType.NUMBER, DataType.NUMBER], returnType: DataType.NUMBER },
+      add,
+    );
+    const result = await drain(dh.accumulate(op, num(0), asList, DataType.NUMBER));
+    expect(result).toEqual(num(6));
+  });
+});

--- a/src/tests/modules.test.ts
+++ b/src/tests/modules.test.ts
@@ -269,11 +269,17 @@ describe("module interop conversions", () => {
       ]);
     });
 
-    test("converts an empty Python list literal into EMPTY_LIST, not an empty ARRAY", async () => {
-      const { context } = makeContext();
-      await expect(
-        pythonToModule(context, "", undefined, { type: "list", value: [] }),
-      ).resolves.toEqual({ type: DataType.EMPTY_LIST, value: null });
+    test("converts an empty Python list literal into a 0-length ARRAY, not EMPTY_LIST", async () => {
+      // Regression test: EMPTY_LIST is also what Python's None maps to (see moduleToPython's own
+      // EMPTY_LIST case) - if [] built EMPTY_LIST here, moduleToPython(pythonToModule([])) would
+      // round-trip back as None instead of [], exactly the ambiguity this redesign removes
+      // elsewhere. A real module round-trip test lives in pvml-modules.test.ts (identity([])).
+      const { context, evaluator } = makeContext();
+      const moduleList = await pythonToModule(context, "", undefined, { type: "list", value: [] });
+      expect(moduleList.type).toBe(DataType.ARRAY);
+      await expect(readArray(evaluator, moduleList as TypedValue<DataType.ARRAY>)).resolves.toEqual(
+        [],
+      );
     });
 
     test("a 2-element list becomes a flat ARRAY too - no more special-casing by length", async () => {

--- a/src/tests/modules.test.ts
+++ b/src/tests/modules.test.ts
@@ -192,6 +192,16 @@ function makeContext(): { context: Context; evaluator: TestDataHandler } {
   return { context, evaluator };
 }
 
+/** Reads a DataType.ARRAY's elements via the raw array_length/array_get primitives - used instead
+ * of list_to_vec since TestDataHandler (this file's isolated double) doesn't implement it. */
+async function readArray(
+  evaluator: TestDataHandler,
+  array: TypedValue<DataType.ARRAY>,
+): Promise<TypedValue<DataType>[]> {
+  const length = await evaluator.array_length(array);
+  return Promise.all(Array.from({ length }, (_, i) => evaluator.array_get(array, i)));
+}
+
 async function drainGenerator<T>(generator: AsyncGenerator<void, T, undefined>): Promise<T> {
   let next = await generator.next();
   while (!next.done) {
@@ -226,11 +236,12 @@ describe("module interop conversions", () => {
       });
     });
 
-    test("converts a Python list literal of any length (other than 2) into a proper PAIR/EMPTY_LIST chain", async () => {
-      // Regression test: pair()/llist()/module round-trips always produce exactly 2-element links,
-      // so any other length can only be a list literal (visitListExpr) - it must become a genuine
-      // Source list, not an ARRAY, or list-typed module parameters (e.g. sound's consecutively)
-      // would silently see zero elements instead of the list the student actually wrote.
+    test("converts a Python list literal of any length into a flat DataType.ARRAY, recursively", async () => {
+      // Per Martin: a pair is just an array of length 2, not a distinct concept - every Python
+      // list (any length, 2 included) becomes a flat ARRAY now, with no origin-tagging or
+      // length-based branching. GenericDataHandler's list_to_vec/pair_head/pair_tail bridging onto
+      // ARRAY is covered separately in GenericDataHandler.test.ts; this file's TestDataHandler
+      // double only implements the raw array_length/array_get primitives, used directly here.
       const { context, evaluator } = makeContext();
       const pythonList: Value = {
         type: "list",
@@ -243,30 +254,19 @@ describe("module interop conversions", () => {
 
       const moduleList = await pythonToModule(context, "", undefined, pythonList);
 
-      expect(moduleList.type).toBe(DataType.PAIR);
-      let current = moduleList;
-      const elements: TypedValue<DataType>[] = [];
-      while (current.type === DataType.PAIR) {
-        elements.push(await evaluator.pair_head(current));
-        current = await evaluator.pair_tail(current);
-      }
-      expect(current.type).toBe(DataType.EMPTY_LIST);
+      expect(moduleList.type).toBe(DataType.ARRAY);
+      const elements = await readArray(evaluator, moduleList as TypedValue<DataType.ARRAY>);
       expect(elements).toEqual([
         { type: DataType.NUMBER, value: 1 },
-        expect.objectContaining({ type: DataType.PAIR }),
+        expect.objectContaining({ type: DataType.ARRAY }),
         { type: DataType.BOOLEAN, value: false },
       ]);
 
-      // The single-element nested list is itself a proper 1-element chain, not an ARRAY.
-      const nested = elements[1] as TypedValue<DataType.PAIR>;
-      await expect(evaluator.pair_head(nested)).resolves.toEqual({
-        type: DataType.CONST_STRING,
-        value: "nested",
-      });
-      await expect(evaluator.pair_tail(nested)).resolves.toEqual({
-        type: DataType.EMPTY_LIST,
-        value: null,
-      });
+      // The single-element nested list is itself a flat 1-element ARRAY.
+      const nested = elements[1] as TypedValue<DataType.ARRAY>;
+      await expect(readArray(evaluator, nested)).resolves.toEqual([
+        { type: DataType.CONST_STRING, value: "nested" },
+      ]);
     });
 
     test("converts an empty Python list literal into EMPTY_LIST, not an empty ARRAY", async () => {
@@ -276,10 +276,7 @@ describe("module interop conversions", () => {
       ).resolves.toEqual({ type: DataType.EMPTY_LIST, value: null });
     });
 
-    test("a 2-element list literal (tagged via listLiteralValues) becomes a proper chain, not a raw dotted pair", async () => {
-      // Regression test: exactly 2 elements is the one length that's genuinely ambiguous between a
-      // list literal and a dotted pair. The InstrType.LIST microcode tags every literal it builds, so
-      // this simulates that tag directly (this test doesn't go through the actual interpreter).
+    test("a 2-element list becomes a flat ARRAY too - no more special-casing by length or listLiteralValues tagging", async () => {
       const { context, evaluator } = makeContext();
       const literal: ListValue = {
         type: "list",
@@ -288,51 +285,29 @@ describe("module interop conversions", () => {
           { type: "number", value: 2 },
         ],
       };
+      // Tagging listLiteralValues (or not) no longer changes anything - kept here only to show
+      // that explicitly, since older code paths still tag literals at construction time.
       listLiteralValues.add(literal);
 
       const moduleList = await pythonToModule(context, "", undefined, literal);
 
-      expect(moduleList.type).toBe(DataType.PAIR);
-      const pair = moduleList as TypedValue<DataType.PAIR>;
-      await expect(evaluator.pair_head(pair)).resolves.toEqual({ type: DataType.NUMBER, value: 1 });
-      const tail = await evaluator.pair_tail(pair);
-      expect(tail.type).toBe(DataType.PAIR);
-      await expect(evaluator.pair_head(tail as TypedValue<DataType.PAIR>)).resolves.toEqual({
-        type: DataType.NUMBER,
-        value: 2,
-      });
-      await expect(evaluator.pair_tail(tail as TypedValue<DataType.PAIR>)).resolves.toEqual({
-        type: DataType.EMPTY_LIST,
-        value: null,
-      });
-    });
-
-    test("an untagged 2-element list (e.g. a module PAIR round-tripped through Python) still becomes a raw dotted pair", async () => {
-      const { context, evaluator } = makeContext();
-      // Not tagged in listLiteralValues, matching what moduleToPython produces for a DataType.PAIR.
-      const dotted: Value = {
-        type: "list",
-        value: [
-          { type: "number", value: 1 },
-          { type: "number", value: 2 },
+      expect(moduleList.type).toBe(DataType.ARRAY);
+      await expect(readArray(evaluator, moduleList as TypedValue<DataType.ARRAY>)).resolves.toEqual(
+        [
+          { type: DataType.NUMBER, value: 1 },
+          { type: DataType.NUMBER, value: 2 },
         ],
-      };
-
-      const moduleValue = await pythonToModule(context, "", undefined, dotted);
-
-      expect(moduleValue.type).toBe(DataType.PAIR);
-      const pair = moduleValue as TypedValue<DataType.PAIR>;
-      await expect(evaluator.pair_head(pair)).resolves.toEqual({ type: DataType.NUMBER, value: 1 });
-      // The tail is the raw second element directly, not another PAIR link.
-      await expect(evaluator.pair_tail(pair)).resolves.toEqual({ type: DataType.NUMBER, value: 2 });
+      );
     });
 
-    test("round-trips a dotted pair (tail not None-terminated) back into a module PAIR, not an ARRAY", async () => {
-      // Regression test: a module (e.g. sound's Sound, (wavesPair, duration)) may return a PAIR
-      // whose tail is arbitrary data rather than another list link. moduleToPython turns that into
-      // a 2-element Python list; passing it back into another module call must reconstruct a PAIR
-      // (via pair_make), not an ARRAY, or ptm(mtp(pairObject)) isn't a fixpoint for anything that
-      // isn't a None-terminated chain.
+    test("round-trips a module PAIR (e.g. sound's Sound, a dotted (wave, duration) pair) back into an ARRAY", async () => {
+      // A module may return a PAIR whose second element is arbitrary data, not another list link
+      // (sound's Sound is exactly this shape). moduleToPython turns that into a 2-element Python
+      // list; passing it back into another module call now builds an ARRAY (uniformly, like any
+      // other list) rather than reconstructing a PAIR. (That pair_head/pair_tail still read the
+      // same two elements off an ARRAY - so a module calling them for clarity keeps working
+      // unchanged - is GenericDataHandler-specific behavior, covered in GenericDataHandler.test.ts;
+      // TestDataHandler here doesn't implement that bridge.)
       const { context, evaluator } = makeContext();
       const pair = await evaluator.pair_make(
         { type: DataType.NUMBER, value: 1 },
@@ -342,13 +317,13 @@ describe("module interop conversions", () => {
       const asPython = await moduleToPython(context, "", undefined, pair);
       const roundTripped = await pythonToModule(context, "", undefined, asPython);
 
-      expect(roundTripped.type).toBe(DataType.PAIR);
-      await expect(evaluator.pair_head(roundTripped as TypedValue<DataType.PAIR>)).resolves.toEqual(
+      expect(roundTripped.type).toBe(DataType.ARRAY);
+      await expect(
+        readArray(evaluator, roundTripped as TypedValue<DataType.ARRAY>),
+      ).resolves.toEqual([
         { type: DataType.NUMBER, value: 1 },
-      );
-      await expect(evaluator.pair_tail(roundTripped as TypedValue<DataType.PAIR>)).resolves.toEqual(
         { type: DataType.NUMBER, value: 2 },
-      );
+      ]);
     });
 
     test("wraps Python builtins as module closures", async () => {

--- a/src/tests/modules.test.ts
+++ b/src/tests/modules.test.ts
@@ -8,7 +8,7 @@ import {
 import { ExprNS, StmtNS } from "../ast-types";
 import { Closure } from "../engines/cse/closure";
 import { Context } from "../engines/cse/context";
-import { listLiteralValues, moduleToPython, pythonToModule } from "../engines/cse/modules";
+import { moduleToPython, pythonToModule } from "../engines/cse/modules";
 import { BuiltinValue, ListValue, Value } from "../engines/cse/stash";
 import { toPythonAst } from "./utils";
 
@@ -276,7 +276,7 @@ describe("module interop conversions", () => {
       ).resolves.toEqual({ type: DataType.EMPTY_LIST, value: null });
     });
 
-    test("a 2-element list becomes a flat ARRAY too - no more special-casing by length or listLiteralValues tagging", async () => {
+    test("a 2-element list becomes a flat ARRAY too - no more special-casing by length", async () => {
       const { context, evaluator } = makeContext();
       const literal: ListValue = {
         type: "list",
@@ -285,9 +285,6 @@ describe("module interop conversions", () => {
           { type: "number", value: 2 },
         ],
       };
-      // Tagging listLiteralValues (or not) no longer changes anything - kept here only to show
-      // that explicitly, since older code paths still tag literals at construction time.
-      listLiteralValues.add(literal);
 
       const moduleList = await pythonToModule(context, "", undefined, literal);
 

--- a/src/tests/pvml-modules.test.ts
+++ b/src/tests/pvml-modules.test.ts
@@ -671,6 +671,20 @@ describe("PyPvmlEvaluator module imports", () => {
     expect(outputs).toEqual(["[0.0]"]);
   });
 
+  test("an empty list through the same VOID-signature passthrough round-trips to [], not None", async () => {
+    // Regression test: an earlier version of this fix special-cased an empty Python list to build
+    // EMPTY_LIST directly (matching pre-existing behavior) - but EMPTY_LIST is also what Python's
+    // None maps to, so identity([]) printed "None" instead of "[]". A genuine 0-length ARRAY (no
+    // special case at all) round-trips correctly.
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new PyPvmlEvaluator4(conductor);
+
+    await evaluator.evaluateChunk("from testmod import identity\nprint(identity([]))\n");
+
+    expect(errors).toEqual([]);
+    expect(outputs).toEqual(["[]"]);
+  });
+
   test("lists of length other than 2 already worked and still do", async () => {
     const { conductor, errors, outputs } = makeMockConductor();
     const evaluator = new PyPvmlEvaluator4(conductor);

--- a/src/tests/pvml-modules.test.ts
+++ b/src/tests/pvml-modules.test.ts
@@ -200,6 +200,17 @@ async function makeTestModule(dh: IDataHandler): Promise<IModulePlugin> {
     },
   );
 
+  // Matches repeat's own identity/composition closures exactly: an all-VOID placeholder
+  // signature (see GenericDataHandler's coerceArgsToSignature-era doc history), relaying
+  // whatever TypedValue it's handed straight back through, untouched, no matter what it is.
+  const identity = await dh.closure_make(
+    { returnType: DataType.VOID, args: [DataType.VOID] },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async function* (x: TypedValue<DataType>) {
+      return x;
+    },
+  );
+
   return {
     exports: [
       { symbol: "answer", value: num(42) },
@@ -217,6 +228,7 @@ async function makeTestModule(dh: IDataHandler): Promise<IModulePlugin> {
       { symbol: "negate_flag", value: negateFlag },
       { symbol: "greeting", value: { type: DataType.CONST_STRING, value: "hello" } },
       { symbol: "shout", value: shout },
+      { symbol: "identity", value: identity },
     ],
   } as unknown as IModulePlugin;
 }
@@ -641,6 +653,22 @@ describe("PyPvmlEvaluator module imports", () => {
 
     expect(errors).toEqual([]);
     expect(outputs).toEqual(["30.0"]);
+  });
+
+  test("a VOID-signature passthrough closure (repeat's identity/composition shape) round-trips a list correctly - was [0.0, None], now [0.0]", async () => {
+    // The actual repeat bug: identity has no declared LIST/ARRAY type to guide encoding (it's
+    // generic over any T, declared DataType.VOID), so [0] used to cross in as a PAIR/EMPTY_LIST
+    // chain and come back out through moduleToPvml's old shallow PAIR case as a 2-element
+    // [head, tail] with EMPTY_LIST misread as an extra None element, instead of a flat 1-element
+    // list. Now that pvmlToModule always builds a flat ARRAY for any Python list, this round-trips
+    // correctly with no declared-type awareness needed at all.
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new PyPvmlEvaluator4(conductor);
+
+    await evaluator.evaluateChunk("from testmod import identity\nprint(identity([0]))\n");
+
+    expect(errors).toEqual([]);
+    expect(outputs).toEqual(["[0.0]"]);
   });
 
   test("lists of length other than 2 already worked and still do", async () => {

--- a/src/tests/pvml-modules.test.ts
+++ b/src/tests/pvml-modules.test.ts
@@ -608,12 +608,12 @@ describe("PyPvmlEvaluator module imports", () => {
   });
 
   test("a literal 2-element Python list argument converts as a genuine list, not a dotted pair", async () => {
-    // The actual bug: [a, b] and pair(a, b) produce the identical runtime shape (a 2-element
-    // array) once compiled - pvmlToModule's "array" case used to have no way to tell them apart,
-    // so a *literal* 2-element list (e.g. simultaneously([sine_sound(...), rest]), the natural
-    // thing a student writes) got misread as a dotted pair instead of a list, corrupting whatever
-    // it was passed to. Fixed by tagging a list literal's completed array at its LDLG load site
-    // (see pvmlListLiteralArrays in types.ts) instead of guessing from shape alone.
+    // The original bug: [a, b] and pair(a, b) produced the identical runtime shape (a 2-element
+    // array) once compiled, so a *literal* 2-element list (e.g. simultaneously([sine_sound(...),
+    // rest]), the natural thing a student writes) got misread as a dotted pair instead of a list,
+    // corrupting whatever it was passed to. Now pvmlToModule always builds a flat DataType.ARRAY
+    // for any Python list regardless of length, so there's no length-2 special case left to
+    // misread in the first place.
     const { conductor, errors, outputs } = makeMockConductor();
     const evaluator = new PyPvmlEvaluator4(conductor);
 
@@ -640,7 +640,7 @@ describe("PyPvmlEvaluator module imports", () => {
 
   test("a 2-element rest-param collection also converts as a genuine list", async () => {
     // def f(*rest) collects exactly 2 positional args into the same flat-array shape a 2-element
-    // list literal has - needs the identical tag (see pvmlListLiteralArrays' doc comment).
+    // list literal has - converts identically now, no special-casing needed.
     const { conductor, errors, outputs } = makeMockConductor();
     const evaluator = new PyPvmlEvaluator4(conductor);
 

--- a/src/tests/py2js-module-interop.test.ts
+++ b/src/tests/py2js-module-interop.test.ts
@@ -218,13 +218,17 @@ describe("moduleToPython", () => {
     ]);
   });
 
-  test("an empty list literal converts to EMPTY_LIST, not an empty ARRAY", async () => {
+  test("an empty list literal converts to a 0-length ARRAY, not EMPTY_LIST, and round-trips back to []", async () => {
+    // Regression test: EMPTY_LIST is also what Python's None maps to (see moduleToPython's own
+    // EMPTY_LIST case) - if [] built EMPTY_LIST here, moduleToPython(pythonToModule([])) would
+    // round-trip back as None instead of [], exactly the ambiguity this redesign removes
+    // elsewhere.
     const dh = new GenericDataHandler();
     const rt = makeRt();
-    await expect(pythonToModule(rt, dh, [])).resolves.toEqual({
-      type: DataType.EMPTY_LIST,
-      value: null,
-    });
+    const typed = await pythonToModule(rt, dh, []);
+    expect(typed.type).toBe(DataType.ARRAY);
+    await expect(dh.list_to_vec(typed as TypedValue<DataType.LIST>)).resolves.toEqual([]);
+    await expect(moduleToPython(rt, dh, typed)).resolves.toEqual([]);
   });
 
   test("CLOSURE becomes an asyncOnly PyFunction", async () => {

--- a/src/tests/py2js-module-interop.test.ts
+++ b/src/tests/py2js-module-interop.test.ts
@@ -131,7 +131,7 @@ describe("moduleToPython", () => {
     expect((result as PyOpaque).typed).toBe(typed);
   });
 
-  test("PAIR round-trips through a 2-element PyList; ARRAY is still rejected", async () => {
+  test("PAIR round-trips through a 2-element PyList", async () => {
     const dh = new GenericDataHandler();
     const rt = makeRt();
     const pair = await dh.pair_make(
@@ -152,9 +152,35 @@ describe("moduleToPython", () => {
       type: DataType.NUMBER,
       value: 2,
     });
+  });
 
-    const arr = await dh.array_make(DataType.NUMBER, 2);
-    await expect(moduleToPython(rt, dh, arr)).rejects.toThrow(Py2JsRuntimeError);
+  test("ARRAY converts to a genuine flat PyList, recursively (e.g. scrabble's word lists)", async () => {
+    const dh = new GenericDataHandler();
+    const rt = makeRt();
+    const arr = await dh.array_make(DataType.CONST_STRING, 2);
+    await dh.array_set(arr as unknown as TypedValue<DataType.ARRAY, DataType.VOID>, 0, {
+      type: DataType.CONST_STRING,
+      value: "cat",
+    });
+    await dh.array_set(arr as unknown as TypedValue<DataType.ARRAY, DataType.VOID>, 1, {
+      type: DataType.CONST_STRING,
+      value: "dog",
+    });
+
+    expect(await moduleToPython(rt, dh, arr)).toEqual(["cat", "dog"]);
+  });
+
+  test("a nested ARRAY (array of arrays) converts to a nested PyList", async () => {
+    const dh = new GenericDataHandler();
+    const rt = makeRt();
+    const inner = await dh.array_make(DataType.CONST_STRING, 1);
+    await dh.array_set(inner as unknown as TypedValue<DataType.ARRAY, DataType.VOID>, 0, {
+      type: DataType.CONST_STRING,
+      value: "a",
+    });
+    const outer = await dh.array_make(DataType.ARRAY, 1, inner);
+
+    expect(await moduleToPython(rt, dh, outer)).toEqual([["a"]]);
   });
 
   test("a chapter-3 native list literal (not built via pair()) now crosses into a module too", async () => {

--- a/src/tests/py2js-module-interop.test.ts
+++ b/src/tests/py2js-module-interop.test.ts
@@ -131,7 +131,12 @@ describe("moduleToPython", () => {
     expect((result as PyOpaque).typed).toBe(typed);
   });
 
-  test("PAIR round-trips through a 2-element PyList", async () => {
+  test("PAIR round-trips through a 2-element PyList, back into an ARRAY", async () => {
+    // Per Martin: a pair is just an array of length 2 - a module PAIR (e.g. sound's Sound, a
+    // dotted (wave, duration) pair) round-trips out as a 2-element PyList, and passing it back in
+    // now builds a flat ARRAY (uniformly, like any other list) rather than reconstructing a PAIR.
+    // pair_head/pair_tail still read the same two elements off it either way (GenericDataHandler's
+    // ARRAY bridge, covered in GenericDataHandler.test.ts).
     const dh = new GenericDataHandler();
     const rt = makeRt();
     const pair = await dh.pair_make(
@@ -143,7 +148,7 @@ describe("moduleToPython", () => {
     expect(native).toEqual([1, 2]);
 
     const roundTripped = await pythonToModule(rt, dh, native);
-    expect(roundTripped.type).toBe(DataType.PAIR);
+    expect(roundTripped.type).toBe(DataType.ARRAY);
     expect(await dh.pair_head(roundTripped as TypedValue<DataType.PAIR>)).toEqual({
       type: DataType.NUMBER,
       value: 1,
@@ -183,19 +188,14 @@ describe("moduleToPython", () => {
     expect(await moduleToPython(rt, dh, outer)).toEqual([["a"]]);
   });
 
-  test("a chapter-3 native list literal (not built via pair()) now crosses into a module too", async () => {
-    // Before pairs and lists were unified into one PyList representation,
-    // pythonToModule's "object" case only recognized PyPair — a genuine
-    // [1, 2] literal (typeof "object", but not instanceof PyPair) fell
-    // through to the generic "complex values are not supported" error, a
-    // misleading message for what was actually just an unhandled list. Once
-    // the type check became Array.isArray, a 2-element literal list crosses
-    // exactly like a pair() result does — there's no representational
-    // difference for pythonToModule to even distinguish them by.
+  test("a chapter-3 native list literal converts to a flat ARRAY, same as any other length", async () => {
+    // Per Martin: a pair is just an array of length 2, not a distinct concept - a genuine [10, 20]
+    // literal (typeof "object", an Array) converts exactly like any other Python list now, as a
+    // flat ARRAY, with no special-casing by length.
     const dh = new GenericDataHandler();
     const rt = makeRt();
     const typed = await pythonToModule(rt, dh, [10n, 20n]);
-    expect(typed.type).toBe(DataType.PAIR);
+    expect(typed.type).toBe(DataType.ARRAY);
     expect(await dh.pair_head(typed as TypedValue<DataType.PAIR>)).toEqual({
       type: DataType.NUMBER,
       value: 10,
@@ -206,10 +206,25 @@ describe("moduleToPython", () => {
     });
   });
 
-  test("an N-element (N != 2) list has no module representation and throws clearly, not silently truncating", async () => {
+  test("an N-element (N != 2) list now converts to a flat ARRAY too, instead of throwing", async () => {
     const dh = new GenericDataHandler();
     const rt = makeRt();
-    await expect(pythonToModule(rt, dh, [1n, 2n, 3n])).rejects.toThrow(/2-element list/);
+    const typed = await pythonToModule(rt, dh, [1n, 2n, 3n]);
+    expect(typed.type).toBe(DataType.ARRAY);
+    await expect(dh.list_to_vec(typed as TypedValue<DataType.LIST>)).resolves.toEqual([
+      { type: DataType.NUMBER, value: 1 },
+      { type: DataType.NUMBER, value: 2 },
+      { type: DataType.NUMBER, value: 3 },
+    ]);
+  });
+
+  test("an empty list literal converts to EMPTY_LIST, not an empty ARRAY", async () => {
+    const dh = new GenericDataHandler();
+    const rt = makeRt();
+    await expect(pythonToModule(rt, dh, [])).resolves.toEqual({
+      type: DataType.EMPTY_LIST,
+      value: null,
+    });
   });
 
   test("CLOSURE becomes an asyncOnly PyFunction", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,10 +1650,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sourceacademy/conductor@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@sourceacademy/conductor@npm:0.7.0"
-  checksum: 10c0/30088c7c6682e76c5421ba80c0890d680650c964c02edb5083ec730ed2a722221702fae1dfd32e9d7e9c520216179de4bbabbbb8971025a98798620da2d6d74c
+"@sourceacademy/conductor@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "@sourceacademy/conductor@npm:0.7.2"
+  checksum: 10c0/84cff73c8c67a5884c9a06774f514b2dc4275e14ee282c7eee4fd32618857f63cdc2a736c4e5d2b6501b7b39d6c9e2f7192af1dbbc8ec1542721c08252c1f022
   languageName: node
   linkType: hard
 
@@ -1671,7 +1671,7 @@ __metadata:
     "@rollup/plugin-wasm": "npm:^6.2.2"
     "@sourceacademy/common-cse-machine": "npm:^0.3.0"
     "@sourceacademy/common-stepper": "npm:^0.0.1"
-    "@sourceacademy/conductor": "npm:^0.7.0"
+    "@sourceacademy/conductor": "npm:^0.7.2"
     "@sourceacademy/runner-cse-machine": "npm:^3.0.0"
     "@sourceacademy/runner-module-loader": "npm:^0.0.1"
     "@sourceacademy/runner-stepper": "npm:^0.0.1"


### PR DESCRIPTION
## Summary

This PR converged through several design iterations with Martin (see linked Slack thread) onto the final shape below. Five commits:

**1. `Keep integers out of the module interface`** — Martin, final: *"'would print 1.0, not 1' is a feature, not a bug. We should keep integers out of modules."* `binary_tree`'s `entry()` printing `1.0` for a tree built from a Python int is correct, intended behavior. A Python int silently becomes `DataType.NUMBER` (a float) the moment it crosses into any module, unconditionally, everywhere — CSE/py2js/PVML's `pythonToModule` and PVML's `pvmlToModule` all convert directly to `NUMBER`, no separate `INTEGER` tag, no exceptions. Matches every engine's pre-existing behavior. Also fixes an independent, unrelated bug bundled into the same history: `closure_call_unchecked` now throws on an invalid closure identifier instead of silently returning `undefined`.

**2. `fix: py2js's moduleToPython converts DataType.ARRAY to a genuine flat PyList`** — CSE and PVML already handled `DataType.ARRAY` (recursive, untyped conversion into a genuine flat list); py2js rejected it outright with a hard `TypeError`. `scrabble`'s module code only ever constructs and returns arrays (its word lists), so it worked on CSE/PVML but crashed on py2js specifically. Fixed with the same recursive conversion the other two engines already had.

**3. `feat: treat PAIR and ARRAY as interchangeable, not separate concepts`** — Martin: *"there is nothing called a pair anymore. Pairs are just arrays of length 2."* The only place "pair" survives is the name of Python builtins (`pair()`, `is_pair()`) and chapter 1-2 error-message wording — never as a distinct representation. Done entirely within py-slang, zero modules-repo changes required for this step:
   - `GenericDataHandler`'s generic list helpers (`is_list`/`list_to_vec`/`length`/`accumulate`) now read a `DataType.ARRAY` directly (already flat) as well as a `PAIR`/`EMPTY_LIST` chain — a module that only calls these (`sound`, `midi`) needs no changes.
   - `pair_head`/`pair_tail`/`pair_sethead`/`pair_settail`/`pair_assert` now also accept an `ARRAY`-tagged value, reading/writing index 0/1 directly — per Martin, modules may keep calling these internally for clarity even once the underlying value is array-backed.
   - `moduleToPython`(CSE)/`moduleToPvml`(PVML)/`moduleToPython`(py2js)'s `PAIR` and `ARRAY` cases are now one shared conversion (`readCompoundElements`) — deliberately *not* `list_to_vec`, which expects a chain terminating in `EMPTY_LIST` (a *proper list*); a raw dotted pair (`sound`'s `Sound`, a `(wave, duration)` pair) doesn't satisfy that.
   - `binary_tree` is the one confirmed exception: its own source hardcodes `value.type !== DataType.PAIR` checks (`is_tree`/`is_empty_tree`) that read conductor's `DataType` tag directly, not through any py-slang abstraction — needs an actual modules-repo change, tracked separately (topological merge: this PR first, `binary_tree`'s PR after).

**4. `fix: pythonToModule always builds a flat ARRAY for a Python list`** — the actual fix for the "`repeat`'s `identity([0])` prints `[0.0, None]`" bug. CSE/PVML/py2js's `pythonToModule` now build every Python list (any length, 2 included, whether a fresh literal, a `pair()`/`llist()` result, or a module `PAIR` round-tripped back through Python) the same way, as a flat `DataType.ARRAY` — no more origin-tagging or length-based branching. An empty list is the one carve-out: becomes `EMPTY_LIST` directly. py2js also gains real support for arbitrary-length lists as a side effect (its old code only ever handled exactly 2 elements, throwing for anything else). Regression test reproduces `repeat`'s exact `identity`/`composition` shape and confirms `identity([0])` now prints `"[0.0]"`, not `"[0.0, None]"`.

**5. `chore: remove dead listLiteralValues/pvmlListLiteralArrays tagging`** — nothing reads either `WeakSet` anymore after commit 4; removed the mechanism entirely rather than leave it as dead weight, including the PVML compiler-level bookkeeping (`listLiteralOffsets`/`markListLiteral`) that only existed to feed it.

## Test plan
- [x] `yarn tsc --noEmit` clean
- [x] `yarn eslint`/`yarn prettier --check` clean on touched files
- [x] Targeted `yarn jest` runs green across all 5 commits' worth of changes: `GenericDataHandler.test.ts`, `modules.test.ts`, `pvml-modules.test.ts` (incl. the `repeat`-shape regression test), `py2js-module-interop.test.ts`, `pvml-interpreter.test.ts`, `pvml.test.ts`, `pvml-assembler.test.ts`, `wasm-modules.test.ts`, `py2js-lists.test.ts`, `py2js-from-import.test.ts` — 603 tests passing
- [x] Manually verified end-to-end against the real deployed `binary_tree`/`midi`/`scrabble` modules through a local frontend + language-directory + py-slang dev stack

## Not in scope for this PR (tracked separately)
- `binary_tree`'s own migration (`is_tree`/`is_empty_tree`) — companion modules-repo PR, merges after this one.