### PR TITLE
Bump sourceacademy-sicp to 0.2.1, guard against tag/version drift

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -71,6 +71,19 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Verify release tag matches pyproject.toml version
+        # A release tagged sicp-vX.Y.Z whose pyproject.toml version doesn't
+        # match builds dist files for the *wrong* version. PyPI then either
+        # silently publishes under the wrong version or, if that version was
+        # already released, rejects the upload with "400 File already exists"
+        # (see sicp-v0.2.0, which was tagged before the version bump landed).
+        run: |
+          tag_version="${GITHUB_REF_NAME#sicp-v}"
+          pkg_version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Release tag '${GITHUB_REF_NAME}' does not match pyproject.toml version '${pkg_version}'. Bump the version and re-tag before releasing."
+            exit 1
+          fi
       - run: python -m pip install --upgrade pip build pytest
       - run: python -m pip install -e .
       - name: Run tests before publishing

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sourceacademy-sicp"
-version = "0.2.0"
+version = "0.2.1"
 description = "The Source Academy Python standard library for CPython: run CS1101S / SICP (Python edition) programs under plain CPython."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- `sicp-v0.2.0` was tagged from a commit where `pyproject.toml` still said `version = "0.1.0"` (the actual bump landed one commit later, in #370). Its `publish` job rebuilt `sourceacademy_sicp-0.1.0-*` and PyPI rejected the upload with `400 File already exists`, since 0.1.0 had already been published from `sicp-v0.1.0`.
- Because that upload never went through, PyPI still only serves `0.1.0` — including that version's README, which still had the (since-fixed, #265) "Not on PyPI yet" caveat frozen into its long description, since PyPI renders the README as it existed at build time and never updates it on its own.
- Bumps `python/pyproject.toml` to `0.2.1` so the next release gets a clean, unused version/tag.
- Adds a guard step to the `publish` job in `python-package.yml` that fails fast if the release tag (`sicp-vX.Y.Z`) doesn't match `pyproject.toml`'s version, so this mismatch can't silently recur.

## Test plan

- [x] `python -m pytest -q` in `python/` — 8 passed
- [x] Validated the new workflow step's YAML and version-extraction logic locally
- [ ] Cut a `sicp-v0.2.1` GitHub Release after merge to confirm the `publish` job succeeds and PyPI shows the current README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X48bQKyGSE2MPgHDqbuEs5