### PR TITLE
parser: support backslash line continuation

### DIFF
--- a/src/parser/lexer.ts
+++ b/src/parser/lexer.ts
@@ -54,6 +54,7 @@ const mooLexer = moo.compile({
   newline: { match: /\r?\n/, lineBreaks: true },
   ws: /[ \t]+/,
   comment: /#[^\r\n]*/,
+  continuation: { match: /\\\r?\n/, lineBreaks: true },
 
   number_complex: /(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?[jJ]/,
   number_float: /(?:\d+\.\d*|\.\d+)(?:[eE][+-]?\d+)?|\d+[eE][+-]?\d+/,
@@ -141,6 +142,14 @@ function processTokens(raw: moo.Token[]): moo.Token[] {
 
     // Always skip whitespace and comments
     if (tok.type === "ws" || tok.type === "comment") {
+      i++;
+      continue;
+    }
+
+    // Explicit line continuation ("\" immediately followed by a newline):
+    // joins the two physical lines, so it's skipped like whitespace and
+    // never produces a newline/indent token.
+    if (tok.type === "continuation") {
       i++;
       continue;
     }

--- a/src/tests/lexer.test.ts
+++ b/src/tests/lexer.test.ts
@@ -118,3 +118,40 @@ describe("Lexer valid indentation", () => {
     expect(types.filter(t => t === "dedent").length).toBe(2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Explicit line continuation (backslash-newline)
+// ---------------------------------------------------------------------------
+describe("Lexer explicit line continuation", () => {
+  test("backslash-newline joins two physical lines into one logical line", () => {
+    const src = "total = 1 + 2 + 3 + \\\n        4 + 5\n";
+    const types = tokenTypes(src);
+    // Only one logical-line newline should be emitted (the trailing one),
+    // and no indent/dedent tokens from the continuation's leading whitespace.
+    expect(types.filter(t => t === "newline")).toHaveLength(1);
+    expect(types).not.toContain("indent");
+    expect(types).not.toContain("dedent");
+  });
+
+  test("continuation inside an indented block", () => {
+    const src = "def f():\n    x = 1 + \\\n        2\n    return x\n";
+    expect(() => tokenize(src)).not.toThrow();
+    const types = tokenTypes(src);
+    expect(types.filter(t => t === "indent").length).toBe(1);
+    expect(types.filter(t => t === "dedent").length).toBe(1);
+  });
+
+  test("CRLF line ending after backslash", () => {
+    const src = "total = 1 + \\\r\n2\r\n";
+    expect(() => tokenize(src)).not.toThrow();
+  });
+
+  test("multiple consecutive continuations", () => {
+    const src = "x = 1 + \\\n    2 + \\\n    3\n";
+    expect(() => tokenize(src)).not.toThrow();
+  });
+
+  test("backslash not immediately followed by newline still throws", () => {
+    expect(() => tokenize("x = 1 \\ + 2\n")).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- The moo lexer had no token rule for `\`, so an explicit line-continuation (`\` immediately followed by a newline) caused moo itself to throw `invalid syntax` before the parser ever ran.
- Added a `continuation` token matching `\\\r?\n`, skipped like whitespace/comments in `processTokens` — no NEWLINE/INDENT/DEDENT is emitted for it, so the two physical lines merge into one logical line per Python semantics.

Fixes #329

## Test plan
- [x] Added `Lexer explicit line continuation` test group in `src/tests/lexer.test.ts`: the issue's exact repro, continuation inside an indented block, CRLF line endings, multiple consecutive continuations, and confirming a bare mid-line backslash still errors.
- [x] Full test suite passes (19,239 tests).

https://claude.ai/code/session_01KrwJGug3rCXijRseRjys9V