### PR TITLE
py2js: let a module-invoked Python callback call another asyncOnly module function

### DIFF
--- a/src/engines/py2js/README.md
+++ b/src/engines/py2js/README.md
@@ -197,10 +197,17 @@ module-interop layer gets to make:
 - A module calling a Python-defined closure (the sound-module scenario:
   `play(wave, duration)` samples `wave` many times): wrapped via
   `dh.closure_make(sig, func)`, where conductor requires `func` itself to
-  be an async generator (`pyClosureFunc`). Its _body_, though, does a
-  single direct, synchronous `rt.callSync` — no interpreter re-entry
-  (unlike the CSE machine's own closure wrapper in `modules.ts`, which
-  pushes onto `control`/`stash` and resumes the whole step loop per call).
+  be an async generator (`pyClosureFunc`). Its _body_, though (outside the
+  `.sync` fast path below), runs `fn` via `rt.acall` — no interpreter
+  re-entry (unlike the CSE machine's own closure wrapper in `modules.ts`,
+  which pushes onto `control`/`stash` and resumes the whole step loop per
+  call), but still able to await a nested `asyncOnly` module call `fn`
+  itself makes — e.g. a `stacking_adsr` envelope lambda calling `adsr`
+  (source-academy/py-slang#348). Using `rt.acall` here costs nothing extra
+  over the old `rt.callSync`: this generator body already only runs when the
+  `.sync` fast path below has failed or wasn't attempted, so a microtask per
+  call is already being paid, and `acall` degrades to essentially the same
+  cost as a plain call when `fn` makes no nested async-needing call.
 
 **The synchronous fast path** (`GenericDataHandler.closure_call_sync`,
 `pyClosureFunc.sync` in `moduleInterop.ts`): the `AsyncGenerator` shell

--- a/src/engines/py2js/moduleInterop.ts
+++ b/src/engines/py2js/moduleInterop.ts
@@ -25,13 +25,14 @@
  *    `play(wave, duration)` samples `wave` many times): the Python closure is
  *    wrapped via `dh.closure_make(sig, func, ...)`, where conductor requires
  *    `func` itself to be an async generator. Its *body*, though, is authored
