### PR TITLE
py2js: fix stdlib builtin errors surfacing as "[object Object]"

### DIFF
--- a/src/engines/py2js/stdlibBridge.ts
+++ b/src/engines/py2js/stdlibBridge.ts
@@ -43,6 +43,7 @@
  * machine does.
  */
 import { ExprNS } from "../../ast-types";
+import { RuntimeSourceError } from "../../errors";
 import { Token, TokenType } from "../../tokenizer";
 import { GroupName } from "../../stdlib/utils";
 import type { Group } from "../../stdlib/utils";
@@ -237,7 +238,29 @@ function bridgeBuiltin(
   // pyArity -1: argument-count validation is the builtin's own @Validate
   // wrapper, so arity errors carry the CSE machine's exact messages.
   const f = rt.def(name, -1, (...args: PyValue[]) => {
-    const result = call(args.map(toTagged), source, command, context);
+    let result: Value | undefined | Promise<Value | undefined>;
+    try {
+      result = call(args.map(toTagged), source, command, context);
+    } catch (e) {
+      // handleRuntimeError (src/engines/cse/error.ts) throws a
+      // RuntimeSourceError — a plain object implementing SourceError, not
+      // `extends Error` (see errors.ts) — so it fails `instanceof Error`
+      // everywhere up the call chain (including index.ts's own catch
+      // blocks), collapsing to the useless "[object Object]" (py-slang#295)
+      // instead of surfacing whatever real message .message holds. Convert
+      // it into a proper Py2JsRuntimeError here, at the boundary where the
+      // CSE-shaped error actually originates, the same way every other
+      // py2js-native error already carries its kind as `.name`.
+      // error.constructor.name is the exact class name (TypeError,
+      // IndexError, ZeroDivisionError, ...) for every RuntimeSourceError
+      // subclass — none of them set `.name` themselves (CSE's own
+      // displayError falls back to a generic "Error" name for the same
+      // reason), so the constructor is the only reliable source for it.
+      if (e instanceof RuntimeSourceError) {
+        throw new Py2JsRuntimeError(e.constructor.name, e.message);
+      }
+      throw e;
+    }
     if (result instanceof Promise) {
       throw new Py2JsRuntimeError(
         "RuntimeError",

--- a/src/tests/py2js-stdlib-error-bridge.test.ts
+++ b/src/tests/py2js-stdlib-error-bridge.test.ts
@@ -1,0 +1,33 @@
+/**
+ * py2js#295: a stdlib builtin bridged from the CSE machine (stdlibBridge.ts)
+ * that raises a runtime error must surface a real message, not
+ * "[object Object]". CSE's own runtime error classes (TypeError,
+ * IndexError, ...) implement SourceError rather than extending Error (see
+ * errors/errors.ts's RuntimeSourceError), so they fail every `instanceof
+ * Error` check up the call chain unless bridgeBuiltin converts them at the
+ * boundary where they actually originate.
+ */
+import { runCodePy2Js } from "../engines/py2js";
+
+test("tail() on a non-pair surfaces a real TypeError, not [object Object]", () => {
+  expect(() => runCodePy2Js("print(tail(5))", 2)).toThrow(
+    /TypeError.*unsupported argument type for tail/s,
+  );
+});
+
+test("head() on a non-pair surfaces a real TypeError, not [object Object]", () => {
+  expect(() => runCodePy2Js("print(head(5))", 2)).toThrow(
+    /TypeError.*unsupported argument type for head/s,
+  );
+});
+
+test("the thrown error's message is never the literal string [object Object]", () => {
+  let caught: unknown;
+  try {
+    runCodePy2Js("print(tail(5))", 2);
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeInstanceOf(Error);
+  expect((caught as Error).message).not.toBe("[object Object]");
+});


### PR DESCRIPTION
## Summary
Closes #295.

`bridgeBuiltin` (`stdlibBridge.ts`) calls straight into CSE's own stdlib implementations (`misc.ts`, `math.ts`, `linked-list.ts`, ...) at the value boundary. When one of those raises a runtime error — `handleRuntimeError` throws a `RuntimeSourceError` — it propagated uncaught all the way to `index.ts`'s catch blocks, whose `e instanceof Error ? ... : String(e)` fallback always hit the `String(e)` branch: `RuntimeSourceError` `implements SourceError`, not `extends Error` (`errors/errors.ts`), so it's a plain object with no custom `toString()`, and `String()` on that is unconditionally `"[object Object]"` regardless of whatever real content `.message` held.

```ts
runCodePy2Js("print(tail(5))", 2);
// before: Py2JsRunError: [object Object]
```

## Fix
Catch it at the boundary where the CSE-shaped error actually originates — `bridgeBuiltin` now wraps the CSE builtin call, and on catching a `RuntimeSourceError`, converts it into a proper `Py2JsRuntimeError`:
- `error.constructor.name` (`TypeError`, `IndexError`, `ZeroDivisionError`, ...) as the kind — none of these error classes ever set `.name` themselves (confirmed by grep across `errors/errors.ts`), so the constructor name is the only reliable source for it
- the original `.message` (CSE's own already-formatted diagnostic) as the message

Not attempting to also clean up that message's synthetic "at line 1" header in the same pass — `stdlibBridge.ts`'s own file header already documents py2js not having real error locations through this bridge yet as a separate, pre-existing, out-of-scope gap; parsing a "clean one-liner" out of ~17 differently-shaped multi-line message constructions in `errors.ts` risked being fragile for meaningfully lower value than just fixing the actual reported bug.

## Test plan
- [x] Added `src/tests/py2js-stdlib-error-bridge.test.ts`: `tail()`/`head()` on a non-pair now surface a real `TypeError` message; explicit check that the message is never the literal string `[object Object]`
- [x] Full py2js + `stdlib-conformance-py2js` suite: 13 suites, 2144 tests, 0 regressions
- [x] Full suite: 61 suites, 19,232 tests, 0 regressions
- [x] `tsc --noEmit`, `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrwJGug3rCXijRseRjys9V