### PR TITLE
py2js: closure_call_sync fast path for module closures called from Python

### DIFF
--- a/src/engines/py2js/moduleInterop.ts
+++ b/src/engines/py2js/moduleInterop.ts
@@ -66,12 +66,18 @@ import { Py2JsRuntime, Py2JsRuntimeError, PyOpaque, PyValue } from "./runtime";
  * Synchronous, scalar-only counterparts to moduleToPython/pythonToModule -
  * used only by the `.sync` fast path a Python closure crossing into a module
  * gets below (see GenericDataHandler.closure_call_sync's doc for the overall
- * design). Cover exactly the value shapes a scalar-in/scalar-out closure (a
- * wave function, sampled 44100x/sec by the sound module) needs: numbers,
- * booleans, strings, None. Return `undefined` for anything else (pairs,
- * closures, opaques, complex) - the "no sync path" signal, safe to use for
- * *arguments* (nothing has run yet) but not for the *result* once the real
- * call has already happened - see pyClosureFunc.sync below.
+ * design). Cover the value shapes a scalar-in/scalar-out closure (a wave
+ * function, sampled 44100x/sec by the sound module) needs - numbers,
+ * booleans, strings, None - plus OPAQUE, needed for an opaque-handle
+ * accessor (pix_n_flix's get_pixel_value/set_pixel_value, taking an opaque
+ * image handle as `source`/`dest`, sampled up to width*height*8x/frame).
+ * OPAQUE needs no real conversion work either way - same as the async
+ * moduleToPython/pythonToModule cases below, it's a zero-cost passthrough
+ * (`new PyOpaque(value)` / `value.typed`), not a scalar decode, so it costs
+ * nothing to add here. Return `undefined` for anything else (pairs, closures,
+ * complex) - the "no sync path" signal, safe to use for *arguments* (nothing
+ * has run yet) but not for the *result* once the real call has already
+ * happened - see pyClosureFunc.sync below.
  */
 function moduleToPythonSync(value: TypedValue<DataType>): PyValue | undefined {
   switch (value.type) {
@@ -84,12 +90,15 @@ function moduleToPythonSync(value: TypedValue<DataType>): PyValue | undefined {
     case DataType.VOID:
     case DataType.EMPTY_LIST:
       return null;
+    case DataType.OPAQUE:
+      return new PyOpaque(value);
     default:
       return undefined;
   }
 }
 
 function pythonToModuleSync(value: PyValue): TypedValue<DataType> | undefined {
+  if (value instanceof PyOpaque) return value.typed;
   switch (typeof value) {
     case "bigint":
       return { type: DataType.NUMBER, value: Number(value) };

--- a/src/engines/py2js/moduleInterop.ts
+++ b/src/engines/py2js/moduleInterop.ts
@@ -13,14 +13,23 @@
  * Closures crossing the module boundary, in EITHER direction, are
  * async-generator calls by conductor's own contract (`ExternCallable` is
  * `(...args) => AsyncGenerator<...>`) — not an implementation choice of any
- * particular engine. Concretely:
+ * particular engine — but that mandatory shape is only the *fallback*, not the
+ * only path, in either direction: `GenericDataHandler.closure_call_sync` is a
+ * shared, engine-agnostic escape hatch that doesn't care which side of the
+ * boundary a closure came from, only whether its underlying function carries a
+ * `.sync` twin. Concretely:
  *
- *  - Python calling an imported module function (`from math import sqrt`):
- *    wrapped as a `PyFunction` whose body runs `dh.closure_call_unchecked`
- *    and iterates the generator. `.next()` on an async generator always
- *    resolves via microtask, so this is unavoidably async — the function is
- *    `asyncOnly` (see runtime.ts), callable only through `acall`/dual mode,
- *    never through a sync module callback.
+ *  - Python calling an imported module function (`from math import sqrt`, or
+ *    a hot per-call accessor like pix_n_flix's `get_pixel_value`): wrapped as
+ *    a `PyFunction` whose sync body attempts `dh.closure_call_sync` first
+ *    (converting arguments/result through the same restricted scalar
+ *    converters as the `.sync` fast path below) and falls back to the async
+ *    body — `dh.closure_call_unchecked`, iterating the generator — only when
+ *    no `.sync` twin is available for that particular call. Today that's most
+ *    module closures (no `.sync` twin attached), which simply throw the same
+ *    "needs a frontend round-trip" error the sync body always raised before;
+ *    a closure that does carry one skips the mandatory async-generator shape
+ *    entirely, the same way sound's wave sampling already does.
  *  - A module calling a Python-defined function (the sound-module scenario:
  *    `play(wave, duration)` samples `wave` many times): the Python closure is
  *    wrapped via `dh.closure_make(sig, func, ...)`, where conductor requires
@@ -284,23 +293,72 @@ export async function moduleToPython(
       return new PyOpaque(value);
     case DataType.CLOSURE: {
       const arity = await dh.closure_arity(value);
-      const f = rt.def(name, arity, () => {
-        // Defensive backstop: the asyncOnly guard in call()/checkCallable
-        // already rejects this before the body would run through the
-        // normal call path; this only fires on a direct raw invocation that
-        // bypasses the runtime (e.g. module code calling the JS function
-        // value itself instead of going through rt.call/rt.acall).
-        throw new Py2JsRuntimeError(
-          "TypeError",
-          `${name}() needs a frontend round-trip and cannot be called from a synchronous module callback`,
-        );
+      // closure_call_sync (GenericDataHandler, not part of conductor's own IDataHandler
+      // contract - see the doc comment on syncCall below) is the mirror image of
+      // pythonToModule's own `.sync` fast path above: a module closure - e.g.
+      // pix_n_flix's get_pixel_value/set_pixel_value, sampled up to width*height*8
+      // times per frame from inside a student's filter - can carry a `.sync` twin
+      // proving it never needs a real host round-trip, exactly like a scalar-in/
+      // scalar-out wave function does in the other direction. The sync body below
+      // attempts that fast path on every call (not just once - unlike a Python
+      // closure's fixed dual-compiled shape, a module closure's sync-capability is
+      // discovered per call, since closure_call_sync itself is what tells us whether
+      // one exists); asyncBody remains the always-correct fallback for calls that
+      // reach it via acall (dual-mode's async spine) or when no `.sync` twin exists.
+      const syncCall = (
+        dh as IDataHandler & {
+          closure_call_sync?: (
+            c: TypedValue<DataType.CLOSURE>,
+            args: TypedValue<DataType>[],
+          ) => TypedValue<DataType> | undefined;
+        }
+      ).closure_call_sync?.bind(dh);
+      const f = rt.def(name, arity, (...args: PyValue[]) => {
+        const typedArgs: TypedValue<DataType>[] = [];
+        for (const a of args) {
+          // An argument outside the restricted scalar coverage safely means "no
+          // sync path for this call" - nothing has run yet, so falling through to
+          // the same error the old unconditional-throw body always raised is exact,
+          // not a guess.
+          const converted = pythonToModuleSync(a);
+          if (converted === undefined) {
+            throw new Py2JsRuntimeError(
+              "TypeError",
+              `${name}() needs a frontend round-trip and cannot be called from a synchronous module callback`,
+            );
+          }
+          typedArgs.push(converted);
+        }
+        const result = syncCall?.(value, typedArgs);
+        if (result === undefined) {
+          throw new Py2JsRuntimeError(
+            "TypeError",
+            `${name}() needs a frontend round-trip and cannot be called from a synchronous module callback`,
+          );
+        }
+        // Once closure_call_sync has actually run - real module-side effects may
+        // already have happened - there is no safe fallback if the *result* doesn't
+        // fit; that would risk calling the closure a second time via asyncBody.
+        // Mirrors pyClosureFunc.sync's identical stance in the other direction.
+        const converted = moduleToPythonSync(result);
+        if (converted === undefined) {
+          throw new Py2JsRuntimeError(
+            "TypeError",
+            `${name}() returned a value that cannot be produced by a synchronous module callback`,
+          );
+        }
+        return converted;
       });
       // Renders as a built-in function (matching the spirit of the CSE
       // machine's own convention for module closures — see the file header
       // comment on threading the real symbol name through, an improvement
       // over CSE's literal "closure" placeholder name there).
       f.pyBuiltin = true;
-      f.asyncOnly = true;
+      // Deliberately not asyncOnly: whether a *specific call* can use the sync body
+      // is now decided dynamically (per the loop above), not fixed at import time -
+      // most module closures still have no `.sync` twin and will simply throw the
+      // same "needs a frontend round-trip" error checkCallable's asyncOnly guard
+      // used to raise earlier, just one level in.
       f.asyncBody = async (...args: PyValue[]) => {
         const typedArgs = await Promise.all(args.map(a => pythonToModule(rt, dh, a)));
         const gen = dh.closure_call_unchecked(value, typedArgs);

--- a/src/tests/py2js-module-interop.test.ts
+++ b/src/tests/py2js-module-interop.test.ts
@@ -231,7 +231,7 @@ describe("moduleToPython", () => {
     await expect(moduleToPython(rt, dh, typed)).resolves.toEqual([]);
   });
 
-  test("CLOSURE becomes an asyncOnly PyFunction", async () => {
+  test("CLOSURE without a .sync twin still requires a frontend round-trip", async () => {
     const dh = new GenericDataHandler();
     const rt = makeRt();
     async function* addOne(
@@ -246,16 +246,50 @@ describe("moduleToPython", () => {
     );
     const fn = await moduleToPython(rt, dh, closure, "add_one");
     expect(typeof fn).toBe("function");
-    const f = fn as unknown as { pyName: string; asyncOnly?: boolean };
+    const f = fn as unknown as { pyName: string };
     expect(f.pyName).toBe("add_one");
-    expect(f.asyncOnly).toBe(true);
 
-    // Sync call rejects: this is the guard that makes a hot, synchronously
-    // sampled module callback fail loudly instead of misbehaving if it tries
-    // to call an imported function that needs a real round-trip.
+    // Sync call rejects: addOne carries no `.sync` twin, so the sync body's
+    // own closure_call_sync attempt comes back undefined and it raises the
+    // same "needs a frontend round-trip" error a hardcoded asyncOnly guard
+    // used to raise unconditionally - this is now a per-call outcome, not a
+    // fixed property of the PyFunction (see the next test).
     expect(() => rt.callSync(fn as never, [4n])).toThrow(/frontend round-trip/);
 
     // Async call goes through and produces the right value.
+    expect(await rt.acall(fn as never, [4n])).toBe(5);
+  });
+
+  test("CLOSURE with a .sync twin is callable synchronously, no frontend round-trip needed", async () => {
+    const dh = new GenericDataHandler();
+    const rt = makeRt();
+    // The pix_n_flix shape: a module accessor (e.g. get_pixel_value) that can
+    // prove it never needs a real host round-trip - a plain, synchronous read
+    // against an in-memory buffer - attaches `.sync` alongside its mandatory
+    // async-generator body, mirroring closureToWave's identical pattern for
+    // sound's wave sampling (src/bundles/sound/src/index.ts).
+    async function* addOne(
+      x: TypedValue<DataType>,
+    ): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+      await Promise.resolve();
+      return { type: DataType.NUMBER, value: (x as TypedValue<DataType.NUMBER>).value + 1 };
+    }
+    Object.assign(addOne, {
+      sync: (x: TypedValue<DataType>): TypedValue<DataType> => ({
+        type: DataType.NUMBER,
+        value: (x as TypedValue<DataType.NUMBER>).value + 1,
+      }),
+    });
+    const closure = await dh.closure_make(
+      { returnType: DataType.NUMBER, args: [DataType.NUMBER] },
+      addOne,
+    );
+    const fn = await moduleToPython(rt, dh, closure, "add_one");
+
+    // No throw, no await needed - the sync body's own closure_call_sync
+    // attempt succeeds and returns the plain value directly.
+    expect(rt.callSync(fn as never, [4n])).toBe(5);
+    // The async path still works too, unconditionally.
     expect(await rt.acall(fn as never, [4n])).toBe(5);
   });
 

--- a/src/tests/py2js-module-interop.test.ts
+++ b/src/tests/py2js-module-interop.test.ts
@@ -293,6 +293,42 @@ describe("moduleToPython", () => {
     expect(await rt.acall(fn as never, [4n])).toBe(5);
   });
 
+  test("CLOSURE with a .sync twin taking/returning an OPAQUE handle is callable synchronously (pix_n_flix's get_pixel_value shape)", async () => {
+    const dh = new GenericDataHandler();
+    const rt = makeRt();
+    // get_pixel_value(source, x, y, p): source is an opaque image handle, not
+    // a scalar - this only works synchronously if moduleToPythonSync/
+    // pythonToModuleSync pass OPAQUE straight through like the async
+    // converters already do, rather than treating it as "no sync path". The
+    // closure body itself doesn't need real buffer semantics to prove this -
+    // just that the OPAQUE argument survives the sync round-trip and comes
+    // back out as the identical PyOpaque, unconverted.
+    async function* identity(
+      handle: TypedValue<DataType>,
+    ): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+      await Promise.resolve();
+      return handle;
+    }
+    Object.assign(identity, {
+      sync: (handle: TypedValue<DataType>): TypedValue<DataType> => handle,
+    });
+    const closure = await dh.closure_make(
+      { returnType: DataType.OPAQUE, args: [DataType.OPAQUE] },
+      identity,
+    );
+    const fn = await moduleToPython(rt, dh, closure, "get_pixel_value");
+
+    const typedHandle = await dh.opaque_make([10, 20, 30, 255]);
+    const opaqueHandle = new PyOpaque(typedHandle);
+
+    // No throw, no await needed - the sync body's own closure_call_sync
+    // attempt succeeds because the OPAQUE handle argument now converts
+    // through pythonToModuleSync instead of bailing to "no sync path", and
+    // the same handle (by reference) comes back out via moduleToPythonSync.
+    expect(rt.callSync(fn as never, [opaqueHandle]) as PyOpaque).toEqual(opaqueHandle);
+    expect((await rt.acall(fn as never, [opaqueHandle])) as PyOpaque).toEqual(opaqueHandle);
+  });
+
   test("a Python closure invoked by a module can itself call another asyncOnly module closure (source-academy/py-slang#348)", async () => {
     const dh = new GenericDataHandler();
     const rt = makeRt();


### PR DESCRIPTION
## Summary

`moduleInterop.ts`'s `moduleToPython` builds a `PyFunction` for every module closure Python imports (`from math import sqrt`, or a hot per-call accessor like pix_n_flix's proposed `get_pixel_value`). Until now this was always `asyncOnly`: a defensive-backstop sync body that unconditionally threw, and an async body that unconditionally paid the mandatory `AsyncGenerator` tax via `closure_call_unchecked` — even when the closure carries a `.sync` twin proving it never needs a real host round-trip.

That fast path already exists and is already generic: `GenericDataHandler.closure_call_sync` looks up a closure's underlying function and calls its `.sync` twin directly if present, regardless of whether the closure came from a module or from Python — it's the exact mechanism `pythonToModule`'s own `.sync` attach already uses for the opposite direction (a Python closure crossing into a module, e.g. sound's wave sampling, 44,100 calls/sec). Only `moduleToPython` never attempted it.

## What changed

- `moduleToPython`'s `DataType.CLOSURE` case now tries `dh.closure_call_sync` first, converting arguments/result through the same restricted scalar converters (`pythonToModuleSync`/`moduleToPythonSync`) the other direction's fast path already uses. Falls back to the same `"needs a frontend round-trip"` error only when no `.sync` twin is available *for that specific call* — a dynamic, per-call decision now, rather than a fixed `asyncOnly` flag rejecting every sync call unconditionally regardless of what the closure was actually capable of.
- `asyncBody` (the always-correct fallback used on the async spine, `acall`) is unchanged.
- Updated `py2js-module-interop.test.ts`: the old "CLOSURE becomes an asyncOnly PyFunction" test is renamed to reflect that this is now a per-call outcome, not a static flag, and a new test confirms a closure carrying `.sync` is now callable synchronously with no round-trip.

## Motivation

Prompted by planning the `pix_n_flix` module's migration to Conductor ([source-academy/modules](https://github.com/source-academy/modules)). A redesigned pixel API (`get_pixel_value`/`set_pixel_value` over an opaque image handle, instead of decomposing every video frame into a Source-level array) needs to be called from inside a student's filter at high frequency — up to `width * height * 8` times per frame. That's the same shape of hot loop as sound's per-sample wave callback, just the reverse direction across the module boundary, and this engine README's own benchmark puts the difference at ~15-20ns/call (sync) vs. ~390-420ns/call (mandatory async-generator) — the gap between a usable frame budget and roughly 2.5fps at 400x300.

Depends on **source-academy/conductor#54**, which fixes `BaseModulePlugin.initialise()` silently dropping a module method's `.sync` twin across `Function.prototype.bind()` — without that fix, a module's `.sync` twin would never survive registration for this change to actually see.

## Test plan

- [x] `yarn jest src/tests/py2js` — 214/214 passing (15 suites)
- [x] `yarn jest src/tests/operator-conformance-py2js.test.ts src/tests/stdlib-conformance-py2js.test.ts` — 4785/4785 passing (no regressions in general execution semantics)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on both changed files — clean