### PR TITLE
PVML: fix print(print) showing "<built-in function display>"

### DIFF
--- a/src/engines/pvml/cse-interop.ts
+++ b/src/engines/pvml/cse-interop.ts
@@ -19,15 +19,25 @@ function functionDisplayValue(name: string): FunctionValue {
 
 /** Reverse of PRIMITIVE_FUNCTIONS (builtins.ts): primitive index -> a name to
  * display when a bare reference to it (e.g. `f = abs`) is str()'d/repr()'d.
- * A few indices have more than one name (e.g. print/display both -> 5); any
- * one of them is a fine display name, so ties just take last-write-wins.
- * Built lazily (not at module load) because builtins.ts and this module
- * import each other — computing this eagerly at top level would run before
- * builtins.ts has finished populating PRIMITIVE_FUNCTIONS. */
+ * A few indices have more than one name (e.g. print/display both -> 5,
+ * len/list_length both -> 2) — not interchangeable for display purposes
+ * (py-slang#278: print(print) rendered as "<built-in function display>",
+ * surprising for code that never mentioned display). PRIMITIVE_FUNCTIONS
+ * always lists the canonical name first and the alias second (each
+ * commented as such), so keep whichever name claims an index first rather
+ * than letting naive last-write-wins Map construction hand it to whatever
+ * alias happens to be listed later. Built lazily (not at module load)
+ * because builtins.ts and this module import each other — computing this
+ * eagerly at top level would run before builtins.ts has finished populating
+ * PRIMITIVE_FUNCTIONS. */
 let primitiveNames: ReadonlyMap<number, string> | undefined;
 function primitiveNameOf(primitiveIndex: number): string | undefined {
   if (!primitiveNames) {
-    primitiveNames = new Map(Array.from(PRIMITIVE_FUNCTIONS, ([name, index]) => [index, name]));
+    const names = new Map<number, string>();
+    for (const [name, index] of PRIMITIVE_FUNCTIONS) {
+      if (!names.has(index)) names.set(index, name);
+    }
+    primitiveNames = names;
   }
   return primitiveNames.get(primitiveIndex);
 }

--- a/src/tests/pvml.test.ts
+++ b/src/tests/pvml.test.ts
@@ -549,6 +549,12 @@ describe("PVML E2E", () => {
       ["def f():\n    pass\nstr(f)", "<function f>", null],
       ["f = lambda x: x\nstr(f)", "<function (anonymous)>", null],
       ["str(abs)", "<built-in function abs>", null],
+      // print/display and len/list_length share a single primitive index
+      // (builtins.ts) -- py-slang#278: this used to render as "display"
+      // (whichever alias cse-interop.ts's reverse-lookup happened to build
+      // last), even though the user never referenced display at all.
+      ["str(print)", "<built-in function print>", null],
+      ["str(len)", "<built-in function len>", null],
     ],
   };
 


### PR DESCRIPTION
## Summary
Closes #278.

`cse-interop.ts`'s `primitiveNameOf` builds an index→name reverse map from `PRIMITIVE_FUNCTIONS` (`builtins.ts`) to render a bare primitive reference (e.g. `str(print)`). Two indices have more than one registered name — `print`/`display` both → 5, `len`/`list_length` both → 2 — and the reverse map was built via `new Map(array-of-pairs)`, which keeps the *last* entry for a repeated key. Since the alias is always listed after its canonical name in `PRIMITIVE_FUNCTIONS` (each commented as such — "Alias for print", "Same concept as len() for list.ts"), the alias silently won the reverse lookup for both shared indices, even though the user only ever referenced the canonical name.

The existing code comment even documented the (wrong) assumption directly: *"any one of them is a fine display name, so ties just take last-write-wins"* — not true here, since a user who wrote `print(print)` reasonably expects to see `print`, not a name they never referenced.

## Fix
Keep whichever name claims a primitive index first, rather than relying on `Map` construction's default overwrite-on-duplicate-key behavior.

## Why this has no downside
Checked directly: the alias names (`display`, `list_length`) aren't resolvable as bare name references at all, on either engine — `print(display)` raises `NameNotFoundError` on both CSE and PVML (they're call-only builtins, not first-class values under those names). So there's no valid program where this change turns a previously-correct display string into a wrong one — it only fixes the previously-wrong case.

## Test plan
- [x] Added regression cases to `pvml.test.ts`'s `strReprTests`: `str(print)` → `<built-in function print>`, `str(len)` → `<built-in function len>`
- [x] Full suite: 60 suites, 19,230 tests, 0 regressions
- [x] `tsc --noEmit`, `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrwJGug3rCXijRseRjys9V