### PR TITLE
py2js input support

### DIFF
--- a/src/conductor/Py2JsEvaluator.ts
+++ b/src/conductor/Py2JsEvaluator.ts
@@ -29,7 +29,11 @@ import { EvaluatorError } from "./errors";
  *
  * Exec-style, like the PVML-in-browser evaluator: every chunk reports no
  * result value; a chunk that wants to surface a value print()s it. Output
- * streams per print() line through the session's onOutput hook.
+ * streams per print() line through the session's onOutput hook. input()
+ * round-trips through the session's requestInput hook (conductor.requestInput)
+ * — a chunk that calls it, at any nesting depth, compiles in dual mode even
+ * with no imports of its own (see Py2JsSession.runChunk's use of
+ * Resolver.referencedNames).
  *
  * Chapters 1-4 (the engine rejects other variants).
  */
@@ -46,6 +50,7 @@ abstract class Py2JsEvaluatorBase extends BasicEvaluator {
     );
     this.session = new Py2JsSession(variant, {
       onOutput: line => this.conductor.sendOutput(line),
+      requestInput: prompt => this.conductor.requestInput(prompt),
       dataHandler,
     });
   }

--- a/src/engines/py2js/README.md
+++ b/src/engines/py2js/README.md
@@ -134,9 +134,13 @@ to `PY2JS_GROUPS[4]`.
 A few builtins are **native** (bypass the generic bridge) because the
 bridge's tagged round-trip is structurally the wrong shape for them:
 
-- `print`/`input`/`arity` — chapter-1 native core. `print`/`input` are
-  stream-based (async) in the CSE machine but plain synchronous code here;
-  `arity` is native because py2js functions aren't CSE closures.
+- `print`/`input`/`arity` — chapter-1 native core. `print` is stream-based
+  (async) in the CSE machine but plain synchronous code here; `input` is
+  dual-bodied (`def2`) and `asyncOnly`, exactly like an imported module
+  function, round-tripping through the conductor evaluator's `requestInput`
+  hook — a REPL chunk that calls it, at any nesting depth, compiles in dual
+  mode even with no imports of its own (`Resolver.referencedNames`); `arity`
+  is native because py2js functions aren't CSE closures.
 - `set_head`/`set_tail` (chapter 3) — the generic bridge converts an
   argument into a _fresh_ CSE-side value, so a mutation the CSE builtin
   performs on it would be silently lost rather than visible on the
