### PR TITLE
Add draw_data to the py2js engine

### DIFF
--- a/src/conductor/Py2JsEvaluator.ts
+++ b/src/conductor/Py2JsEvaluator.ts
@@ -1,6 +1,8 @@
 import { BasicEvaluator, IRunnerPlugin } from "@sourceacademy/conductor/runner";
+import { DATA_VISUALIZER_DIRECTORY_ID } from "@sourceacademy/common-data-visualizer";
 import { ModuleLoaderRunnerPlugin } from "@sourceacademy/runner-module-loader";
 import { Py2JsSession } from "../engines/py2js";
+import { Py2JsDataVisualizerRunnerPlugin } from "./dataVisualizer/Py2JsDataVisualizerRunnerPlugin";
 import { asInterfacableEvaluator, GenericDataHandler } from "./GenericDataHandler";
 import { EvaluatorError } from "./errors";
 
@@ -45,9 +47,15 @@ import { EvaluatorError } from "./errors";
  * whatever grace window the host happens to allow after a chunk resolves).
  *
  * Chapters 1-4 (the engine rejects other variants).
+ *
+ * draw_data (chapter 2+, bridged natively as part of the LINKED_LISTS group — see
+ * stdlibBridge.ts's nativeDrawData): registered only for §2+, exactly mirroring
+ * PyCseEvaluatorBase's identical gate — draw_data doesn't exist as a builtin below that, so there's
+ * no reason to register the plugin or have the host fetch its web bundle for §1 users.
  */
 abstract class Py2JsEvaluatorBase extends BasicEvaluator {
   private readonly session: Py2JsSession;
+  private readonly dataVisualizerPlugin?: Py2JsDataVisualizerRunnerPlugin;
 
   protected constructor(conductor: IRunnerPlugin, variant: number) {
     super(conductor);
@@ -57,16 +65,24 @@ abstract class Py2JsEvaluatorBase extends BasicEvaluator {
       this.conductor,
       asInterfacableEvaluator(this, dataHandler),
     );
+
+    if (variant >= 2) {
+      this.dataVisualizerPlugin = conductor.registerPlugin(Py2JsDataVisualizerRunnerPlugin);
+      conductor.hostLoadPlugin(DATA_VISUALIZER_DIRECTORY_ID);
+    }
+
     this.session = new Py2JsSession(variant, {
       onOutput: line => this.conductor.sendOutput(line),
       onPendingWorkChange: delta => (delta > 0 ? this.beginPendingWork() : this.endPendingWork()),
       requestInput: prompt => this.conductor.requestInput(prompt),
       dataHandler,
+      dataVisualizer: this.dataVisualizerPlugin,
     });
   }
 
   async evaluateChunk(chunk: string): Promise<void> {
     try {
+      await this.dataVisualizerPlugin?.resetRun();
       await this.session.runChunk(chunk);
       this.conductor.sendResult(undefined);
     } catch (e) {

--- a/src/conductor/dataVisualizer/Py2JsDataVisualizerRunnerPlugin.ts
+++ b/src/conductor/dataVisualizer/Py2JsDataVisualizerRunnerPlugin.ts
@@ -1,0 +1,22 @@
+import {
+  BaseDataVisualizerRunnerPlugin,
+  type RefIdAllocator,
+} from "@sourceacademy/runner-data-visualizer";
+import type { SerializedDataVisualizerNode } from "@sourceacademy/common-data-visualizer";
+
+import type { PyValue } from "../../engines/py2js/runtime";
+import { toDataVisualizerNodePy2Js } from "./toDataVisualizerNodePy2Js";
+
+/**
+ * The py2js engine's binding of the language-agnostic data visualizer runner — the native-value
+ * counterpart of `PythonDataVisualizerRunnerPlugin` (the CSE machine's binding).
+ *
+ * All py2js-specific knowledge lives in {@link toDataVisualizerNodePy2Js}; this class is the thin
+ * adapter `BaseDataVisualizerRunnerPlugin` expects — no cycle-detection or classification here, that
+ * stays host-side, shared across every language and every engine.
+ */
+export class Py2JsDataVisualizerRunnerPlugin extends BaseDataVisualizerRunnerPlugin<PyValue> {
+  protected toNode(value: PyValue, refs: RefIdAllocator): SerializedDataVisualizerNode {
+    return toDataVisualizerNodePy2Js(value, refs);
+  }
+}

--- a/src/conductor/dataVisualizer/__tests__/toDataVisualizerNodePy2Js.test.ts
+++ b/src/conductor/dataVisualizer/__tests__/toDataVisualizerNodePy2Js.test.ts
@@ -1,0 +1,105 @@
+import { createRefIdAllocator } from "@sourceacademy/runner-data-visualizer";
+
+import { PyComplexNumber } from "../../../types/value-types";
+import { PyOpaque, type PyValue } from "../../../engines/py2js/runtime";
+import { toDataVisualizerNodePy2Js } from "../toDataVisualizerNodePy2Js";
+
+describe("toDataVisualizerNodePy2Js", () => {
+  test("converts leaf values", () => {
+    const refs = createRefIdAllocator();
+    expect(toDataVisualizerNodePy2Js(42n, refs)).toEqual({
+      type: "leaf",
+      displayValue: "42",
+      label: "bigint",
+    });
+    expect(toDataVisualizerNodePy2Js(2.5, refs)).toEqual({
+      type: "leaf",
+      displayValue: "2.5",
+      label: "number",
+    });
+    expect(toDataVisualizerNodePy2Js("hi", refs)).toEqual({
+      type: "leaf",
+      displayValue: "hi",
+      label: "string",
+    });
+    expect(toDataVisualizerNodePy2Js(true, refs)).toEqual({
+      type: "leaf",
+      displayValue: "True",
+      label: "bool",
+    });
+    const complex = new PyComplexNumber(1, 2);
+    expect(toDataVisualizerNodePy2Js(complex, refs)).toEqual({
+      type: "leaf",
+      displayValue: complex.toString(),
+      label: "complex",
+    });
+  });
+
+  test("converts None to the empty terminator", () => {
+    const refs = createRefIdAllocator();
+    expect(toDataVisualizerNodePy2Js(null, refs)).toEqual({ type: "empty" });
+  });
+
+  test("converts a pair (a length-2 PyList) to an array node", () => {
+    const refs = createRefIdAllocator();
+    const pair: PyValue = [1n, 2n];
+    const node = toDataVisualizerNodePy2Js(pair, refs);
+    expect(node).toEqual({
+      type: "array",
+      refId: expect.any(Number),
+      children: [
+        { type: "leaf", displayValue: "1", label: "bigint" },
+        { type: "leaf", displayValue: "2", label: "bigint" },
+      ],
+    });
+  });
+
+  test("converts a longer native list (not fixed at length 2)", () => {
+    const refs = createRefIdAllocator();
+    const list: PyValue = [1n, 2n, 3n, 4n];
+    const node = toDataVisualizerNodePy2Js(list, refs);
+    if (node.type !== "array") throw new Error("expected an array node");
+    expect(node.children).toHaveLength(4);
+  });
+
+  test("a self-referential list terminates via a ref node instead of recursing forever", () => {
+    const refs = createRefIdAllocator();
+    const xs: PyValue[] = [1n];
+    xs.push(xs);
+
+    const node = toDataVisualizerNodePy2Js(xs, refs);
+    if (node.type !== "array") throw new Error("expected an array node");
+    expect(node.children[0]).toEqual({ type: "leaf", displayValue: "1", label: "bigint" });
+    expect(node.children[1]).toEqual({ type: "ref", refId: node.refId });
+  });
+
+  test("a shared-but-acyclic list is referenced the second time, not re-walked", () => {
+    const refs = createRefIdAllocator();
+    const shared: PyValue = [9n];
+    const outer: PyValue = [shared, shared];
+
+    const node = toDataVisualizerNodePy2Js(outer, refs);
+    if (node.type !== "array") throw new Error("expected an array node");
+    const [first, second] = node.children;
+    if (first.type !== "array")
+      throw new Error("expected the first occurrence to be an array node");
+    expect(second).toEqual({ type: "ref", refId: first.refId });
+  });
+
+  test("functions become function nodes, referenced by identity on repeat occurrence", () => {
+    const refs = createRefIdAllocator();
+    const fn = Object.assign((x: PyValue) => x, { pyName: "f", pyArity: 1, pyBuiltin: false });
+
+    const first = toDataVisualizerNodePy2Js(fn, refs);
+    const second = toDataVisualizerNodePy2Js(fn, refs);
+    if (first.type !== "function") throw new Error("expected a function node");
+    expect(second).toEqual({ type: "ref", refId: first.refId });
+  });
+
+  test("an opaque module value falls back to a leaf rather than throwing", () => {
+    const refs = createRefIdAllocator();
+    const opaque = new PyOpaque({} as never);
+    const node = toDataVisualizerNodePy2Js(opaque, refs);
+    expect(node).toEqual({ type: "leaf", displayValue: "<opaque object>", label: "opaque" });
+  });
+});

--- a/src/conductor/dataVisualizer/toDataVisualizerNodePy2Js.ts
+++ b/src/conductor/dataVisualizer/toDataVisualizerNodePy2Js.ts
@@ -1,0 +1,61 @@
+import type { RefIdAllocator } from "@sourceacademy/runner-data-visualizer";
+import type { SerializedDataVisualizerNode } from "@sourceacademy/common-data-visualizer";
+
+import { PyOpaque, type PyValue, pyStr } from "../../engines/py2js/runtime";
+
+/**
+ * Converts one py2js runtime {@link PyValue} into a {@link SerializedDataVisualizerNode}. The py2js
+ * counterpart of `toDataVisualizerNode.ts` (which does the same for the CSE machine's tagged
+ * `Value`) — purely mechanical, dispatches on the native (unboxed) value's own JS shape and recurses
+ * into list elements. No cycle-detection or classification happens here; that's entirely the host's
+ * job (see `BaseDataVisualizerRunnerPlugin`'s doc comment in `@sourceacademy/runner-data-visualizer`).
+ *
+ * Deliberately does NOT reuse stdlibBridge.ts's toTagged/CSE-Value round-trip: that conversion walks
+ * a pair/list's spine with no cycle guard (relies on no bridged builtin ever being handed a genuinely
+ * self-referential structure), whereas a `draw_data`d structure can be exactly that (chapter 3+'s
+ * set_head/set_tail build real cycles) — walking native PyValues directly and leaning on `refs` here,
+ * the same way the CSE adapter does, is what makes a cyclic argument terminate via a "ref" node
+ * instead of hanging.
+ *
+ * A SICP §2 pair *is* a length-2 `PyList` in py2js (runtime.ts) — there's no separate pair type — so
+ * every list, regardless of length, becomes the wire format's N-ary `"array"` node; the host
+ * distinguishes "pair" from "list" by `children.length`, not by tag. Leaf labels ("bigint", "number",
+ * "bool", "string", "complex", "opaque") match the CSE adapter's `Value.type` labels exactly, since
+ * the host's `formatLeaf` special-cases `label === "string"` for quoting and nothing else.
+ */
+export function toDataVisualizerNodePy2Js(
+  value: PyValue,
+  refs: RefIdAllocator,
+): SerializedDataVisualizerNode {
+  switch (typeof value) {
+    case "bigint":
+      return { type: "leaf", displayValue: pyStr(value), label: "bigint" };
+    case "number":
+      return { type: "leaf", displayValue: pyStr(value), label: "number" };
+    case "boolean":
+      return { type: "leaf", displayValue: pyStr(value), label: "bool" };
+    case "string":
+      return { type: "leaf", displayValue: pyStr(value), label: "string" };
+    case "function": {
+      const { refId, alreadySeen } = refs.get(value);
+      if (alreadySeen) return { type: "ref", refId };
+      return { type: "function", refId, displayValue: pyStr(value) };
+    }
+    default:
+      if (value === null) return { type: "empty" };
+      if (Array.isArray(value)) {
+        const { refId, alreadySeen } = refs.get(value);
+        if (alreadySeen) return { type: "ref", refId };
+        return {
+          type: "array",
+          refId,
+          children: value.map(element => toDataVisualizerNodePy2Js(element, refs)),
+        };
+      }
+      if (value instanceof PyOpaque) {
+        return { type: "leaf", displayValue: pyStr(value), label: "opaque" };
+      }
+      // PyComplexNumber, the only PyValue variant left.
+      return { type: "leaf", displayValue: pyStr(value), label: "complex" };
+  }
+}

--- a/src/engines/py2js/index.ts
+++ b/src/engines/py2js/index.ts
@@ -14,6 +14,7 @@
  * src/tests/operator-conformance-py2js.test.ts.
  */
 import { IDataHandler } from "@sourceacademy/conductor/types";
+import type { BaseDataVisualizerRunnerPlugin } from "@sourceacademy/runner-data-visualizer";
 import { GenericDataHandler } from "../../conductor/GenericDataHandler";
 import { parse } from "../../parser";
 import { Resolver } from "../../resolver";
@@ -273,6 +274,14 @@ export interface Py2JsSessionOptions extends RunPy2JsOptions {
    */
   requestInput?: (prompt?: string) => Promise<string>;
   /**
+   * The host conductor's data visualizer plugin, threaded down to draw_data (bridged as one of the
+   * LINKED_LISTS group's native builtins — see stdlibBridge.ts's nativeDrawData). The conductor
+   * evaluator (Py2JsEvaluator.ts) registers and supplies its own instance for chapter 2+, mirroring
+   * PyCseEvaluatorBase's identical registration; left unset for standalone/test use (runCodePy2Js et
+   * al. never pass one), in which case draw_data is a silent no-op.
+   */
+  dataVisualizer?: BaseDataVisualizerRunnerPlugin<PyValue>;
+  /**
    * `__program__`'s value for this session — "the string representation of
    * the editor content at the time when 'Run' was last pressed" per
    * docs/specs/python_interpreter.tex, for the REPL case. Mirrors
@@ -333,7 +342,7 @@ export class Py2JsSession {
     // Same builtin layering as prepare(): bridged stdlib under the native
     // core, extraBuiltins over everything. The bridge's source string is
     // empty — its synthetic error nodes never point at real chunk text.
-    const bridged = bridgeStdlibGroups(this.rt, this.groups, "", variant);
+    const bridged = bridgeStdlibGroups(this.rt, this.groups, "", variant, options.dataVisualizer);
     for (const [name, value] of Object.entries(bridged)) {
       if (!(name in this.rt.builtins)) this.rt.builtins[name] = value;
     }

--- a/src/engines/py2js/stdlibBridge.ts
+++ b/src/engines/py2js/stdlibBridge.ts
@@ -42,6 +42,8 @@
  * bridged builtins carry pyMinArgs so it reports the same numbers the CSE
  * machine does.
  */
+import type { BaseDataVisualizerRunnerPlugin } from "@sourceacademy/runner-data-visualizer";
+
 import { ExprNS } from "../../ast-types";
 import { RuntimeSourceError } from "../../errors";
 import { Token, TokenType } from "../../tokenizer";
@@ -387,6 +389,45 @@ function nativeApplyInUnderlyingPython(rt: Py2JsRuntime): PyFunction {
 }
 
 /**
+ * draw_data(value1, value2, *values) (bridged as part of the LINKED_LISTS group, alongside
+ * pair/llist/head/tail — available from chapter 2 onward, matching python_2_specs.md's own
+ * documented signature and CSE's identical chapter gating). Reimplemented natively rather than
+ * through the generic bridge for two reasons:
+ *
+ *  - toTagged/toTaggedList (above) walk a pair/list's spine with no cycle guard — fine for every
+ *    other bridged builtin, none of which is ever handed a genuinely self-referential structure in
+ *    practice, but chapter 3+'s set_head/set_tail can build exactly that, and a user visualizing such
+ *    a structure is precisely the case draw_data exists to handle gracefully (a "ref" node, not a
+ *    hang). Passing the native args straight to the plugin's sendDrawing — which walks them via
+ *    toDataVisualizerNodePy2Js (conductor/dataVisualizer/), with its own refs-based cycle guard —
+ *    avoids that conversion entirely.
+ *  - sendDrawing is synchronous and fire-and-forget (a channel send), so there is no async result to
+ *    thread back through the generic bridge's Value round-trip in the first place.
+ *
+ * `plugin` is undefined below chapter 2 (bridgeStdlibGroups is never called with one there — see
+ * Py2JsEvaluator.ts) and in every standalone/test run (runCodePy2Js et al. pass no dataVisualizer
+ * option), in which case this is a silent no-op, exactly like context.dataVisualizer?.sendDrawing(...)
+ * on the CSE side when no host conductor is attached.
+ */
+function nativeDrawData(plugin: BaseDataVisualizerRunnerPlugin<PyValue> | undefined): PyFunction {
+  const f = ((...args: PyValue[]) => {
+    if (args.length < 2) {
+      throw new Py2JsRuntimeError(
+        "TypeError",
+        `draw_data() takes at least 2 arguments (${args.length} given)`,
+      );
+    }
+    plugin?.sendDrawing(args);
+    return null;
+  }) as PyFunction;
+  f.pyName = "draw_data";
+  f.pyArity = -1;
+  f.pyBuiltin = true;
+  f.pyMinArgs = 2;
+  return f;
+}
+
+/**
  * Bridge every builtin (and constant) of the given stdlib groups into py2js
  * native values. `source` is the program text, used by stdlib error
  * constructors for their (currently synthetic) location info.
@@ -396,6 +437,7 @@ export function bridgeStdlibGroups(
   groups: Group[],
   source: string,
   variant: number,
+  dataVisualizer?: BaseDataVisualizerRunnerPlugin<PyValue>,
 ): Record<string, PyValue> {
   const context = new Context();
   context.variant = variant;
@@ -407,9 +449,8 @@ export function bridgeStdlibGroups(
           ? bridgeBuiltin(rt, name, value, context, source)
           : fromTagged(name, value);
     }
-    // See nativeSetPairSlot/nativeStream's doc comments for why these two
-    // groups' primitives are reimplemented natively instead of left as the
-    // generic bridge produced above.
+    // See nativeSetPairSlot/nativeStream/nativeDrawData's doc comments for why these groups'
+    // primitives are reimplemented natively instead of left as the generic bridge produced above.
     if (group.name === GroupName.PAIRMUTATORS) {
       out.set_head = nativeSetPairSlot("set_head", 0, variant <= 2);
       out.set_tail = nativeSetPairSlot("set_tail", 1, variant <= 2);
@@ -419,6 +460,12 @@ export function bridgeStdlibGroups(
     }
     if (group.name === GroupName.MCE) {
       out.apply_in_underlying_python = nativeApplyInUnderlyingPython(rt);
+    }
+    // LINKED_LISTS (pair/llist/head/tail) is chapter 2's own "list library" — draw_data belongs
+    // alongside it rather than in its own group (unlike the CSE machine, which uses a dedicated
+    // DATA_VISUALIZER group), so it inherits the exact same chapter-2-onward availability.
+    if (group.name === GroupName.LINKED_LISTS) {
+      out.draw_data = nativeDrawData(dataVisualizer);
     }
   }
   return out;

--- a/src/tests/Py2JsEvaluator.test.ts
+++ b/src/tests/Py2JsEvaluator.test.ts
@@ -13,7 +13,12 @@ import { Py2JsEvaluator1, Py2JsEvaluator2 } from "../conductor/Py2JsEvaluator";
 /** Minimal IRunnerPlugin mock: the evaluator calls sendResult/sendError/
  * sendOutput on its `conductor`, plus registerPlugin once in its constructor
  * (module-loader registration — see Py2JsEvaluator.ts); no test here imports
- * anything, so the stub just needs to exist, not do anything real. */
+ * anything, so the stub just needs to exist, not do anything real.
+ * hostLoadPlugin is called (chapter 2+ only) to fetch the data visualizer's
+ * host bundle — no test here opens that tab, so it's a no-op stub too;
+ * registerPlugin returning undefined means draw_data (also chapter 2+) is
+ * exercised against no plugin, the same "no real Conductor run" case
+ * dataVisualizer.test.ts covers on the CSE side. */
 function makeMockConductor() {
   const results: unknown[] = [];
   const errors: { name: string; message: string }[] = [];
@@ -23,6 +28,7 @@ function makeMockConductor() {
     sendError: (e: unknown) => errors.push(e as { name: string; message: string }),
     sendOutput: (m: string) => outputs.push(m),
     registerPlugin: () => undefined,
+    hostLoadPlugin: () => undefined,
   } as unknown as IRunnerPlugin;
   return { conductor, results, errors, outputs };
 }
@@ -129,6 +135,16 @@ describe("Py2JsEvaluator1", () => {
     expect(errors).toEqual([]);
     expect(outputs).toEqual(["1", "a b", ""]);
   });
+
+  test("draw_data doesn't exist as a name below chapter 2", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new Py2JsEvaluator1(conductor);
+
+    await evaluator.evaluateChunk("draw_data(1, 2)\n");
+
+    expect(errors).toHaveLength(1);
+    expect(outputs).toEqual([]);
+  });
 });
 
 describe("Py2JsEvaluator2", () => {
@@ -153,5 +169,27 @@ describe("Py2JsEvaluator2", () => {
 
     expect(errors).toEqual([]);
     expect(outputs).toEqual(["[2, [4, None]]"]);
+  });
+
+  test("draw_data validates arity, and returns None without a real Conductor-attached plugin", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new Py2JsEvaluator2(conductor);
+
+    await evaluator.evaluateChunk("draw_data()\n");
+    expect(errors).toHaveLength(1);
+    expect(errors[0].name).toBe("TypeError");
+
+    await evaluator.evaluateChunk("draw_data(1)\n");
+    expect(errors).toHaveLength(2);
+    expect(errors[1].name).toBe("TypeError");
+
+    // The mock conductor's registerPlugin returns undefined (no real plugin attached, mirroring
+    // "the normal case outside a real Conductor run" — see dataVisualizer.test.ts on the CSE
+    // side) — draw_data still validates arity and returns None without crashing.
+    await evaluator.evaluateChunk("print(draw_data(1, 2))\n");
+    await evaluator.evaluateChunk("print(draw_data(1, 2, 3))\n");
+
+    expect(errors).toHaveLength(2);
+    expect(outputs).toEqual(["None", "None"]);
   });
 });

--- a/src/tests/py2js-draw-data.test.ts
+++ b/src/tests/py2js-draw-data.test.ts
@@ -1,0 +1,53 @@
+/**
+ * draw_data (chapter 2+, bridged natively as part of the LINKED_LISTS group — see
+ * stdlibBridge.ts's nativeDrawData): exercises the actual wiring from a running program's
+ * draw_data(...) call through to a data visualizer plugin's sendDrawing, via a fake plugin passed
+ * straight into Py2JsSession (bypassing the full Conductor registration machinery, which
+ * Py2JsEvaluator.test.ts's mock conductor stubs out entirely). Py2JsEvaluator.test.ts covers the
+ * complementary "no plugin attached" case.
+ */
+import type { BaseDataVisualizerRunnerPlugin } from "@sourceacademy/runner-data-visualizer";
+import { Py2JsSession, type PyValue } from "../engines/py2js";
+
+function makeFakePlugin() {
+  const rows: PyValue[][] = [];
+  const plugin = {
+    sendDrawing: (values: PyValue[]) => rows.push(values),
+    resetRun: () => undefined,
+  } as unknown as BaseDataVisualizerRunnerPlugin<PyValue>;
+  return { plugin, rows };
+}
+
+test("draw_data forwards its arguments to the data visualizer plugin's sendDrawing, unconverted", async () => {
+  const { plugin, rows } = makeFakePlugin();
+  const session = new Py2JsSession(2, { dataVisualizer: plugin });
+
+  await session.runChunk("draw_data(1, pair(2, 3))\n");
+
+  expect(rows).toHaveLength(1);
+  expect(rows[0]).toEqual([1n, [2n, 3n]]);
+});
+
+test("multiple draw_data calls each produce their own sendDrawing call", async () => {
+  const { plugin, rows } = makeFakePlugin();
+  const session = new Py2JsSession(2, { dataVisualizer: plugin });
+
+  await session.runChunk("draw_data(1, 2)\ndraw_data(3, 4)\n");
+
+  expect(rows).toEqual([
+    [1n, 2n],
+    [3n, 4n],
+  ]);
+});
+
+test("a self-referential pair passed to draw_data does not hang the bridge", async () => {
+  const { plugin, rows } = makeFakePlugin();
+  const session = new Py2JsSession(3, { dataVisualizer: plugin });
+
+  await session.runChunk("x = [1, None]\nset_tail(x, x)\ndraw_data(x, 2)\n");
+
+  expect(rows).toHaveLength(1);
+  const [first] = rows[0];
+  if (!Array.isArray(first)) throw new Error("expected an array");
+  expect(first[1]).toBe(first);
+});


### PR DESCRIPTION
## Summary

Wires `draw_data` up for the py2js engine (compiles Python to JS), alongside the existing CSE machine support added in #365. Available from **chapter 2 onward**, bridged natively as part of the **LINKED_LISTS** group — the same group `pair`/`llist`/`head`/`tail` belong to — rather than getting its own dedicated group the way the CSE machine's `dataVisualizer` group does.

- `src/conductor/dataVisualizer/toDataVisualizerNodePy2Js.ts` — the py2js native-value counterpart of `toDataVisualizerNode.ts` (CSE), dispatching on py2js's own unboxed value shapes (bigint/number/boolean/string/null/PyComplexNumber/array/PyOpaque/function) instead of CSE's tagged `Value`.
- `src/conductor/dataVisualizer/Py2JsDataVisualizerRunnerPlugin.ts` — thin `BaseDataVisualizerRunnerPlugin<PyValue>` binding, mirroring `PythonDataVisualizerRunnerPlugin`'s shape.
- `src/engines/py2js/stdlibBridge.ts` — `nativeDrawData`, registered when bridging the `LINKED_LISTS` group.
- `src/engines/py2js/index.ts` / `src/conductor/Py2JsEvaluator.ts` — thread a registered `Py2JsDataVisualizerRunnerPlugin` down into the session (`variant >= 2` only, mirroring `PyCseEvaluatorBase`'s identical gate), with `resetRun()` called per chunk.

## Why native, not the generic bridge

Every other bridged stdlib builtin goes through `stdlibBridge.ts`'s generic `toTagged`/`toTaggedList` round-trip (native py2js value → CSE's tagged `Value` → back), which walks a pair/list's spine with **no cycle guard** — fine for every other builtin, since none of them is ever handed a genuinely self-referential structure in practice. `draw_data` is different: chapter 3+'s `set_head`/`set_tail` can build a real cycle, and visualizing such a structure gracefully (a "ref" arrow, not a hang) is the whole point of the feature. So `draw_data` is implemented natively, walking `PyValue`s directly through its own `RefIdAllocator`-based cycle guard — proven by a test that draws a genuinely self-referential pair without hanging.

## Test plan

- [x] `src/conductor/dataVisualizer/__tests__/toDataVisualizerNodePy2Js.test.ts` — leaf values, pairs, longer lists, a self-referential list, shared-non-cyclic structure, functions, opaque values.
- [x] `src/tests/py2js-draw-data.test.ts` — end-to-end through a real `Py2JsSession`: arguments forward unconverted to a fake plugin's `sendDrawing`, multiple calls each produce their own row, and a genuinely self-referential pair (built via `set_tail`) doesn't hang.
- [x] `src/tests/Py2JsEvaluator.test.ts` — extended with arity validation and chapter-1 gating (name not found) through the full conductor evaluator.
- [x] Full suite: `yarn test` — 19,405 passed, 0 failed. `yarn run lint` / `yarn run format:ci` clean. `yarn run build --all` succeeds (all `Py2JsEvaluator{1,2,3,4}.js` bundles build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SWoqgBNWe8oP21aL2qejk