### PR TITLE
Bump sourceacademy-sicp to 0.2.0

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sourceacademy-sicp"
-version = "0.1.0"
+version = "0.2.0"
 description = "The Source Academy Python standard library for CPython: run CS1101S / SICP (Python edition) programs under plain CPython."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- `pyproject.toml`'s `version` was never bumped past `0.1.0`, even though the `sicp-v0.2.0` GitHub Release ("list multiplication, fixed-size lists") was cut and its `publish` job ran.
- That run failed with `400 File already exists` from PyPI, because `0.1.0` was already live there from the earlier `sicp-v0.1.0` release. PyPI still only serves `0.1.0` today.
- Bumps `version = "0.2.0"` so the next Release publish actually lands the newer package contents.

## Test plan
- [ ] After merge, cut a new GitHub Release (e.g. re-tag/re-run for `sicp-v0.2.0`, or a fresh `sicp-v0.2.1` if the tag can't be reused) and confirm the `publish` job in `.github/workflows/python-package.yml` succeeds
- [ ] Confirm `pip install sourceacademy-sicp` picks up `0.2.0` from PyPI

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01QckPNko9QfDTdWPrHfRoK2