### PR TITLE
Fix Pynter WASM debug trailer leaking into the REPL; surface fault names properly

### DIFF
--- a/src/conductor/PyPvmlPynterEvaluator.ts
+++ b/src/conductor/PyPvmlPynterEvaluator.ts
@@ -9,6 +9,31 @@ import math from "../stdlib/math";
 import misc from "../stdlib/misc";
 import { EvaluatorError } from "./errors";
 
+// siwasm_run (Pynter's devices/wasm/wasm/lib.c) printf's one of these two
+// trailers to stdout on every run, as a debugging aid for the WASM demo,
+// which has no other way to surface the return value:
+//
+//   - success: "Program exited with result type <type>: <value>" — pure
+//     noise for us, since evaluateChunk already reads that value directly
+//     off siwasm_run's return pointer (readReturnValue in pynter-wasm.ts).
+//   - fault: "Program exited unsuccessfully: <fault name>" (e.g. "divide by
+//     zero", "program called error()") — the ONLY place the fault name
+//     appears. On a fault, wasm_result is left zeroed (type 0), so
+//     readReturnValue's switch falls into its `default` case and throws a
+//     generic "Unknown return type: 0" — the fault name would otherwise be
+//     lost entirely rather than merely mislabeled as program output.
+const RESULT_TRAILER_RE = /^Program exited with result type /;
+const FAULT_TRAILER_RE = /^Program exited unsuccessfully: (.+)$/;
+
+/** Fault name captured out of a matching FAULT_TRAILER_RE line, e.g. "divide by zero". */
+export function matchPynterWasmFaultTrailer(text: string): string | undefined {
+  return FAULT_TRAILER_RE.exec(text)?.[1];
+}
+
+export function isPynterWasmResultTrailer(text: string): boolean {
+  return RESULT_TRAILER_RE.test(text);
+}
+
 function pynterValueToNative(value: PynterValue): unknown {
   switch (value.type) {
     case "int":
@@ -38,6 +63,9 @@ function pynterValueToNative(value: PynterValue): unknown {
  */
 export class PyPvmlPynterEvaluator extends BasicEvaluator {
   private pynter: Awaited<ReturnType<typeof initPynter>> | null = null;
+  // Set by the print callback below when the current run's fault trailer
+  // goes by; read (and reset) by the catch block once runBinary rejects.
+  private lastFault: string | undefined;
 
   async evaluateChunk(chunk: string): Promise<void> {
     try {
@@ -54,13 +82,23 @@ export class PyPvmlPynterEvaluator extends BasicEvaluator {
 
       if (!this.pynter) {
         this.pynter = await initPynter({
-          print: (text: string) => this.conductor.sendOutput(text),
+          print: (text: string) => {
+            const fault = matchPynterWasmFaultTrailer(text);
+            if (fault !== undefined) {
+              this.lastFault = fault;
+              return;
+            }
+            if (isPynterWasmResultTrailer(text)) return;
+            this.conductor.sendOutput(text);
+          },
         });
       }
+      this.lastFault = undefined;
       const result = this.pynter.runBinary(binary);
       this.conductor.sendResult(pynterValueToNative(result));
     } catch (e) {
-      this.conductor.sendError(new EvaluatorError(e));
+      const error = this.lastFault !== undefined ? new Error(`Pynter fault: ${this.lastFault}`) : e;
+      this.conductor.sendError(new EvaluatorError(error));
     }
   }
 }

--- a/src/tests/PyPvmlPynterEvaluator.test.ts
+++ b/src/tests/PyPvmlPynterEvaluator.test.ts
@@ -96,13 +96,12 @@ describe("matchPynterWasmFaultTrailer", () => {
     expect(matchPynterWasmFaultTrailer(text)).toBe(expected);
   });
 
-  test.each([
-    "42",
-    "Program exited early",
-    "Program exited with result type undefined: undefined",
-  ])("does not match %j", text => {
-    expect(matchPynterWasmFaultTrailer(text)).toBeUndefined();
-  });
+  test.each(["42", "Program exited early", "Program exited with result type undefined: undefined"])(
+    "does not match %j",
+    text => {
+      expect(matchPynterWasmFaultTrailer(text)).toBeUndefined();
+    },
+  );
 });
 
 describe("PyPvmlPynterEvaluator fault handling", () => {

--- a/src/tests/PyPvmlPynterEvaluator.test.ts
+++ b/src/tests/PyPvmlPynterEvaluator.test.ts
@@ -1,5 +1,9 @@
 import type { IRunnerPlugin } from "@sourceacademy/conductor/runner";
-import { PyPvmlPynterEvaluator } from "../conductor/PyPvmlPynterEvaluator";
+import {
+  isPynterWasmResultTrailer,
+  matchPynterWasmFaultTrailer,
+  PyPvmlPynterEvaluator,
+} from "../conductor/PyPvmlPynterEvaluator";
 
 /** Minimal IRunnerPlugin mock: PyPvmlPynterEvaluator only ever calls
  * sendResult/sendError/sendOutput on its `conductor`. */
@@ -56,5 +60,84 @@ describe("PyPvmlPynterEvaluator", () => {
 
     expect(errors).toHaveLength(2);
     expect(String(errors[1])).toMatch(/not found/i);
+  });
+});
+
+describe("isPynterWasmResultTrailer", () => {
+  // The success trailer is pure noise — evaluateChunk already reads the
+  // result value directly off siwasm_run's return pointer — so it's just
+  // dropped, with nothing captured out of it.
+  test.each([
+    "Program exited with result type undefined: undefined",
+    "Program exited with result type integer: 42",
+  ])("matches the WASM success trailer line %j", text => {
+    expect(isPynterWasmResultTrailer(text)).toBe(true);
+  });
+
+  test.each(["42", "Program exited early", "Program exited unsuccessfully: divide by zero"])(
+    "does not match %j",
+    text => {
+      expect(isPynterWasmResultTrailer(text)).toBe(false);
+    },
+  );
+});
+
+describe("matchPynterWasmFaultTrailer", () => {
+  // On a fault, siwasm_run's return pointer is left zeroed (type 0), so this
+  // trailer is the ONLY place the fault name (e.g. "divide by zero",
+  // "program called error()") appears — it must be captured, not just
+  // dropped like the success trailer, or the fault reason is lost entirely
+  // rather than merely mislabeled as program output.
+  test.each([
+    ["Program exited unsuccessfully: divide by zero", "divide by zero"],
+    ["Program exited unsuccessfully: program called error()", "program called error()"],
+    ["Program exited unsuccessfully: index error", "index error"],
+  ])("captures the fault name out of %j", (text, expected) => {
+    expect(matchPynterWasmFaultTrailer(text)).toBe(expected);
+  });
+
+  test.each([
+    "42",
+    "Program exited early",
+    "Program exited with result type undefined: undefined",
+  ])("does not match %j", text => {
+    expect(matchPynterWasmFaultTrailer(text)).toBeUndefined();
+  });
+});
+
+describe("PyPvmlPynterEvaluator fault handling", () => {
+  // Simulates what the real WASM print callback would receive on a fault
+  // (see lib.c: it prints the fault trailer, then siwasm_run returns a
+  // zeroed result pointer, so readReturnValue's default case throws
+  // "Unknown return type: 0" — reproduced here directly since Jest can't run
+  // the actual WASM module). Confirms the evaluator turns that opaque throw
+  // into an error naming the actual fault, using the trailer text it
+  // captured along the way, rather than losing the fault name once the
+  // trailer line itself stops being forwarded to sendOutput.
+  test("a captured fault trailer produces a fault-named error instead of the raw 'Unknown return type' throw", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new PyPvmlPynterEvaluator(conductor);
+    const mutableEvaluator = evaluator as unknown as {
+      lastFault: string | undefined;
+      pynter: unknown;
+    };
+
+    // evaluateChunk resets lastFault right before calling runBinary, then
+    // the real print callback would set it back during that synchronous
+    // WASM call (before siwasm_run's return throws readReturnValue's generic
+    // error) — reproduced here by having the mock runBinary do the same.
+    mutableEvaluator.pynter = {
+      runBinary: () => {
+        mutableEvaluator.lastFault = "program called error()";
+        throw new Error("Unknown return type: 0");
+      },
+    };
+
+    await evaluator.evaluateChunk("error('asdf')\n");
+
+    expect(outputs).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(String(errors[0])).toContain("program called error()");
+    expect(String(errors[0])).not.toMatch(/Unknown return type/);
   });
 });


### PR DESCRIPTION
## Summary
- Pynter's WASM build (`siwasm_run` in `devices/wasm/wasm/lib.c`) `printf`s a debug trailer to stdout on every run, meant for its own standalone demo — `PyPvmlPynterEvaluator` was piping that stdout straight to `conductor.sendOutput`, so a stray `Program exited with result type undefined: undefined` line showed up in the REPL after every program.
- On a fault, that trailer is also the *only* place the fault name (e.g. `divide by zero`, `program called error()`) appears — the WASM return pointer comes back zeroed on a fault, so simply dropping the trailer would have silently discarded the fault reason, leaving only a useless `Unknown return type: 0` in `sendError`.
- The fix: drop the redundant success trailer, but capture the fault trailer's fault name and use it to replace the generic throw with a proper `Pynter fault: <name>` error.
- No changes to Pynter/the WASM binary itself — same fix documented in `source-academy/pynter`'s README (new fault-code table for all 16 `pynter_fault_t` codes, with examples) and its WASM npm package README (fault-reporting guidance for browser embedders), landing separately in that repo.

## Test plan
- [x] `yarn jest src/tests/PyPvmlPynterEvaluator.test.ts` — 15 passing, including new coverage for `isPynterWasmResultTrailer`, `matchPynterWasmFaultTrailer`, and the evaluator's fault-to-error translation (Jest can't run the real WASM module — see the mocking note in the test file — so the fault path is reproduced directly against a mocked `runBinary`).
- [x] `yarn eslint` / `yarn tsc --noEmit` clean.
- [ ] Manual confirmation in an actual browser host (Jest stubs `.wasm` entirely) that the trailer no longer appears and fault errors now read `Pynter fault: <name>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrwJGug3rCXijRseRjys9V