### PR TITLE
Bump @sourceacademy/pynter-wasm to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@sourceacademy/common-cse-machine": "^0.3.0",
     "@sourceacademy/common-stepper": "^0.0.1",
     "@sourceacademy/conductor": "^0.7.2",
-    "@sourceacademy/pynter-wasm": "^0.1.0",
+    "@sourceacademy/pynter-wasm": "^0.2.0",
     "@sourceacademy/runner-cse-machine": "^3.0.0",
     "@sourceacademy/runner-module-loader": "^0.0.1",
     "@sourceacademy/runner-stepper": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,7 +1672,7 @@ __metadata:
     "@sourceacademy/common-cse-machine": "npm:^0.3.0"
     "@sourceacademy/common-stepper": "npm:^0.0.1"
     "@sourceacademy/conductor": "npm:^0.7.2"
-    "@sourceacademy/pynter-wasm": "npm:^0.1.0"
+    "@sourceacademy/pynter-wasm": "npm:^0.2.0"
     "@sourceacademy/runner-cse-machine": "npm:^3.0.0"
     "@sourceacademy/runner-module-loader": "npm:^0.0.1"
     "@sourceacademy/runner-stepper": "npm:^0.0.1"
@@ -1704,10 +1704,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sourceacademy/pynter-wasm@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@sourceacademy/pynter-wasm@npm:0.1.0"
-  checksum: 10c0/21e1acb65ea6a2de4ffff48811606acbc84b76a6503ae8f86bc884c9b0f0ad288b3bdec3ad1df1156b5b16967ced8243d3f3bb8727c728e902bce18345b564ae
+"@sourceacademy/pynter-wasm@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@sourceacademy/pynter-wasm@npm:0.2.0"
+  checksum: 10c0/7c780ca0d0df7972813b12e10dfa65582aa4f0a5916b8f5f7823a5602fecc5f898a8c49b5af5c72f7e82a21ae8128e06e282ea353889023fe8547ddba2e75489
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- `@sourceacademy/pynter-wasm` had exactly one published version, `0.1.0` (2026-07-14), while `pynter`'s `master` had moved on with 8 unreleased commits — notably the list-indexing/list-multiplication parity work for py-slang#299, which is where the `index_error`/`value_error` fault codes came from.
- #344's fault-name parsing in `PyPvmlPynterEvaluator` is generic (it doesn't hardcode fault names — see `matchPynterWasmFaultTrailer`), but it can only surface whatever the running binary actually reports. Against the stale 0.1.0 build, that meant reporting stale/wrong names — e.g. `Pynter fault: stack overflow` for `[1, 2, 3][10]`, when current pynter source correctly calls that `index error`.
- pynter `v0.2.0` was just cut from current `master` and published.
- `^0.1.0` doesn't resolve to `0.2.0` (a caret range on a `0.x` version pins the minor per semver), so this bumps the version range in `package.json`, not just the lockfile.

## Verification
- [x] `node_modules/@sourceacademy/pynter-wasm/pynterwasm.wasm` now contains `index error`/`value error` in its strings (absent at 0.1.0).
- [x] Full test suite: 64 suites passed, 2 skipped, 19270 tests passed, 0 failures.
- [x] `yarn format:ci` / `yarn lint` / `yarn tsc --noEmit` all clean.

## Related
- source-academy/pynter#30 (segfault on large list allocation) and #31 (operators-vs-spec audit) are separate, still-open issues found while investigating this — not blocking this version bump, since this release already carries real improvements (`index_error`/`value_error`, #299's list fixes) independent of those two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrwJGug3rCXijRseRjys9V