### PR TITLE
Wasm fix: shadow stack manipulation for negative unary and comparison operators

### DIFF
--- a/src/engines/wasm/runtime/operators.ts
+++ b/src/engines/wasm/runtime/operators.ts
@@ -526,11 +526,6 @@ function identityCheck(): WasmInstruction[] {
                 wasm
                   .if(i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.COMPLEX)))
                   .then(
-                    // wasm.call(POP_SHADOW_STACK_FX),
-                    // wasm.raw`(local.set $y_val) (local.set $y_tag)`,
-                    // wasm.call(POP_SHADOW_STACK_FX),
-                    // wasm.raw`(local.set $x_val) (local.set $x_tag)`,
-
                     local.set(
                       "$is_result",
                       i32.and(
@@ -549,11 +544,6 @@ function identityCheck(): WasmInstruction[] {
                     wasm
                       .if(i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.STRING)))
                       .then(
-                        // wasm.call(POP_SHADOW_STACK_FX),
-                        // wasm.raw`(local.set $y_val) (local.set $y_tag)`,
-                        // wasm.call(POP_SHADOW_STACK_FX),
-                        // wasm.raw`(local.set $x_val) (local.set $x_tag)`,
-
                         local.set(
                           "$is_result",
                           i32.eqz(

--- a/src/engines/wasm/runtime/operators.ts
+++ b/src/engines/wasm/runtime/operators.ts
@@ -8,7 +8,7 @@ import {
   wasm,
   type WasmInstruction,
 } from "@sourceacademy/wasm-util";
-import { MALLOC_FX } from "./gc";
+import { IS_TAG_GCABLE, MALLOC_FX } from "./gc";
 import { LIST_REPEAT_FX, LIST_SLOT_TAG_LOAD_FX, LIST_SLOT_VAL_LOAD_FX } from "./list";
 import {
   CHAPTER,
@@ -18,7 +18,7 @@ import {
   TYPE_TAG,
   getErrorIndex,
 } from "./metadata";
-import { POP_SHADOW_STACK_FX } from "./shadowStack";
+import { POP_SHADOW_STACK_FX, SILENT_PUSH_SHADOW_STACK_FX } from "./shadowStack";
 import { BOOLISE_FX } from "./stdlib";
 import {
   MAKE_BOOL_FX,
@@ -56,6 +56,8 @@ export const NEG_FX = wasm
       .if(i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.COMPLEX)))
       .then(
         wasm.return(
+          wasm.call(POP_SHADOW_STACK_FX).args(),
+          wasm.raw`(local.set $x_val) (local.set $x_tag)`,
           wasm
             .call(MAKE_COMPLEX_FX)
             .args(
@@ -524,6 +526,11 @@ function identityCheck(): WasmInstruction[] {
                 wasm
                   .if(i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.COMPLEX)))
                   .then(
+                    // wasm.call(POP_SHADOW_STACK_FX),
+                    // wasm.raw`(local.set $y_val) (local.set $y_tag)`,
+                    // wasm.call(POP_SHADOW_STACK_FX),
+                    // wasm.raw`(local.set $x_val) (local.set $x_tag)`,
+
                     local.set(
                       "$is_result",
                       i32.and(
@@ -542,6 +549,11 @@ function identityCheck(): WasmInstruction[] {
                     wasm
                       .if(i32.eq(local.get("$x_tag"), i32.const(TYPE_TAG.STRING)))
                       .then(
+                        // wasm.call(POP_SHADOW_STACK_FX),
+                        // wasm.raw`(local.set $y_val) (local.set $y_tag)`,
+                        // wasm.call(POP_SHADOW_STACK_FX),
+                        // wasm.raw`(local.set $x_val) (local.set $x_tag)`,
+
                         local.set(
                           "$is_result",
                           i32.eqz(
@@ -607,6 +619,14 @@ export const COMPARISON_OP_FX = wasm
   .results(i32, i64)
   .locals({ $a: f64, $b: f64, $c: f64, $d: f64, $is_result: i32, $eq_result: i32 })
   .body(
+    wasm
+      .if(wasm.call(IS_TAG_GCABLE).args(local.get("$y_tag")))
+      .then(wasm.call(POP_SHADOW_STACK_FX), wasm.raw`(local.set $y_val) (local.set $y_tag)`),
+
+    wasm
+      .if(wasm.call(IS_TAG_GCABLE).args(local.get("$x_tag")))
+      .then(wasm.call(POP_SHADOW_STACK_FX), wasm.raw`(local.set $x_val) (local.set $x_tag)`),
+
     wasm
       .if(
         i32.or(
@@ -978,6 +998,17 @@ export const LIST_STRUCT_EQ_FX = wasm
         "$ey_val",
         wasm.call(LIST_SLOT_VAL_LOAD_FX).args(local.get("$y_val"), local.get("$i")),
       ),
+
+      wasm
+        .if(wasm.call(IS_TAG_GCABLE).args(local.get("$ex_tag")))
+        .then(
+          wasm.call(SILENT_PUSH_SHADOW_STACK_FX).args(local.get("$ex_tag"), local.get("$ex_val")),
+        ),
+      wasm
+        .if(wasm.call(IS_TAG_GCABLE).args(local.get("$ey_tag")))
+        .then(
+          wasm.call(SILENT_PUSH_SHADOW_STACK_FX).args(local.get("$ey_tag"), local.get("$ey_val")),
+        ),
 
       wasm
         .call(COMPARISON_OP_FX)

--- a/src/tests/wasm/wasm-misc.spec.ts
+++ b/src/tests/wasm/wasm-misc.spec.ts
@@ -1,5 +1,6 @@
 import { compileToWasmAndRun } from "../../engines/wasm";
 import { ERROR_MAP, TYPE_TAG } from "../../engines/wasm/runtime";
+import linkedList from "../../stdlib/linked-list";
 import { FeatureNotSupportedError } from "../../validator";
 
 it = it.concurrent;
@@ -188,5 +189,17 @@ y = 10
     const { rawResult, renderedResult } = await compileToWasmAndRun(``);
     expect(rawResult).toBeNull();
     expect(renderedResult).toBeNull();
+  });
+
+  it("Shadow stack-related regression test: comparison between a GCable and a non-GCable operand does not leak either operand", async () => {
+    const pythonCode = `print("asdf" == pair(1,2))`;
+    expect(
+      (await compileToWasmAndRun(pythonCode, true, { chapter: 4, groups: [linkedList] })).errors,
+    ).toEqual([]);
+  });
+
+  it("Shadow stack-related regression test: unary operator on GCable operand does not leak operand", async () => {
+    const pythonCode = `print(-(1+0j))`;
+    expect((await compileToWasmAndRun(pythonCode, true)).errors).toEqual([]);
   });
 });

--- a/src/tests/wasm/wasm-shadow-stack.spec.ts
+++ b/src/tests/wasm/wasm-shadow-stack.spec.ts
@@ -129,6 +129,124 @@ x
     });
   });
 
+  describe("unary/comparison operator shadow stack discipline", () => {
+    it("negating a complex number does not leave a stale operand on the stack", async () => {
+      await expectShadowStackToEqual(`-(2j)`, [TYPE_TAG.COMPLEX]);
+    });
+
+    it("`is` on two complex numbers does not leave stale operands on the stack", async () => {
+      await expectShadowStackToEqual(`2j is 2j`, []);
+    });
+
+    it("`is not` on two complex numbers does not leave stale operands on the stack", async () => {
+      await expectShadowStackToEqual(`2j is not 3j`, []);
+    });
+
+    it("`is` on two strings does not leave stale operands on the stack", async () => {
+      await expectShadowStackToEqual(`"foo" is "foo"`, []);
+    });
+
+    it("`==` on two strings does not leave stale operands on the stack", async () => {
+      await expectShadowStackToEqual(`"foo" == "foo"`, []);
+    });
+
+    it("`<` on two strings does not leave stale operands on the stack", async () => {
+      await expectShadowStackToEqual(`"foo" < "bar"`, []);
+    });
+
+    it("`==` on two complex numbers does not leave stale operands on the stack", async () => {
+      await expectShadowStackToEqual(`2j == 3j`, []);
+    });
+
+    it("`!=` on two complex numbers does not leave stale operands on the stack", async () => {
+      await expectShadowStackToEqual(`2j != 3j`, []);
+    });
+
+    it("`==` comparing a float against a complex does not leave a stale complex operand on the stack", async () => {
+      await expectShadowStackToEqual(`3.0 == 2j`, []);
+    });
+
+    it("`==` on two lists does not leave stale operands on the stack", async () => {
+      await expectShadowStackToEqual(`[1, 2] == [1, 2]`, []);
+    });
+
+    it("`!=` on two lists does not leave stale operands on the stack", async () => {
+      await expectShadowStackToEqual(`[1, 2] != [1, 3]`, []);
+    });
+
+    it("`==` on nested lists does not leave stale operands on the stack", async () => {
+      await expectShadowStackToEqual(`[[1, 2], [3, 4]] == [[1, 2], [3, 4]]`, []);
+    });
+  });
+
+  // ==, !=, is, is not are the only operators typed any,any -> bool (per the
+  // operand-typing table): every other operator restricts at least one side
+  // to a specific type, so those never need to worry about the *other* side
+  // being non-GCable. For these four, left and right are independently
+  // allowed to be GCable or not, so the shadow-stack discipline has to hold
+  // in every combination: both non-GCable (stack should be completely
+  // untouched, not just clean), one side GCable, or both GCable but of
+  // different underlying types (a tag mismatch, which mustn't skip popping
+  // either operand just because it short-circuits to "not equal"/"not
+  // identical" without ever dereferencing).
+  describe("==, !=, is, is not: across any/any operand-typing table", () => {
+    const GCABLE = [
+      { label: "string", literal: `"hello"` },
+      { label: "complex", literal: `2j` },
+      { label: "list", literal: `[1, 2]` },
+      { label: "closure", literal: `(lambda x: x)` },
+    ];
+
+    // Representative non-GCable partners
+    const NON_GCABLE = [
+      { label: "int", literal: `5` },
+      { label: "None", literal: `None` },
+    ];
+
+    const OPS = ["==", "!=", "is", "is not"];
+
+    describe("both non-GCable: shadow stack untouched", () => {
+      for (const op of OPS)
+        for (const left of NON_GCABLE)
+          for (const right of NON_GCABLE)
+            it(`\`${left.literal} ${op} ${right.literal}\` touches nothing`, async () => {
+              await expectShadowStackToEqual(`${left.literal} ${op} ${right.literal}`, []);
+            });
+    });
+
+    describe("left GCable, right non-GCable", () => {
+      for (const op of OPS)
+        for (const left of GCABLE)
+          for (const right of NON_GCABLE)
+            it(`\`${left.literal} ${op} ${right.literal}\` does not leak`, async () => {
+              await expectShadowStackToEqual(`${left.literal} ${op} ${right.literal}`, []);
+            });
+    });
+
+    describe("left non-GCable, right GCable", () => {
+      for (const op of OPS)
+        for (const left of NON_GCABLE)
+          for (const right of GCABLE)
+            it(`\`${left.literal} ${op} ${right.literal}\` does not leak`, async () => {
+              await expectShadowStackToEqual(`${left.literal} ${op} ${right.literal}`, []);
+            });
+    });
+
+    describe("both GCable but different types", () => {
+      const MISMATCHED_PAIRS = [
+        [GCABLE[0], GCABLE[2]], // string vs list
+        [GCABLE[1], GCABLE[3]], // complex vs closure
+        [GCABLE[0], GCABLE[3]], // string vs closure
+      ];
+
+      for (const op of OPS)
+        for (const [left, right] of MISMATCHED_PAIRS)
+          it(`\`${left.literal} ${op} ${right.literal}\` (${left.label} vs ${right.label}) does not leak`, async () => {
+            await expectShadowStackToEqual(`${left.literal} ${op} ${right.literal}`, []);
+          });
+    });
+  });
+
   describe("GET/SET_LEX_ADDRESS", () => {
     it("setting variable to GCable object should pop GCable object off stack", async () => {
       const pythonCode = `x = [1, 2, 3]`;


### PR DESCRIPTION
fixes #324 