### PR TITLE
Remove unused PythonLexerState interface

### DIFF
--- a/src/parser/lexer.ts
+++ b/src/parser/lexer.ts
@@ -257,10 +257,6 @@ function processTokens(raw: moo.Token[]): moo.Token[] {
 
 // ── PythonLexer (Nearley-compatible wrapper) ───────────────────────────────
 
-interface PythonLexerState extends moo.LexerState {
-  pos: number;
-}
-
 export class PythonLexer implements moo.Lexer {
   tokens: moo.Token[] = [];
   pos = 0;


### PR DESCRIPTION
## Summary
Closes #280 (build warning: `'PythonLexerState' is defined but never used  @typescript-eslint/no-unused-vars`).

`PythonLexerState` (`src/parser/lexer.ts`) is never referenced anywhere in the codebase. `save()`'s actual implementation bypasses it entirely:
```ts
save(): moo.LexerState {
  return { pos: this.pos } as unknown as moo.LexerState;
}
```
Using `PythonLexerState` here wouldn't even remove the need for a cast — since it `extends moo.LexerState`, it requires `line`/`col`/`state` on top of `pos`, none of which `save()`/`reset()` actually track (this lexer's own save/reset protocol only ever reads/writes `pos`). So this isn't a near-miss worth wiring in properly; it's genuinely dead code describing a shape nothing in the file produces.

## Fix
Removed the interface. Zero behavior change — `save()`/`reset()`'s existing (already slightly hacky, but out of scope here) double-cast is untouched.

## Test plan
- [x] `tsc --noEmit`, `eslint` clean — lint warnings drop from 3 to 2 (the two remaining are unrelated pre-existing warnings)
- [x] `lexer.test.ts`, `nearley-parser.test.ts`: 198 passing
- [x] Full suite: 60 suites, 19,231 tests, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrwJGug3rCXijRseRjys9V