@@ -310,7 +314,9 @@ boundary (matching the CSE converter's identical restrictions).
   `RuntimeSourceError` doesn't extend JS `Error`, so it fails the
   `instanceof Error` check in `index.ts`'s catch blocks. Pre-existing since
   chapter 2, not py2js-chapter-specific.
-- `input()` is not implemented.
+- `input()` round-trips through the conductor evaluator's `requestInput` hook
+  (`Py2JsEvaluator.ts`); `runCodePy2Js`/`runCodePy2JsDual` (no conductor) have
+  no such hook wired, so `input()` there raises `RuntimeError`.
 - `DataType.ARRAY` and complex numbers do not cross the module boundary in
   either direction (see Module interop above).
 - No chapter 5 — SICPy has four chapters.

--- a/src/engines/py2js/index.ts
+++ b/src/engines/py2js/index.ts
@@ -261,6 +261,14 @@ export interface Py2JsSessionOptions extends RunPy2JsOptions {
    */
   dataHandler?: IDataHandler;
   /**
+   * Resolves one input() call with what the user typed — forwarded to
+   * Py2JsRuntime.requestInput (see runtime.ts's doc comment on the field).
+   * The conductor evaluator (Py2JsEvaluator.ts) supplies
+   * `prompt => this.conductor.requestInput(prompt)`; left unset for
+   * standalone/test use, in which case input() raises RuntimeError.
+   */
+  requestInput?: (prompt?: string) => Promise<string>;
+  /**
    * `__program__`'s value for this session — "the string representation of
    * the editor content at the time when 'Run' was last pressed" per
    * docs/specs/python_interpreter.tex, for the REPL case. Mirrors
@@ -312,6 +320,7 @@ export class Py2JsSession {
     this.dataHandler = options.dataHandler ?? new GenericDataHandler();
     this.rt = new Py2JsRuntime(variant >= 3);
     this.rt.onOutput = options.onOutput;
+    this.rt.requestInput = options.requestInput;
     if (options.programText !== undefined) {
       this.rt.builtins.__program__ = options.programText;
     }
@@ -362,9 +371,19 @@ export class Py2JsSession {
     const errors = resolver.resolve(ast);
     if (errors.length > 0) throw errors[0];
 
-    if (hasImports(ast.statements)) {
+    const imports = hasImports(ast.statements);
+    if (imports) {
       const bindings = await loadChunkImports(this.rt, this.dataHandler, ast.statements);
       this.rt.setPendingImports(bindings);
+    }
+
+    // input() is asyncOnly, exactly like an imported module function
+    // (runtime.ts's doc comment on the native builtin core) — a chunk that
+    // calls it anywhere, at any nesting depth, must compile on the async
+    // spine even with no imports of its own. referencedNames already saw
+    // every such reference during the resolve() call above (including
+    // inside nested function bodies), so this needs no second AST walk.
+    if (imports || resolver.referencedNames.has("input")) {
       const js = compileProgram(ast, Object.keys(this.rt.builtins), {
         mode: "dual",
         repl: { priorGlobals },

--- a/src/engines/py2js/runtime.ts
+++ b/src/engines/py2js/runtime.ts
@@ -490,6 +490,16 @@ export class Py2JsRuntime {
   onOutput?: (line: string) => void;
 
   /**
+   * Requests one line of input, resolving with what the user typed —
+   * the conductor evaluator wires this to conductor.requestInput, the same
+   * contract the CSE machine's createInputStream/receiveInput use (see
+   * src/engines/cse/streams.ts). Absent when running standalone
+   * (runCodePy2Js/runCodePy2JsDual with no conductor), in which case
+   * input() raises RuntimeError instead of hanging forever.
+   */
+  requestInput?: (prompt?: string) => Promise<string>;
+
+  /**
    * Persistent module-level bindings for REPL-mode chunks (see compiler.ts's
    * REPL-mode doc): every top-level binding of every chunk lives here, so a
    * later chunk — and functions from earlier chunks, via gref's late lookup —
@@ -962,12 +972,20 @@ export class Py2JsRuntime {
   /**
    * The native builtin core: the few builtins that cannot go through the
    * stdlib bridge (see stdlibBridge.ts, which supplies everything else from
-   * the real src/stdlib groups). print and input are async/stream-based in
-   * the stdlib; arity inspects CSE closures, which py2js functions are not;
-   * set_timeout/clear_all_timeout (source-academy/py-slang#311) need a live
-   * reference to this runtime to call back into Python later — see the doc
-   * comment on set_timeout below for why py2js, uniquely among the engines,
-   * needs no special re-entry support to do this.
+   * the real src/stdlib groups). print is fire-and-forget sync; input needs
+   * the async spine (like an imported module function — see moduleInterop.ts)
+   * to await a real frontend round-trip, so it is dual-bodied (def2) and
+   * marked asyncOnly, exactly like an asyncOnly module closure: the sync body
+   * only exists as a defensive backstop (checkCallable's asyncOnly guard
+   * already rejects a sync call before it would run), the real logic lives in
+   * asyncBody. index.ts's Py2JsSession forces dual-mode compilation for any
+   * REPL chunk that references `input` (Resolver.referencedNames), the same
+   * way it already does for a chunk with an import. arity inspects CSE
+   * closures, which py2js functions are not; set_timeout/clear_all_timeout
+   * (source-academy/py-slang#311) need a live reference to this runtime to
+   * call back into Python later — see the doc comment on set_timeout below
+   * for why py2js, uniquely among the engines, needs no special re-entry
+   * support to do this.
    */
   readonly builtins: Record<string, PyValue> = {
     print: this.builtin("print", -1, (...args) => {
@@ -978,12 +996,47 @@ export class Py2JsRuntime {
       this.onOutput?.(line);
       return null;
     }),
-    input: this.builtin("input", -1, () => {
-      throw new Py2JsRuntimeError(
-        "RuntimeError",
-        "input() is not supported by the py2js engine yet",
+    input: (() => {
+      const f = this.def2(
+        "input",
+        -1,
+        () => {
+          throw new Py2JsRuntimeError(
+            "TypeError",
+            "input() needs a frontend round-trip and cannot be called from a synchronous module callback",
+          );
+        },
+        async (...args: PyValue[]) => {
+          // Same 0-or-1-argument gate as the stdlib's @Validate(0, 1, "input",
+          // true) (src/stdlib/misc.ts) — reproduced by hand rather than
+          // bridged, since bridgeBuiltin's generic path rejects any builtin
+          // that returns a Promise (stdlibBridge.ts).
+          if (args.length > 1) {
+            throw new Py2JsRuntimeError(
+              "TypeError",
+              `input() takes at most 1 argument (${args.length} given)`,
+            );
+          }
+          // Matches CPython: input(prompt) writes the prompt to stdout (no
+          // trailing newline) before blocking on stdin.
+          const prompt = args.length > 0 ? pyStr(args[0]) : undefined;
+          if (prompt !== undefined) {
+            this.output.push(prompt);
+            this.onOutput?.(prompt);
+          }
+          if (!this.requestInput) {
+            throw new Py2JsRuntimeError(
+              "RuntimeError",
+              "input() is not supported in this context (no input source configured)",
+            );
+          }
+          return this.requestInput(prompt);
+        },
       );
-    }),
+      f.pyBuiltin = true;
+      f.asyncOnly = true;
+      return f;
+    })(),
     // Native rather than bridged: CSE's print_llist (stdlib/linked-list.ts)
     // is async (writes to the output stream directly), like print/input.
     print_llist: this.builtin("print_llist", 1, v => {

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -235,6 +235,17 @@ export class Resolver implements StmtNS.Visitor<void>, ExprNS.Visitor<void> {
   functionScope: Environment | null;
   errors: Error[];
   functionEnvironments: FunctionEnvironments;
+  /**
+   * Every identifier referenced as a Variable expression anywhere in the
+   * resolved AST — at any nesting depth, since visitVariableExpr fires from
+   * inside nested function/lambda bodies too (visitFunctionDefStmt/
+   * visitLambdaExpr both recurse via `this.resolve(body)`). py2js's index.ts
+   * uses this to decide whether a REPL chunk must compile on the async spine
+   * (see compiler.ts's dual-mode doc) because it calls `input()` somewhere —
+   * reusing this pass instead of a second AST walk, since the resolver
+   * already visits every such reference while checking declarations.
+   */
+  readonly referencedNames: Set<string> = new Set();
   private validators: FeatureValidator[];
   // Names declared `global` in the current function body (reset on function entry/exit).
   private globalNamesInCurrentFunction: Set<string> = new Set();
@@ -906,6 +917,7 @@ export class Resolver implements StmtNS.Visitor<void>, ExprNS.Visitor<void> {
 
   //// EXPRESSIONS
   visitVariableExpr(expr: ExprNS.Variable): void {
+    this.referencedNames.add(expr.name.lexeme);
     try {
       this.environment?.lookupNameCurrentEnvWithError(expr.name);
     } catch (e) {

--- a/src/tests/py2js-input.test.ts
+++ b/src/tests/py2js-input.test.ts
@@ -1,0 +1,102 @@
+/**
+ * py2js's input() (source-academy/py-slang#338): dual-bodied (def2) and
+ * asyncOnly, exactly like an imported module function — round-trips through
+ * the conductor evaluator's requestInput hook (Py2JsEvaluator.ts ->
+ * Py2JsSession -> Py2JsRuntime.requestInput, mirroring the CSE machine's
+ * createInputStream/receiveInput contract in src/engines/cse/streams.ts).
+ *
+ * A chunk that calls input() forces dual-mode compilation even with no
+ * imports of its own — Py2JsSession.runChunk detects this via
+ * Resolver.referencedNames (populated by every Variable reference the
+ * resolver visits, at any nesting depth) rather than a second AST walk.
+ */
+import type { IRunnerPlugin } from "@sourceacademy/conductor/runner";
+import { Py2JsEvaluator1 } from "../conductor/Py2JsEvaluator";
+import { Py2JsSession } from "../engines/py2js";
+
+function makeMockConductor(responses: string[]) {
+  const errors: { name: string; message: string }[] = [];
+  const outputs: string[] = [];
+  const prompts: (string | undefined)[] = [];
+  let call = 0;
+  const conductor = {
+    sendResult: () => undefined,
+    sendError: (e: unknown) => errors.push(e as { name: string; message: string }),
+    sendOutput: (m: string) => outputs.push(m),
+    registerPlugin: () => undefined,
+    requestInput: (prompt?: string) => {
+      prompts.push(prompt);
+      return Promise.resolve(responses[call++]);
+    },
+  } as unknown as IRunnerPlugin;
+  return { conductor, errors, outputs, prompts };
+}
+
+describe("Py2JsEvaluator: input()", () => {
+  test("with a prompt: sends the prompt via sendOutput and binds the typed value", async () => {
+    const { conductor, errors, outputs, prompts } = makeMockConductor(["world"]);
+    const evaluator = new Py2JsEvaluator1(conductor);
+
+    await evaluator.evaluateChunk('name = input("Name: ")\nprint(name)\n');
+
+    expect(errors).toEqual([]);
+    expect(prompts).toEqual(["Name: "]);
+    expect(outputs).toEqual(["Name: ", "world"]);
+  });
+
+  test("with no prompt: requests input with an undefined prompt", async () => {
+    const { conductor, errors, outputs, prompts } = makeMockConductor(["42"]);
+    const evaluator = new Py2JsEvaluator1(conductor);
+
+    await evaluator.evaluateChunk("print(input())\n");
+
+    expect(errors).toEqual([]);
+    expect(prompts).toEqual([undefined]);
+    expect(outputs).toEqual(["42"]);
+  });
+
+  test("too many arguments is a TypeError, matching the stdlib's @Validate(0, 1, ...) gate", async () => {
+    const { conductor, errors, outputs } = makeMockConductor([]);
+    const evaluator = new Py2JsEvaluator1(conductor);
+
+    await evaluator.evaluateChunk('input("a", "b")\n');
+
+    expect(outputs).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].name).toBe("TypeError");
+    expect(errors[0].message).toContain("input() takes at most 1 argument (2 given)");
+  });
+
+  test("a call to input() nested inside a user function still compiles in dual mode (no import in the chunk)", async () => {
+    const { conductor, errors, outputs, prompts } = makeMockConductor(["world"]);
+    const evaluator = new Py2JsEvaluator1(conductor);
+
+    await evaluator.evaluateChunk(
+      "def ask():\n    return input('N: ')\nprint(ask() + '!')\n",
+    );
+
+    expect(errors).toEqual([]);
+    expect(prompts).toEqual(["N: "]);
+    expect(outputs).toEqual(["N: ", "world!"]);
+  });
+
+  test("later chunks in the same session still see earlier bindings after a dual-mode input() chunk", async () => {
+    const { conductor, errors, outputs } = makeMockConductor(["hi"]);
+    const evaluator = new Py2JsEvaluator1(conductor);
+
+    await evaluator.evaluateChunk("x = input()\n");
+    await evaluator.evaluateChunk("print(x + '!')\n");
+
+    expect(errors).toEqual([]);
+    expect(outputs).toEqual(["hi!"]);
+  });
+});
+
+describe("Py2JsSession: input() without a requestInput hook", () => {
+  test("raises RuntimeError instead of hanging (standalone/test use with no conductor)", async () => {
+    const session = new Py2JsSession(1);
+    await expect(session.runChunk("print(input())\n")).rejects.toMatchObject({
+      name: "RuntimeError",
+    });
+  });
+});

--- a/src/tests/py2js-input.test.ts
+++ b/src/tests/py2js-input.test.ts
@@ -71,9 +71,7 @@ describe("Py2JsEvaluator: input()", () => {
     const { conductor, errors, outputs, prompts } = makeMockConductor(["world"]);
     const evaluator = new Py2JsEvaluator1(conductor);
 
-    await evaluator.evaluateChunk(
-      "def ask():\n    return input('N: ')\nprint(ask() + '!')\n",
-    );
+    await evaluator.evaluateChunk("def ask():\n    return input('N: ')\nprint(ask() + '!')\n");
 
     expect(errors).toEqual([]);
     expect(prompts).toEqual(["N: "]);

--- a/src/tests/stdlib-conformance-py2js.test.ts
+++ b/src/tests/stdlib-conformance-py2js.test.ts
@@ -19,8 +19,11 @@
  * outcomes compare that both engines raised.
  *
  * Exclusions:
- *  - input: stream-based; py2js deliberately raises "not supported yet"
- *    while the CSE runner blocks on (closed) stdin — no comparable outcome.
+ *  - input: needs a real requestInput round-trip (see runtime.ts/
+ *    Py2JsEvaluator.ts), which only the conductor evaluator wires up —
+ *    runCodePy2Js here has none, so it raises RuntimeError, while the CSE
+ *    reference (via runCode, also conductor-less) blocks on (closed) stdin
+ *    and returns "" — no comparable outcome either way.
  *  - set_timeout / clear_all_timeout: implemented only by py2js so far
  *    (source-academy/py-slang#311) — the CSE reference always raises "not
  *    yet supported by the CSE machine" (src/stdlib/misc.ts), a permanent,
@@ -47,7 +50,7 @@ const LITERALS = ["2", "2.5", "(1+2j)", "True", "'ab'", "None", "(lambda x: x)"]
 /** Chapter 2 adds "list" — always a pair, per operator-spec.ts's literalFor. */
 const CH2_LITERALS = [...LITERALS, "pair(1, 2)"];
 
-// input: see below. set_timeout/clear_all_timeout: implemented only by
+// input: see above. set_timeout/clear_all_timeout: implemented only by
 // py2js so far (source-academy/py-slang#311) — the CSE reference always
 // throws "not yet supported", a permanent, expected mismatch, not a bridge
 // bug to catch.


### PR DESCRIPTION
support for input():  resolver checks for input() and switches to async mode if found