### PR TITLE
CSE machine: label loop-increment assigns and tag expression statements

### DIFF
--- a/src/conductor/plugins/PyCseMachinePlugin.ts
+++ b/src/conductor/plugins/PyCseMachinePlugin.ts
@@ -330,7 +330,16 @@ function serializeControlItem(item: ControlStackItem, code: string): SerializedI
       nodeMeta.bodyNodeTypes = bodyArray.map(n => PY_TO_JS_NODE_TYPE[n.kind] ?? "Identifier");
     }
 
-    return Object.keys(nodeMeta).length > 0 ? { displayText, metadata: nodeMeta } : { displayText };
+    // Expression statements ("1 + 2" as a bare statement) are indistinguishable from a
+    // plain sub-expression once pushed — the machine only reveals it was a statement
+    // later, when the "pop" instruction that discards its value appears (issue #270).
+    // Tag it so the visualizer can mark it distinctly (e.g. a different color) up front.
+    const tag = item.kind === "SimpleExpr" ? "expressionStatement" : undefined;
+
+    const result: SerializedInstruction = { displayText };
+    if (Object.keys(nodeMeta).length > 0) result.metadata = nodeMeta;
+    if (tag) result.tag = tag;
+    return result;
   }
 
   return { displayText: "<unknown>" };

--- a/src/engines/cse/utils.ts
+++ b/src/engines/cse/utils.ts
@@ -898,5 +898,10 @@ export function generateForIncrement(
   const literalToken = new Token(TokenType.BIGINT, value.toString(), line, 0, -1);
   literalToken.synthetic = true;
   const literal = new ExprNS.BigIntLiteral(literalToken, literalToken, value.toString());
-  return new StmtNS.Assign(token, literalToken, variable, literal);
+  const assign = new StmtNS.Assign(token, literalToken, variable, literal);
+  // Synthetic node — startToken/endToken don't span real source, so
+  // serializeControlItem would otherwise fall back to the generic "assign"
+  // KIND_LABEL, hiding which variable is being set to what (issue #293).
+  Object.assign(assign, { syntheticLabel: `${variableName} = ${value}` });
+  return assign;
 }

--- a/src/tests/PyCseMachinePlugin.test.ts
+++ b/src/tests/PyCseMachinePlugin.test.ts
@@ -348,6 +348,24 @@ describe("serializeControlItem", () => {
     expect(result.displayText).toBe("my-while");
   });
 
+  // Regression test for https://github.com/source-academy/py-slang/issues/270.
+  it("SimpleExpr node is tagged as an expression statement", () => {
+    const result = serializeControlItem(
+      {
+        kind: "SimpleExpr",
+        startToken: { indexInSource: 0, line: 1 },
+        endToken: { indexInSource: 5, line: 1, lexeme: "" },
+      },
+      "1 + 2",
+    );
+    expect(result.tag).toBe("expressionStatement");
+  });
+
+  it("non-SimpleExpr node has no tag", () => {
+    const result = serializeControlItem({ kind: "While" }, code);
+    expect(result.tag).toBeUndefined();
+  });
+
   it("synthetic BigIntLiteral shows its value", () => {
     const result = serializeControlItem({ kind: "BigIntLiteral", value: 99n }, code);
     expect(result.displayText).toBe("99");
@@ -624,6 +642,14 @@ describe("collectSnapshots", () => {
     // whichever line last had a "real" (non-synthetic) node.
     expect(transitions.filter(l => l === 1).length).toBeGreaterThan(1);
     expect(transitions.filter(l => l === 2).length).toBeGreaterThan(1);
+  });
+
+  // Regression test for https://github.com/source-academy/py-slang/issues/293.
+  it("for-loop increment control item shows 'x = <value>', not the generic 'assign'", async () => {
+    const snapshots = await runAndCollect(`for x in range(3):\n    print(x)`);
+    const controlTexts = snapshots.flatMap(s => s.control.map(c => c.displayText));
+    expect(controlTexts).toContain("x = 0");
+    expect(controlTexts).not.toContain("assign");
   });
 
   it("frame transition on return happens at the ENVIRONMENT instruction", async () => {


### PR DESCRIPTION
## Summary
- \`generateForIncrement\`'s synthetic per-iteration Assign node (the loop variable update) had synthetic tokens, so \`serializeControlItem\` fell back to the generic \`"assign"\` KIND_LABEL instead of showing which variable was set to what. It now carries a \`syntheticLabel\` of \`"x = <value>"\` (fixes #293).
- Tagged \`SimpleExpr\` control items with \`tag: "expressionStatement"\` so the visualizer can render them distinctly. Currently an expression statement like \`1 + 2\` is indistinguishable from a plain sub-expression until a "pop" mysteriously appears on a later step to discard its value (fixes #270). The frontend consumes this tag to render the coloring — see source-academy/frontend#4159.

<img width="1087" height="706" alt="image" src="https://github.com/user-attachments/assets/3c77a631-ad40-4f6b-8891-1b32770f05f2" />

## Test plan
- [x] \`jest src/tests/PyCseMachinePlugin.test.ts\` — added unit tests for the tag and an end-to-end regression test asserting a \`for\` loop's control stack shows \`"x = 0"\` instead of \`"assign"\`; all 91 tests pass.
- [x] Manually verify in the Python playground: stepping through a \`for\` loop shows \`x = <value>\` instead of \`assign\`, and an expression statement's control item is visually distinct (color change lands via the frontend PR above).