### PR TITLE
Bump @sourceacademy/conductor to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@sourceacademy/common-cse-machine": "^0.3.0",
     "@sourceacademy/common-stepper": "^0.0.1",
-    "@sourceacademy/conductor": "^0.7.2",
+    "@sourceacademy/conductor": "^0.8.0",
     "@sourceacademy/pynter-wasm": "^0.2.0",
     "@sourceacademy/runner-cse-machine": "^3.0.0",
     "@sourceacademy/runner-module-loader": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,10 +1650,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sourceacademy/conductor@npm:^0.7.2":
-  version: 0.7.2
-  resolution: "@sourceacademy/conductor@npm:0.7.2"
-  checksum: 10c0/84cff73c8c67a5884c9a06774f514b2dc4275e14ee282c7eee4fd32618857f63cdc2a736c4e5d2b6501b7b39d6c9e2f7192af1dbbc8ec1542721c08252c1f022
+"@sourceacademy/conductor@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@sourceacademy/conductor@npm:0.8.0"
+  checksum: 10c0/8b970b1f5fffbcb5242f5c358fb25af8d916cb5af9ca7fa9e0128928fde1783ed65465241858a82002bd8b5f21f5f5b80d3ea57bbd05faed604e6dd1c36600e9
   languageName: node
   linkType: hard
 
@@ -1671,7 +1671,7 @@ __metadata:
     "@rollup/plugin-wasm": "npm:^6.2.2"
     "@sourceacademy/common-cse-machine": "npm:^0.3.0"
     "@sourceacademy/common-stepper": "npm:^0.0.1"
-    "@sourceacademy/conductor": "npm:^0.7.2"
+    "@sourceacademy/conductor": "npm:^0.8.0"
     "@sourceacademy/pynter-wasm": "npm:^0.2.0"
     "@sourceacademy/runner-cse-machine": "npm:^3.0.0"
     "@sourceacademy/runner-module-loader": "npm:^0.0.1"


### PR DESCRIPTION
## Summary
- Bumps `@sourceacademy/conductor` from `^0.7.2` to `^0.8.0`.
- `0.8.0` includes [conductor#53](https://github.com/source-academy/conductor/pull/53) (`hostLoadPlugin`/`requestLoadPlugin` become async, `Promise<void>` instead of `void`; RPC procedure renamed from the notification `$requestLoadPlugin` to the awaitable `requestLoadPlugin`) and [conductor#52](https://github.com/source-academy/conductor/pull/52) (additive `beginPendingWork`/`endPendingWork` on `BasicEvaluator`, opt-in, no behavior change for evaluators that don't call them).

## Why no code changes
The only `hostLoadPlugin` call site (`PyStepperEvaluator.ts`) is already fire-and-forget inside a constructor, so it still compiles and behaves identically against the new `Promise<void>` return type.

This also unblocks the `fix-settimeout-worker-teardown` branch (fixing #329), which depends on `beginPendingWork`/`endPendingWork` from conductor 0.8.0.

## Test plan
- [x] `yarn tsc --noEmit` passes
- [x] `yarn jest --testPathPattern="conductor|py2js"` — 18 suites / 5183 tests pass

Draft — not merging yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)