### PR TITLE
Add draw_data builtin (Data Visualizer support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,10 +72,12 @@
   },
   "dependencies": {
     "@sourceacademy/common-cse-machine": "^0.3.0",
+    "@sourceacademy/common-data-visualizer": "^0.0.1",
     "@sourceacademy/common-stepper": "^0.0.1",
     "@sourceacademy/conductor": "^0.8.0",
     "@sourceacademy/pynter-wasm": "^0.2.0",
     "@sourceacademy/runner-cse-machine": "^3.0.0",
+    "@sourceacademy/runner-data-visualizer": "^0.0.1",
     "@sourceacademy/runner-module-loader": "^0.0.1",
     "@sourceacademy/runner-stepper": "^0.0.1",
     "@sourceacademy/wasm-util": "^1.0.6",

--- a/src/conductor/PyCseEvaluator.ts
+++ b/src/conductor/PyCseEvaluator.ts
@@ -206,6 +206,15 @@ export class PyCseEvaluator3 extends PyCseEvaluatorBase {
 
 export class PyCseEvaluator4 extends PyCseEvaluatorBase {
   constructor(conductor: IRunnerPlugin) {
-    super(conductor, 4, [misc, math, linkedList, list, pairmutator, stream, parser, dataVisualizer]);
+    super(conductor, 4, [
+      misc,
+      math,
+      linkedList,
+      list,
+      pairmutator,
+      stream,
+      parser,
+      dataVisualizer,
+    ]);
   }
 }

--- a/src/conductor/PyCseEvaluator.ts
+++ b/src/conductor/PyCseEvaluator.ts
@@ -16,6 +16,7 @@ import {
 } from "../engines/cse/streams";
 import { parse } from "../parser/parser-adapter";
 import { analyze } from "../resolver/analysis";
+import dataVisualizer from "../stdlib/dataVisualizer";
 import linkedList from "../stdlib/linked-list";
 import list from "../stdlib/list";
 import math from "../stdlib/math";
@@ -193,18 +194,18 @@ export class PyCseEvaluator1 extends PyCseEvaluatorBase {
 
 export class PyCseEvaluator2 extends PyCseEvaluatorBase {
   constructor(conductor: IRunnerPlugin) {
-    super(conductor, 2, [misc, math, linkedList]);
+    super(conductor, 2, [misc, math, linkedList, dataVisualizer]);
   }
 }
 
 export class PyCseEvaluator3 extends PyCseEvaluatorBase {
   constructor(conductor: IRunnerPlugin) {
-    super(conductor, 3, [misc, math, linkedList, list, pairmutator, stream]);
+    super(conductor, 3, [misc, math, linkedList, list, pairmutator, stream, dataVisualizer]);
   }
 }
 
 export class PyCseEvaluator4 extends PyCseEvaluatorBase {
   constructor(conductor: IRunnerPlugin) {
-    super(conductor, 4, [misc, math, linkedList, list, pairmutator, stream, parser]);
+    super(conductor, 4, [misc, math, linkedList, list, pairmutator, stream, parser, dataVisualizer]);
   }
 }

--- a/src/conductor/PyCseEvaluator.ts
+++ b/src/conductor/PyCseEvaluator.ts
@@ -1,5 +1,6 @@
 import { ErrorType } from "@sourceacademy/conductor/common";
 import { BasicEvaluator, IRunnerPlugin } from "@sourceacademy/conductor/runner";
+import { DATA_VISUALIZER_DIRECTORY_ID } from "@sourceacademy/common-data-visualizer";
 import { CseMachinePlugin } from "@sourceacademy/runner-cse-machine";
 import { ModuleLoaderRunnerPlugin } from "@sourceacademy/runner-module-loader";
 import { Context } from "../engines/cse/context";
@@ -23,6 +24,7 @@ import pairmutator from "../stdlib/pairmutator";
 import parser from "../stdlib/parser";
 import stream from "../stdlib/stream";
 import { Group } from "../stdlib/utils";
+import { PythonDataVisualizerRunnerPlugin } from "./dataVisualizer/PyDataVisualizerRunnerPlugin";
 import { asInterfacableEvaluator, GenericDataHandler } from "./GenericDataHandler";
 import { collectSnapshots } from "./plugins/PyCseMachinePlugin";
 
@@ -47,6 +49,9 @@ abstract class PyCseEvaluatorBase extends BasicEvaluator {
    * type py2js's evaluator uses; only the pythonToModule/moduleToPython
    * conversion layer (modules.ts) is CSE-specific. */
   private readonly dataHandler = new GenericDataHandler();
+  /** Registered only for §2+ — draw_data doesn't exist as a builtin below that, so there's no
+   * reason to register the plugin or have the host fetch its web bundle for §1 users. */
+  private readonly dataVisualizerPlugin?: PythonDataVisualizerRunnerPlugin;
 
   protected constructor(conductor: IRunnerPlugin, variant: number, groups: Group[]) {
     super(conductor);
@@ -60,6 +65,11 @@ abstract class PyCseEvaluatorBase extends BasicEvaluator {
     this.csePlugin = conductor.registerPlugin(
       CseMachinePlugin as never,
     ) as unknown as CseMachinePlugin;
+
+    if (variant >= 2) {
+      this.dataVisualizerPlugin = conductor.registerPlugin(PythonDataVisualizerRunnerPlugin);
+      conductor.hostLoadPlugin(DATA_VISUALIZER_DIRECTORY_ID);
+    }
 
     for (const group of this.groups) {
       for (const [name, value] of group.builtins) {
@@ -99,6 +109,7 @@ abstract class PyCseEvaluatorBase extends BasicEvaluator {
       };
       this.context.conductor = this.conductor;
       this.context.evaluator = this.dataHandler;
+      this.context.dataVisualizer = this.dataVisualizerPlugin ?? null;
       await this.ensurePreludesLoaded();
 
       const script = chunk + "\n";
@@ -125,6 +136,7 @@ abstract class PyCseEvaluatorBase extends BasicEvaluator {
       this.context.runtime.breakpointSteps = [];
       this.context.runtime.changepointSteps = [];
       this.context.runtime.break = false;
+      await this.dataVisualizerPlugin?.resetRun();
 
       // CSE chapters (3+): collect snapshots up to the step cap, then stop.
       // Output produced after the step cap is not emitted — that's intentional.

--- a/src/conductor/dataVisualizer/PyDataVisualizerRunnerPlugin.ts
+++ b/src/conductor/dataVisualizer/PyDataVisualizerRunnerPlugin.ts
@@ -1,0 +1,18 @@
+import { BaseDataVisualizerRunnerPlugin, type RefIdAllocator } from "@sourceacademy/runner-data-visualizer";
+import type { SerializedDataVisualizerNode } from "@sourceacademy/common-data-visualizer";
+
+import { Value } from "../../engines/cse/stash";
+import { toDataVisualizerNode } from "./toDataVisualizerNode";
+
+/**
+ * The py-slang (Python) binding of the language-agnostic data visualizer runner.
+ *
+ * All Python-specific knowledge lives in {@link toDataVisualizerNode}; this class is the thin
+ * adapter `BaseDataVisualizerRunnerPlugin` expects — no cycle-detection or classification here, that
+ * stays host-side, shared across every language. Mirrors `PythonStepperRunnerPlugin`'s shape.
+ */
+export class PythonDataVisualizerRunnerPlugin extends BaseDataVisualizerRunnerPlugin<Value> {
+  protected toNode(value: Value, refs: RefIdAllocator): SerializedDataVisualizerNode {
+    return toDataVisualizerNode(value, refs);
+  }
+}

--- a/src/conductor/dataVisualizer/PyDataVisualizerRunnerPlugin.ts
+++ b/src/conductor/dataVisualizer/PyDataVisualizerRunnerPlugin.ts
@@ -1,4 +1,7 @@
-import { BaseDataVisualizerRunnerPlugin, type RefIdAllocator } from "@sourceacademy/runner-data-visualizer";
+import {
+  BaseDataVisualizerRunnerPlugin,
+  type RefIdAllocator,
+} from "@sourceacademy/runner-data-visualizer";
 import type { SerializedDataVisualizerNode } from "@sourceacademy/common-data-visualizer";
 
 import { Value } from "../../engines/cse/stash";

--- a/src/conductor/dataVisualizer/__tests__/toDataVisualizerNode.test.ts
+++ b/src/conductor/dataVisualizer/__tests__/toDataVisualizerNode.test.ts
@@ -74,7 +74,8 @@ describe("toDataVisualizerNode", () => {
     const node = toDataVisualizerNode(outer, refs);
     if (node.type !== "array") throw new Error("expected an array node");
     const [first, second] = node.children;
-    if (first.type !== "array") throw new Error("expected the first occurrence to be an array node");
+    if (first.type !== "array")
+      throw new Error("expected the first occurrence to be an array node");
     expect(second).toEqual({ type: "ref", refId: first.refId });
   });
 

--- a/src/conductor/dataVisualizer/__tests__/toDataVisualizerNode.test.ts
+++ b/src/conductor/dataVisualizer/__tests__/toDataVisualizerNode.test.ts
@@ -1,0 +1,103 @@
+import { createRefIdAllocator } from "@sourceacademy/runner-data-visualizer";
+import type { SerializedDataVisualizerNode } from "@sourceacademy/common-data-visualizer";
+
+import { Value } from "../../../engines/cse/stash";
+import { toDataVisualizerNode } from "../toDataVisualizerNode";
+
+function num(value: number): Value {
+  return { type: "number", value };
+}
+
+describe("toDataVisualizerNode", () => {
+  test("converts leaf values", () => {
+    const refs = createRefIdAllocator();
+    expect(toDataVisualizerNode(num(42), refs)).toEqual({
+      type: "leaf",
+      displayValue: "42.0",
+      label: "number",
+    });
+    expect(toDataVisualizerNode({ type: "string", value: "hi" }, refs)).toEqual({
+      type: "leaf",
+      displayValue: "hi",
+      label: "string",
+    });
+    expect(toDataVisualizerNode({ type: "bool", value: true }, refs)).toEqual({
+      type: "leaf",
+      displayValue: "True",
+      label: "bool",
+    });
+  });
+
+  test("converts None to the empty terminator", () => {
+    const refs = createRefIdAllocator();
+    expect(toDataVisualizerNode({ type: "none" }, refs)).toEqual({ type: "empty" });
+  });
+
+  test("converts a pair (a length-2 ListValue) to an array node", () => {
+    const refs = createRefIdAllocator();
+    const pair: Value = { type: "list", value: [num(1), num(2)] };
+    const node = toDataVisualizerNode(pair, refs);
+    expect(node).toEqual({
+      type: "array",
+      refId: expect.any(Number),
+      children: [
+        { type: "leaf", displayValue: "1.0", label: "number" },
+        { type: "leaf", displayValue: "2.0", label: "number" },
+      ],
+    });
+  });
+
+  test("converts a longer native list (not fixed at length 2)", () => {
+    const refs = createRefIdAllocator();
+    const list: Value = { type: "list", value: [num(1), num(2), num(3), num(4)] };
+    const node = toDataVisualizerNode(list, refs);
+    if (node.type !== "array") throw new Error("expected an array node");
+    expect(node.children).toHaveLength(4);
+  });
+
+  test("a self-referential list terminates via a ref node instead of recursing forever", () => {
+    const refs = createRefIdAllocator();
+    const xs: Value = { type: "list", value: [num(1)] };
+    xs.value.push(xs);
+
+    const node = toDataVisualizerNode(xs, refs);
+    if (node.type !== "array") throw new Error("expected an array node");
+    expect(node.children[0]).toEqual({ type: "leaf", displayValue: "1.0", label: "number" });
+    expect(node.children[1]).toEqual({ type: "ref", refId: node.refId });
+  });
+
+  test("a shared-but-acyclic list is referenced the second time, not re-walked", () => {
+    const refs = createRefIdAllocator();
+    const shared: Value = { type: "list", value: [num(9)] };
+    const outer: Value = { type: "list", value: [shared, shared] };
+
+    const node = toDataVisualizerNode(outer, refs);
+    if (node.type !== "array") throw new Error("expected an array node");
+    const [first, second] = node.children;
+    if (first.type !== "array") throw new Error("expected the first occurrence to be an array node");
+    expect(second).toEqual({ type: "ref", refId: first.refId });
+  });
+
+  test("closures/functions become function nodes, referenced by identity on repeat occurrence", () => {
+    const refs = createRefIdAllocator();
+    const fn: Value = {
+      type: "function",
+      name: "f",
+      params: [],
+      body: [],
+      env: { tail: null, name: "global", head: {}, id: "-1" },
+    };
+
+    const first = toDataVisualizerNode(fn, refs);
+    const second = toDataVisualizerNode(fn, refs);
+    if (first.type !== "function") throw new Error("expected a function node");
+    expect(second).toEqual({ type: "ref", refId: first.refId });
+  });
+
+  test("unrecognized-in-this-context values (error/opaque) fall back to a leaf rather than throwing", () => {
+    const refs = createRefIdAllocator();
+    const errorValue: Value = { type: "error", message: "boom" };
+    const node: SerializedDataVisualizerNode = toDataVisualizerNode(errorValue, refs);
+    expect(node).toEqual({ type: "leaf", displayValue: "boom", label: "error" });
+  });
+});

--- a/src/conductor/dataVisualizer/toDataVisualizerNode.ts
+++ b/src/conductor/dataVisualizer/toDataVisualizerNode.ts
@@ -14,7 +14,10 @@ import { toPythonString } from "../../stdlib/utils";
  * list, regardless of length, becomes the wire format's N-ary `"array"` node; the host distinguishes
  * "pair" from "list" by `children.length`, not by tag.
  */
-export function toDataVisualizerNode(value: Value, refs: RefIdAllocator): SerializedDataVisualizerNode {
+export function toDataVisualizerNode(
+  value: Value,
+  refs: RefIdAllocator,
+): SerializedDataVisualizerNode {
   switch (value.type) {
     case "none":
       return { type: "empty" };

--- a/src/conductor/dataVisualizer/toDataVisualizerNode.ts
+++ b/src/conductor/dataVisualizer/toDataVisualizerNode.ts
@@ -1,0 +1,54 @@
+import type { RefIdAllocator } from "@sourceacademy/runner-data-visualizer";
+import type { SerializedDataVisualizerNode } from "@sourceacademy/common-data-visualizer";
+
+import { Value } from "../../engines/cse/stash";
+import { toPythonString } from "../../stdlib/utils";
+
+/**
+ * Converts one py-slang runtime {@link Value} into a {@link SerializedDataVisualizerNode}. Purely
+ * mechanical — dispatches on `Value.type` and recurses into list elements. No cycle-detection or
+ * classification happens here; that's entirely the host's job (see `BaseDataVisualizerRunnerPlugin`'s
+ * doc comment in `@sourceacademy/runner-data-visualizer`).
+ *
+ * A SICP §2 pair *is* a length-2 `ListValue` in py-slang — there's no separate pair type — so every
+ * list, regardless of length, becomes the wire format's N-ary `"array"` node; the host distinguishes
+ * "pair" from "list" by `children.length`, not by tag.
+ */
+export function toDataVisualizerNode(value: Value, refs: RefIdAllocator): SerializedDataVisualizerNode {
+  switch (value.type) {
+    case "none":
+      return { type: "empty" };
+    case "list": {
+      const { refId, alreadySeen } = refs.get(value);
+      if (alreadySeen) {
+        return { type: "ref", refId };
+      }
+      return {
+        type: "array",
+        refId,
+        children: value.value.map(element => toDataVisualizerNode(element, refs)),
+      };
+    }
+    case "closure":
+    case "function":
+    case "multi_lambda":
+    case "builtin": {
+      const { refId, alreadySeen } = refs.get(value);
+      if (alreadySeen) {
+        return { type: "ref", refId };
+      }
+      return { type: "function", refId, displayValue: toPythonString(value) };
+    }
+    case "number":
+    case "bool":
+    case "complex":
+    case "string":
+    case "error":
+    case "bigint":
+    case "opaque":
+      return { type: "leaf", displayValue: toPythonString(value), label: value.type };
+    default:
+      value satisfies never;
+      return { type: "leaf", displayValue: String(value), label: "unknown" };
+  }
+}

--- a/src/engines/cse/context.ts
+++ b/src/engines/cse/context.ts
@@ -1,12 +1,13 @@
 import { ConductorError } from "@sourceacademy/conductor/common";
 import { IRunnerPlugin } from "@sourceacademy/conductor/runner";
 import { IDataHandler } from "@sourceacademy/conductor/types";
+import { BaseDataVisualizerRunnerPlugin } from "@sourceacademy/runner-data-visualizer";
 import { StmtNS } from "../../ast-types";
 import { RuntimeSourceError } from "../../errors";
 import { NativeStorage } from "../../types";
 import { Control } from "./control";
 import { Environment } from "./environment";
-import { BuiltinValue, Stash } from "./stash";
+import { BuiltinValue, Stash, Value } from "./stash";
 import { InputStreamContext, WritableContext } from "./streams";
 import { Node } from "./types";
 
@@ -21,6 +22,11 @@ export class Context {
 
   public conductor: IRunnerPlugin | null = null;
   public evaluator: IDataHandler | null = null;
+  /** Set by the evaluator when a data-visualizer runner is registered (§2+); the `draw_data`
+   * builtin sends through this. Typed against the external abstract base, not the local concrete
+   * `PythonDataVisualizerRunnerPlugin` subclass, matching how `conductor`/`evaluator` above are
+   * typed by interface rather than by concrete class. */
+  public dataVisualizer: BaseDataVisualizerRunnerPlugin<Value> | null = null;
 
   public streams:
     | {

--- a/src/stdlib/dataVisualizer.ts
+++ b/src/stdlib/dataVisualizer.ts
@@ -1,0 +1,43 @@
+import { ExprNS } from "../ast-types";
+import { Context } from "../engines/cse/context";
+import { BuiltinValue, NoneValue, Value } from "../engines/cse/stash";
+import { GroupName, minArgMap, Validate } from "./utils";
+
+const dataVisualizerBuiltins = new Map<string, BuiltinValue>();
+
+export class DataVisualizerBuiltins {
+  // Minimum 2 args per python_2_specs.md's own documented signature:
+  // `def draw_data(value1, value2, *values)` — diverges from js-slang's minimum of 1.
+  @Validate(2, null, "draw_data", true)
+  static async draw_data(
+    args: Value[],
+    _source: string,
+    _command: ExprNS.Call,
+    context: Context,
+  ): Promise<NoneValue> {
+    await context.dataVisualizer?.sendDrawing(args);
+    return { type: "none" };
+  }
+}
+
+for (const builtin of Object.getOwnPropertyNames(DataVisualizerBuiltins)) {
+  if (
+    typeof DataVisualizerBuiltins[builtin as keyof typeof DataVisualizerBuiltins] === "function" &&
+    !builtin.startsWith("_")
+  ) {
+    dataVisualizerBuiltins.set(builtin, {
+      type: "builtin",
+      func: DataVisualizerBuiltins[
+        builtin as keyof typeof DataVisualizerBuiltins
+      ] as BuiltinValue["func"],
+      name: builtin,
+      minArgs: minArgMap.get(builtin) || 0,
+    });
+  }
+}
+
+export default {
+  name: GroupName.DATA_VISUALIZER,
+  prelude: "",
+  builtins: dataVisualizerBuiltins,
+};

--- a/src/stdlib/utils.ts
+++ b/src/stdlib/utils.ts
@@ -13,6 +13,7 @@ export enum GroupName {
   LIST = "list",
   PAIRMUTATORS = "pair-mutators",
   MCE = "mce",
+  DATA_VISUALIZER = "data-visualizer",
 }
 
 /**

--- a/src/tests/dataVisualizer.test.ts
+++ b/src/tests/dataVisualizer.test.ts
@@ -1,0 +1,21 @@
+import { MissingRequiredPositionalError } from "../errors";
+import dataVisualizer from "../stdlib/dataVisualizer";
+import linkedList from "../stdlib/linked-list";
+import math from "../stdlib/math";
+import misc from "../stdlib/misc";
+import { generateTestCases, TestCases } from "./utils";
+
+describe("Data Visualizer Tests", () => {
+  const dataVisualizerTests: TestCases = {
+    "arity and return value": [
+      ["draw_data()", MissingRequiredPositionalError, null],
+      ["draw_data(1)", MissingRequiredPositionalError, null],
+      // context.dataVisualizer is unset outside a real Conductor run (no plugin registered in
+      // this harness) — draw_data still validates arity and returns None without crashing.
+      ["draw_data(1, 2)", null, null],
+      ["draw_data(1, 2, 3)", null, null],
+    ],
+  };
+
+  generateTestCases(dataVisualizerTests, 2, [misc, math, linkedList, dataVisualizer]);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,6 +1643,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sourceacademy/common-data-visualizer@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "@sourceacademy/common-data-visualizer@npm:0.0.1"
+  checksum: 10c0/ce926ba006bf5a6ed6d06fd318c51089be4015596b0b98a52b2160fde1834e1f968a4bdbfb9685e6990505836cdf2c6ac42ce77abfbf3ab58fcb3ed0d5e2402d
+  languageName: node
+  linkType: hard
+
 "@sourceacademy/common-stepper@npm:^0.0.1":
   version: 0.0.1
   resolution: "@sourceacademy/common-stepper@npm:0.0.1"
@@ -1670,10 +1677,12 @@ __metadata:
     "@rollup/plugin-typescript": "npm:^12.1.2"
     "@rollup/plugin-wasm": "npm:^6.2.2"
     "@sourceacademy/common-cse-machine": "npm:^0.3.0"
+    "@sourceacademy/common-data-visualizer": "npm:^0.0.1"
     "@sourceacademy/common-stepper": "npm:^0.0.1"
     "@sourceacademy/conductor": "npm:^0.8.2"
     "@sourceacademy/pynter-wasm": "npm:^0.2.0"
     "@sourceacademy/runner-cse-machine": "npm:^3.0.0"
+    "@sourceacademy/runner-data-visualizer": "npm:^0.0.1"
     "@sourceacademy/runner-module-loader": "npm:^0.0.1"
     "@sourceacademy/runner-stepper": "npm:^0.0.1"
     "@sourceacademy/wasm-util": "npm:^1.0.6"
@@ -1718,6 +1727,15 @@ __metadata:
     "@sourceacademy/common-cse-machine": ">=0.3.0"
     "@sourceacademy/conductor": ">=0.3.0"
   checksum: 10c0/dbf3c9220bb35b2f10d46dcfd13e1c827931d9bb9fb41266eff512d5859ab7734e594cda3b0e741a9896e8f7a3598cdb4d914ef13b7ecce941f8fc1798d8965e
+  languageName: node
+  linkType: hard
+
+"@sourceacademy/runner-data-visualizer@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "@sourceacademy/runner-data-visualizer@npm:0.0.1"
+  peerDependencies:
+    "@sourceacademy/conductor": ">=0.3.0"
+  checksum: 10c0/d5e1530c90e9508ed8e32f23d906fdd46696f94ac720c0c7c11c5d57fbe1781c54ca91741c22b099779f2f9937c24b6ecf426daa59fe6db14376e6793414c849
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Wires `draw_data` up for Python, on top of the Conductor Data Visualizer plugin ([source-academy/plugins PR](https://github.com/source-academy/plugins/pull/71), opened alongside this one). Python's side is intentionally thin and mechanical — all cycle-detection, shared-structure handling, and rendering lives host-side (shared across every future language), per the architecture in that PR.

- `src/conductor/dataVisualizer/toDataVisualizerNode.ts` — pure adapter, dispatches on `Value.type`, reuses `toPythonString` for leaf/function display values.
- `src/conductor/dataVisualizer/PyDataVisualizerRunnerPlugin.ts` — ~10-line subclass of `BaseDataVisualizerRunnerPlugin<Value>`.
- `src/stdlib/dataVisualizer.ts` — the `draw_data` builtin itself, `@Validate(2, null, "draw_data", true)` (min 2 args — `python_2_specs.md` documents the signature as `draw_data(value1, value2, *values)`).
- `src/conductor/PyCseEvaluator.ts` / `src/engines/cse/context.ts` — registers the plugin and calls `hostLoadPlugin` for chapter ≥2, resets it each run alongside the other per-run plugin resets.

## Note on dependencies

`package.json` declares normal version ranges (`^0.0.1`) for `@sourceacademy/common-data-visualizer`/`@sourceacademy/runner-data-visualizer`, matching every other `@sourceacademy/*` dependency here — but those packages aren't published to npm yet (that happens when the paired `plugins` PR merges). Until then, `yarn install` here needs a temporary portal-link override, e.g.:
```json
"resolutions": {
  "@sourceacademy/common-data-visualizer": "portal:../plugins/src/common/data-visualizer",
  "@sourceacademy/runner-data-visualizer": "portal:../plugins/src/runner/data-visualizer"
}
```
(not committed — just needed for local review/CI until the plugins PR publishes.)

## Bugs found and fixed elsewhere during this work

Not part of this PR's diff, but surfaced while testing it end-to-end:

- **[source-academy/conductor#63](https://github.com/source-academy/conductor/issues/63)** — filed. A real upstream bug in the published `@sourceacademy/conductor` package (confirmed present through 0.8.2): duplicate, divergent compiled chunks for the runner-side plugin-loading logic, which can make `hostLoadPlugin()` fail with `TypeError: self[fn] is not a function` depending on which chunk a given build happens to route to.
- **[source-academy/py-slang#356](https://github.com/source-academy/py-slang/issues/356)** — commented with a root-caused fix location. Pre-existing, unrelated to `draw_data`: `x = pair(1, None); x[1] = x` crashes with "Maximum call stack size exceeded" — traced (via sourcemapped stack trace) to `PyCseMachinePlugin.ts:70`'s `formatValue()`, whose `"list"` case recurses with no cycle guard, unlike the identity-tracking (`_listIdMap`/`getListId`) already present a few lines above it for a different purpose.

## Test plan

- [x] `src/conductor/dataVisualizer/__tests__/toDataVisualizerNode.test.ts` — leaf values, pairs, longer lists, a hand-built self-referential list (asserts the walk terminates via a "ref" node), shared-non-cyclic structure.
- [x] `src/tests/dataVisualizer.test.ts` — arity errors, return value, chapter gating.
- [x] Live-tested end-to-end via Playwright against a real Python §4 evaluator with the paired `plugins`/`plugin-directory`/`frontend` branches.
