### PR TITLE
Document set_timeout/clear_all_timeout in MISC docs

### DIFF
--- a/docs/lib/misc.js
+++ b/docs/lib/misc.js
@@ -263,3 +263,20 @@ function str(object = "") { }
  */
 function time_time() { }
 
+/**
+ * Schedules <CODE>f</CODE> to be called with no arguments after <CODE>t</CODE> milliseconds have
+ * elapsed, without blocking the calling code. <CODE>f</CODE> is invoked once, the next time the
+ * scheduled delay elapses.
+ *
+ * @param {function} <CODE>f</CODE> - the function to call once <CODE>t</CODE> milliseconds have elapsed
+ * @param {int | float} <CODE>t</CODE> - the delay, in milliseconds, before <CODE>f</CODE> is called
+ * @returns {None} None
+ */
+function set_timeout(f, t) { }
+
+/**
+ * Cancels every <CODE>set_timeout</CODE> callback that has been scheduled but has not yet fired.
+ *
+ * @returns {None} None
+ */
+function clear_all_timeout() { }


### PR DESCRIPTION
## Summary
- Fixes #360: `set_timeout`/`clear_all_timeout` were added to the language in #322 but never got JSDoc entries in `docs/lib/misc.js`, so they didn't show up on https://docs.sourceacademy.org/python/.
- Adds JSDoc entries for both, matching the style of the other MISC builtins: `set_timeout(f, t)` schedules `f()` to run after `t` milliseconds without blocking, and `clear_all_timeout()` cancels every pending `set_timeout` callback.

## Test plan
- [x] Verified with a standalone `jsdoc` run (same generator/config used by `scripts/jsdoc.sh`) that the new entries parse and render correctly on the generated MISC page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)