### PR TITLE
Fix jsdoc build failure from duplicate declarations in misc.js

### DIFF
--- a/docs/lib/misc.js
+++ b/docs/lib/misc.js
@@ -74,17 +74,6 @@ defaults to <CODE>0</CODE>.
 function complex(v = 0, i = 0) { }
 
 /**
- * Prints the provided <CODE>*object</CODE> arguments to the standard output (similar to a simplified
- * <CODE>print</CODE>) and then raises an exception. This function accepts a variable number of arguments,
- * converts them to their <CODE>string</CODE> representations using <CODE>str()</CODE>, outputs them (with a
- * newline) just like what <CODE>print</CODE> does, and immediately halts execution by raising an exception.
- *
- * @param {any} <CODE>*object</CODE> - Objects to be printed to the standard output
- * @returns {NoneType} the <CODE>None</CODE> value
- */
-function error(...object) { }
-
-/**
  * Return the imaginary part of a complex number <CODE>x</CODE>.
  * 
  * @param {complex} <CODE>x</CODE> - a complex number
@@ -199,18 +188,6 @@ function max(arg1, arg2, ...args) { }
 function min(arg1, arg2, ...args) { }
 
 /**
- * A simplified version of the Python built-in <CODE>print</CODE> function.
- * This function takes any number of parameters <CODE>*object</CODE>, converts them to their
- * <CODE>string</CODE> representations using <CODE>str()</CODE>, and writes them to the standard
- * output (<CODE>sys.stdout</CODE>), followed by a newline character. See the official Python
- * documentation for <CODE>print</CODE>.
- *
- * @param {any} <CODE>*object</CODE> - object(s) to be printed to the standard output
- * @returns {NoneType} the <CODE>None</CODE> value
- */
-function print(...object) { }
-
-/**
  * Return the next random floating-point number in the range <CODE>0.0 ≤ X < 1.0</CODE>.
  *
  * @returns {float} the next random floating-point number in the range <CODE>0.0 ≤ X < 1.0</CODE>
@@ -255,13 +232,6 @@ function round(number, ndigits) { }
  * @returns {string} the informal <CODE>string</CODE> representation of <CODE>object</CODE>
  */
 function str(object = "") { }
-
-/**
- * Return the number of milliseconds elapsed since <CODE>January 1, 1970 00:00:00 UTC</CODE>.
- *
- * @returns {float} current time in milliseconds
- */
-function time_time() { }
 
 /**
  * Schedules <CODE>f</CODE> to be called with no arguments after <CODE>t</CODE> milliseconds have


### PR DESCRIPTION
## Summary
While checking that #361 actually made `set_timeout`/`clear_all_timeout` show up on https://docs.sourceacademy.org/python/, I found the entire MISC section renders as empty ("No names predeclared in MISC") — and same for python_1 through python_4, which all bundle `misc.js`.

Root cause: `docs/lib/misc.js` declares `print`, `error`, and `time_time` twice each (identical doc content both times — looks like a merge artifact). `jsdoc`'s parser rejects duplicate top-level function declarations as a syntax error, so it has been failing to parse `misc.js` on every single build:

```
ERROR: Unable to parse .../docs/lib/misc.js: Identifier 'error' has already been declared. (85:9)
```

`scripts/jsdoc.sh`'s `run_jsdoc` doesn't check `jsdoc`'s exit code, so `deploy-docs.yml` has been reporting green while quietly shipping an empty MISC page for a while.

- Removes the three duplicate declarations, keeping one copy of each (content was byte-identical between copies).
- No content is lost — every function that was in either copy is still documented.

## Test plan
- [x] Ran the same `jsdoc` generator/config as `scripts/jsdoc.sh` (`run_jsdoc`-equivalent invocation) against `docs/lib/misc.js` before/after: before, it errors and produces an empty page; after, it parses clean and every MISC function (including `print`, `error`, `time_time`, `set_timeout`, `clear_all_timeout`) renders.
- [x] Also ran the full python_4 group build (misc.js + math.js + linked_list.js + pairmutator.js + list.js + stream.js + mce.js) with no errors.