- *    here, and does a single direct, synchronous `rt.callSync` — no
- *    interpreter re-entry (unlike the CSE machine's `modules.ts`, whose
+ *    here, and (outside the `.sync` fast path below) runs fn via `rt.acall` —
+ *    no interpreter re-entry (unlike the CSE machine's `modules.ts`, whose
  *    equivalent closure wrapper pushes onto `control`/`stash` and resumes the
- *    whole step loop per call). One microtask per call is unavoidable
- *    (conductor's contract, not py2js's), but the work inside it is a plain
- *    JS function call — see the engine README's module-interop notes for the
- *    measured cost.
+ *    whole step loop per call), but still able to await a nested asyncOnly
+ *    module call fn itself makes (source-academy/py-slang#348). One microtask
+ *    per call is unavoidable (conductor's contract, not py2js's), but the
+ *    work inside it is a plain JS function call — see the engine README's
+ *    module-interop notes for the measured cost.
  *
  * Chapter 1 has no list type (NoListsValidator) and no way to construct or
  * consume one, so DataType.PAIR round-trips through PyList — a pair and a
@@ -128,22 +129,40 @@ export async function pythonToModule(
         ...args: TypedValue<DataType>[]
       ): AsyncGenerator<void, TypedValue<DataType>, undefined> {
         const nativeArgs = await Promise.all(args.map(a => moduleToPython(rt, dh, a)));
-        const result = rt.callSync(fn, nativeArgs);
+        // rt.acall, not rt.callSync: this generator body only ever runs when
+        // dh.closure_call_sync's `.sync` fast path below has already failed
+        // (see closure_call_sync's doc) or was never attempted, so a microtask
+        // per call is already being paid here regardless. Running fn's *async*
+        // body means a call fn makes to another module closure - e.g. the
+        // student's own callback calling an unrelated asyncOnly module
+        // function, like `adsr` from inside a `stacking_adsr` envelope lambda
+        // (source-academy/py-slang#348) - can actually await that round-trip
+        // instead of hitting asyncOnly's synchronous-call guard. For an
+        // ordinary fn with no such nested call, acall degrades to essentially
+        // the same cost as callSync (see acall's own doc comment), so this
+        // costs nothing in the common case and fixes the compound one.
+        const result = await rt.acall(fn, nativeArgs);
         return pythonToModule(rt, dh, result);
       }
-      // The fast path: rt.callSync(fn, ...) is already synchronous (py2js's
-      // whole point) - the only async part of the body above is argument/
+      // The fast path: rt.callSync(fn, ...) is synchronous (py2js's whole
+      // point) - the only async part of the body above is argument/
       // result conversion, and that's only async because moduleToPython/
       // pythonToModule are written uniformly with the closure case (which
       // genuinely needs `await dh.closure_make(...)`). For a scalar-in/
       // scalar-out closure (the wave-sampling shape), conversion never
       // actually needs to await anything, so this restricted synchronous
-      // twin removes the last microtask too. Bailing to `undefined` for an
-      // unsupported *argument* is safe (fn hasn't run yet); once fn has
-      // actually run, a result that doesn't fit is a hard error, not a
-      // fallback signal - falling back to the async path at that point would
-      // call fn a second time, double-running any side effects (print(),
-      // mutation) it has.
+      // twin removes the last microtask too. Unlike pyClosureFunc above, this
+      // fast path deliberately keeps rt.callSync rather than rt.acall - it
+      // exists only for provably scalar-only closures (moduleToPythonSync/
+      // pythonToModuleSync below bail to `undefined` the moment an argument or
+      // result isn't a plain scalar), so fn can never reach a nested asyncOnly
+      // call through this path in the first place; going through the sync
+      // body here is what makes the hot, 44100Hz-sampling case actually fast.
+      // Bailing to `undefined` for an unsupported *argument* is safe (fn
+      // hasn't run yet); once fn has actually run, a result that doesn't fit
+      // is a hard error, not a fallback signal - falling back to the async
+      // path at that point would call fn a second time, double-running any
+      // side effects (print(), mutation) it has.
       (
         pyClosureFunc as typeof pyClosureFunc & {
           sync?: (...a: TypedValue<DataType>[]) => TypedValue<DataType> | undefined;

--- a/src/tests/py2js-from-import.test.ts
+++ b/src/tests/py2js-from-import.test.ts
@@ -212,7 +212,7 @@ test("the sound-module scenario: a module samples a Python-defined function via 
   expect(outputs).toEqual(["6.0"]);
 });
 
-test("a synchronously-sampled Python callback cannot itself call an import needing a round-trip", async () => {
+test("a Python callback invoked by a module can itself call another import needing a round-trip (source-academy/py-slang#348)", async () => {
   const dh = new GenericDataHandler();
 
   async function* playFunc(
@@ -247,15 +247,23 @@ test("a synchronously-sampled Python callback cannot itself call an import needi
     ],
   });
 
-  const { session } = makeSession(dh);
-  await expect(
-    session.runChunk(
-      "from audio import play, slow_helper\n" +
-        "def wave(t):\n" +
-        "    return slow_helper(t)\n" +
-        "print(play(wave))\n",
-    ),
-  ).rejects.toThrow(/needs a frontend round-trip/);
+  const { session, outputs } = makeSession(dh);
+  // play calls back into wave(0) via closure_call_unchecked (never
+  // closure_call_sync - wave isn't scalar-in/scalar-out-provable here), and
+  // wave's own body calls slow_helper, an asyncOnly import in its own right.
+  // Regression test for #348: this used to throw "needs a frontend
+  // round-trip" because the callback wrapper ran wave's *sync* body
+  // (rt.callSync) regardless of how the module invoked it, so a nested
+  // asyncOnly call inside wave could never await. It now runs wave's async
+  // body instead, so the nested round-trip actually completes.
+  await session.runChunk(
+    "from audio import play, slow_helper\n" +
+      "def wave(t):\n" +
+      "    return slow_helper(t)\n" +
+      "print(play(wave))\n",
+  );
+
+  expect(outputs).toEqual(["0.0"]);
 });
 
 test("a module PAIR (a Sound-shaped value) round-trips through sine_sound/play", async () => {

--- a/src/tests/py2js-module-interop.test.ts
+++ b/src/tests/py2js-module-interop.test.ts
@@ -258,4 +258,49 @@ describe("moduleToPython", () => {
     // Async call goes through and produces the right value.
     expect(await rt.acall(fn as never, [4n])).toBe(5);
   });
+
+  test("a Python closure invoked by a module can itself call another asyncOnly module closure (source-academy/py-slang#348)", async () => {
+    const dh = new GenericDataHandler();
+    const rt = makeRt();
+
+    // A module-exported function needing a real frontend round-trip -
+    // moduleToPython's CLOSURE case marks every module closure this way,
+    // regardless of whether it's provably pure (e.g. sound's `adsr`).
+    async function* bump(
+      x: TypedValue<DataType>,
+    ): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+      await Promise.resolve();
+      return { type: DataType.NUMBER, value: (x as TypedValue<DataType.NUMBER>).value + 1 };
+    }
+    const bumpClosure = await dh.closure_make(
+      { returnType: DataType.NUMBER, args: [DataType.NUMBER] },
+      bump,
+    );
+    const bumpFn = await moduleToPython(rt, dh, bumpClosure, "bump");
+
+    // The student's own closure (e.g. stacking_adsr's envelope lambda),
+    // dual-compiled: its sync body calls bumpFn synchronously (as any
+    // compiled call does in sync mode, and would throw since bumpFn is
+    // asyncOnly) and its async body awaits it via rt.acall - exactly what
+    // py2js's compiler emits for `lambda x: bump(x)`.
+    const envelope = rt.def2(
+      "envelope",
+      1,
+      (x: unknown) => rt.call(bumpFn as never, [x as number]),
+      async (x: unknown) => rt.acall(bumpFn as never, [x as number]),
+    );
+
+    const typed = await pythonToModule(rt, dh, envelope);
+    if (typed.type !== DataType.CLOSURE) throw new Error("unreachable");
+
+    // The module's-eye view: invoke the student closure the same way
+    // stacking_adsr invokes its envelope callbacks - through
+    // closure_call_unchecked, never closure_call_sync (bumpFn isn't a plain
+    // scalar-only closure candidate here, but even if it were, unchecked is
+    // the path a module takes once it needs the real async round-trip).
+    const gen = dh.closure_call_unchecked(typed, [{ type: DataType.NUMBER, value: 4 }]);
+    let step = await gen.next();
+    while (!step.done) step = await gen.next();
+    expect(step.value).toEqual({ type: DataType.NUMBER, value: 5 });
+  });
 });


### PR DESCRIPTION
## Summary
- `pyClosureFunc`'s fallback body (the generic path used when `closure_call_sync`'s `.sync` fast path can't handle a call) ran the Python callback via `rt.callSync`, which always executes the sync compiled body regardless of how the module invoked it — so a nested call to another `asyncOnly` module function (e.g. a `stacking_adsr` envelope lambda calling `adsr()`) always threw "needs a frontend round-trip", even though the surrounding call was already on the async path.
- Switched that fallback body to `rt.acall`. This body is already an async generator paying a microtask per call (the `.sync` fast path exists precisely to skip that cost for provably scalar-only closures), so this is free in the common case and lets a nested `asyncOnly` call actually await its round-trip.
- Fixed one existing test (`py2js-from-import.test.ts`) that had encoded the bug as expected behavior, and added a direct regression test at the `moduleInterop.ts` layer plus an end-to-end one through a real session.

Fixes #348.

## Test plan
- [x] `npx jest src/tests --testPathPattern="py2js"` — 61 suites, ~19k tests pass
- [x] Manually reverted the fix and confirmed the new/updated tests fail with the exact error from the issue (`needs a frontend round-trip and cannot be called from a synchronous module callback`), then confirmed they pass with the fix restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrwJGug3rCXijRseRjys9V