### PR TITLE
Fix Pynter evaluator hanging forever in the browser

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -21,7 +21,24 @@ function plugins() {
     }),
     commonjs({ include: ["node_modules/**"] }),
     json(),
-    wasm({ maxFileSize: 100 * 1024 }),
+    // pynterwasm.wasm crossed 100KB a while back (it's now ~103KB), which
+    // pushed it over this threshold: above maxFileSize, @rollup/plugin-wasm
+    // stops inlining the module as a base64 string and instead emits it as a
+    // separate physical asset, fetched at runtime via a bare relative
+    // filename (see its browserFilePath template — plain `fetch(filepath)`,
+    // no base URL). That relative fetch resolves fine from a normal
+    // <script src> or same-origin Worker, but the frontend's conductor
+    // runner loads each evaluator bundle into a Worker constructed from a
+    // `blob:` object URL — and a relative URL cannot be resolved against a
+    // blob: base at all (`fetch("x.wasm")` there throws synchronously:
+    // "Failed to parse URL from x.wasm"). Emscripten's generated
+    // createWasm() invokes instantiateWasm inside its own try/catch, which
+    // swallows that throw instead of rejecting anything, so neither the
+    // module's ready-promise nor pynter-wasm.ts's own instantiate-failure
+    // race (added for a different, asynchronous failure mode) ever settles
+    // — initPynter() hangs forever. Comfortably over pynterwasm.wasm's
+    // current size keeps it inlined and avoids the runtime fetch entirely.
+    wasm({ maxFileSize: 512 * 1024 }),
     typescript(),
     nodeResolve(),
     nodePolyfills(),


### PR DESCRIPTION
## Summary
- `pynterwasm.wasm` recently crossed the 100KB `maxFileSize` threshold in `@rollup/plugin-wasm`'s config, so it stopped being inlined as base64 and started being fetched at runtime via a bare relative filename.
- That relative fetch works fine from a normal `<script src>`, but the conductor runner loads each evaluator bundle into a `Worker` constructed from a `blob:` object URL (confirmed live on sourceacademy.org by instrumenting `window.Worker`) — and a relative URL cannot be resolved against a `blob:` base at all. `fetch("x.wasm")` there throws **synchronously** (`TypeError: Failed to parse URL from x.wasm`), reproduced directly in a blob-based worker.
- Emscripten's generated `createWasm()` invokes `instantiateWasm` inside its own try/catch, which swallows that throw instead of propagating or rejecting anything. Neither the module's ready-promise nor `pynter-wasm.ts`'s own instantiate-failure race (added in #334 for a different, asynchronous failure mode) ever settles, so `initPynter()` — and the whole `evaluateChunk()` call — hangs forever with no error surfacing anywhere.
- Pyodide is unaffected because it loads its own assets from an absolute CDN URL (`cdn.jsdelivr.net`), never relying on the worker's own `blob:` location for relative resolution.
- Fix: raise `maxFileSize` in `rollup.config.mjs` so `pynterwasm.wasm` (~103KB) stays inlined as base64, eliminating the runtime fetch entirely.

## Test plan
- [x] Rebuilt the `PyPvmlPynterEvaluator` bundle locally and confirmed the emitted `dist/` no longer contains a separate `.wasm` asset, and the bundle uses the `atob` base64-decode path instead of the `fetch(...)` path.
- [x] `PyPvmlPynterEvaluator.test.ts` still passes.
- [x] Reproduced the exact hang mechanism live on sourceacademy.org (Pynter evaluator, Python §3) by instrumenting `window.Worker` to confirm the runner spawns a `blob:` URL worker, then reproduced the same `TypeError: Failed to parse URL` synchronously in an isolated blob-worker `fetch()` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrwJGug3rCXijRseRjys9V