### PR TITLE
Fix Pynter worker crashing on missing node_module/document globals

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -13,6 +13,48 @@ if (!EVALUATOR) {
   throw new Error("EVALUATOR env var must be set. Use scripts/build.ts.");
 }
 
+// @sourceacademy/pynter-wasm's published pynterwasm.js uses
+// `require("module").createRequire(import.meta.url)` at module-load time to
+// build a `require` it only actually *invokes* inside an `ENVIRONMENT_IS_NODE`
+// guard (to lazily require("node:fs") when running under Node) — but building
+// that require isn't guarded, so it, and Rollup's own `import.meta.url`
+// polyfill for it, both run unconditionally in every environment:
+//  1. Rollup can't bundle the Node builtin "module" for a browser target, so
+//     it externalizes it; for the IIFE output that means referencing a bare
+//     global (`node_module`, Rollup's own sanitized guess — see the "Missing
+//     global variable name" build warning) that nothing ever defines, so
+//     evaluating `node_module.createRequire(...)` throws `ReferenceError:
+//     node_module is not defined`.
+//  2. Rollup's IIFE-format polyfill for `import.meta.url` (its
+//     `_documentCurrentScript` helper) falls back to reading
+//     `document.baseURI` — fine on the browser main thread, but a Worker has
+//     no `document` at all, so that throws `ReferenceError: document is not
+//     defined` too.
+// Either one happens the moment the worker script runs, before the
+// conductor's message channels are even wired up, so the failure never
+// reaches evaluateChunk()'s try/catch or surfaces anywhere: the whole worker
+// just dies, and Pynter hangs forever with no output and no error (confirmed
+// live: source-academy.github.io/py-slang's deployed PyPvmlPynterEvaluator.js
+// throws this in every browser Worker, even after #339's separate
+// wasm-loading fix). The "iife" output is the only one affected — the "cjs"
+// output really does run in Node, where both `document` and
+// `require("node:module")` are moot/available respectively.
+//
+// Define both missing globals: a `createRequire` that's safe to *construct*
+// but throws if ever actually *called* (which it isn't, in the browser), and
+// a `document` stand-in that gets read via
+// `(document.currentScript?.tagName === 'SCRIPT' && document.currentScript.src) || new URL(file, document.baseURI).href`
+// — the same blob:-URL-as-relative-base problem #339 hit already rules out a
+// real `baseURI` (a Worker's own blob: URL can't be used as a base for
+// relative resolution — `new URL('x', 'blob:...')` itself throws
+// "Invalid URL"). So instead make `currentScript` look like a real <script>
+// pointing at the worker's own URL, which short-circuits the `&&` chain
+// before that unusable `new URL(...)` fallback is ever reached.
+const NODE_MODULE_BROWSER_SHIM_BANNER = [
+  'var node_module = { createRequire: function () { return function unavailableRequire() { throw new Error("require() is not available in the browser"); }; } };',
+  'if (typeof document === "undefined") { var document = { baseURI: "", currentScript: { tagName: "SCRIPT", src: (typeof location !== "undefined" ? location.href : "") } }; }',
+].join("\n");
+
 function plugins() {
   return [
     replace({
@@ -65,6 +107,7 @@ const config = [
       // pyodide's own loader uses a dynamic import() for a Node-only path;
       // a single-file iife bundle can't code-split it out, so inline it.
       inlineDynamicImports: true,
+      banner: NODE_MODULE_BROWSER_SHIM_BANNER,
     },
     plugins: plugins(),
   },


### PR DESCRIPTION
## Summary

#339 fixed one cause of Pynter hanging forever in the browser (the wasm asset being fetched via a bare relative URL, which can't resolve against a `blob:` worker base). It's deployed and correct — but Pynter still hangs, because of a second, unrelated bug in the same build pipeline.

`@sourceacademy/pynter-wasm`'s generated glue calls `require("module").createRequire(import.meta.url)` unconditionally at module-load time — only the resulting `require`'s *call* is guarded behind an `ENVIRONMENT_IS_NODE` check, not its *construction*. In the browser IIFE build this throws immediately when the worker script starts:

1. Rollup can't bundle the Node builtin `module` for a browser target, so it externalizes it as a bare global (`node_module`, per the "Missing global variable name" build warning) that's never defined → `ReferenceError: node_module is not defined`.
2. Rollup's own `import.meta.url` polyfill for IIFE output falls back to reading `document.baseURI` — which doesn't exist in a Worker at all → `ReferenceError: document is not defined`.

Either one kills the whole worker **before the conductor's message channels are even wired up**, so the failure never reaches `evaluateChunk()`'s try/catch or surfaces anywhere in the UI. Pynter just hangs forever with no output and no error — confirmed live on sourceacademy.org even with #339's fix already deployed.

## Fix

Add a `banner` to the IIFE rollup output defining both missing globals:
- a `createRequire` stub that's safe to *construct* but throws if ever actually *called* (which it isn't, in the browser)
- a `document.currentScript` stand-in pointing at the worker's own URL — not `document.baseURI`, since a Worker's `blob:` URL can't be used as a relative-resolution base either (`new URL('x', 'blob:...')` itself throws `Invalid URL` — the same class of problem #339 hit)

The `cjs` output target is unaffected — that one really does run in Node, where `document` is moot and `require("node:module")` just works.

## Test plan

- [x] Reproduced live on sourceacademy.org: Python §3 → Pynter → `print(1 + 2)` hangs forever, even with #339 deployed.
- [x] Isolated repro: fetched the real deployed `PyPvmlPynterEvaluator.js`, spawned a `Worker` from a `blob:` URL with no other machinery — reproduced `ReferenceError: node_module is not defined` 100% of the time, zero messages ever sent.
- [x] After the fix, rebuilt the bundle and re-ran the same isolated repro — no crash, worker sets up its channels cleanly.
- [x] Full end-to-end verification using the real `@sourceacademy/conductor` host library driving the rebuilt bundle in an actual `blob:`-URL Worker: `startEvaluator` → `requestFile` → `print(1 + 2)` → `OUTPUT: 3` → clean result, no hang.
- [x] `PyPvmlPynterEvaluator.test.ts` and `native-pynter.test.ts` still pass.
- [x] Other evaluator targets (e.g. `PyCseEvaluator1`) still build cleanly with the added banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01KrwJGug3rCXijRseRjys9V