### PR TITLE
Add conductor-level multi-chunk tests for PyCseEvaluatorBase and bump conductor to 0.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@sourceacademy/common-cse-machine": "^0.3.0",
     "@sourceacademy/common-data-visualizer": "^0.0.1",
     "@sourceacademy/common-stepper": "^0.0.1",
-    "@sourceacademy/conductor": "^0.8.2",
+    "@sourceacademy/conductor": "^0.8.3",
     "@sourceacademy/pynter-wasm": "^0.2.0",
     "@sourceacademy/runner-autocomplete": "^0.0.2",
     "@sourceacademy/runner-cse-machine": "^3.0.0",

--- a/src/tests/PyCseEvaluator.test.ts
+++ b/src/tests/PyCseEvaluator.test.ts
@@ -157,7 +157,9 @@ describe("PyCseEvaluator1..4 (chapter selection)", () => {
     const evaluator = new PyCseEvaluator3(conductor);
 
     await evaluator.evaluateChunk("print([1, 2, 3][0])");
-    await evaluator.evaluateChunk("total = 0\nfor i in range(3):\n    total = total + i\nprint(total)");
+    await evaluator.evaluateChunk(
+      "total = 0\nfor i in range(3):\n    total = total + i\nprint(total)",
+    );
 
     expect(errors).toEqual([]);
     expect(outputs).toEqual(["1\n", "3\n"]);

--- a/src/tests/PyCseEvaluator.test.ts
+++ b/src/tests/PyCseEvaluator.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Conductor-evaluator tests for the CSE machine (mirrors Py2JsEvaluator.test.ts
+ * and PyPvmlEvaluator.test.ts).
+ *
+ * PyCseEvaluatorBase's `this.context` is a single instance field that
+ * survives across evaluateChunk() calls (see PyCseEvaluator.ts's own doc
+ * comment on that field) - this is the actual mechanism a persistent REPL
+ * session (source-academy/py-slang#359) depends on once
+ * @sourceacademy/conductor's BasicEvaluator.startEvaluator loops on further
+ * chunks instead of stopping after the first. Until now this repo had no
+ * test driving PyCseEvaluatorBase itself (as opposed to the lower-level
+ * evaluate()/runInContext() helpers utils.ts's generateTestCases() uses)
+ * through more than one evaluateChunk() call.
+ */
+import type { IRunnerPlugin } from "@sourceacademy/conductor/runner";
+import {
+  PyCseEvaluator1,
+  PyCseEvaluator2,
+  PyCseEvaluator3,
+  PyCseEvaluator4,
+} from "../conductor/PyCseEvaluator";
+
+/** Minimal IRunnerPlugin mock. PyCseEvaluatorBase's constructor unconditionally registers
+ * CseMachinePlugin (used by evaluateChunk via `this.csePlugin.sendSnapshots(...)`, without
+ * optional chaining, once variant >= 3) and the autocomplete plugin, plus - for variant >= 2 -
+ * PythonDataVisualizerRunnerPlugin (used via `this.dataVisualizerPlugin?.resetRun()`). One
+ * generic stub covers every registerPlugin call: only the methods each plugin path actually
+ * invokes need to exist. */
+function makeMockConductor() {
+  const results: unknown[] = [];
+  const errors: unknown[] = [];
+  const outputs: string[] = [];
+  const sendSnapshots = jest.fn();
+  const resetRun = jest.fn().mockResolvedValue(undefined);
+  const conductor = {
+    requestFile: () => Promise.resolve(undefined),
+    sendResult: (r: unknown) => results.push(r),
+    sendError: (e: unknown) => errors.push(e),
+    sendOutput: (m: string) => outputs.push(m),
+    registerPlugin: () => ({ sendSnapshots, resetRun }),
+    hostLoadPlugin: () => Promise.resolve(),
+  } as unknown as IRunnerPlugin;
+  return { conductor, results, errors, outputs, sendSnapshots };
+}
+
+describe("PyCseEvaluator1 (chapter 1, no CSE snapshots)", () => {
+  test("persists a global variable across evaluateChunk calls", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new PyCseEvaluator1(conductor);
+
+    await evaluator.evaluateChunk("x = 5");
+    await evaluator.evaluateChunk("print(x + 1)");
+
+    expect(errors).toEqual([]);
+    expect(outputs).toEqual(["6\n"]);
+  });
+
+  test("persists a function definition across evaluateChunk calls", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new PyCseEvaluator1(conductor);
+
+    await evaluator.evaluateChunk("def f(x):\n    return x * 2");
+    await evaluator.evaluateChunk("print(f(21))");
+
+    expect(errors).toEqual([]);
+    expect(outputs).toEqual(["42\n"]);
+  });
+
+  test("an erroring chunk reports through sendError and does not kill the session", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new PyCseEvaluator1(conductor);
+
+    await evaluator.evaluateChunk("x = 10");
+    await evaluator.evaluateChunk("print(1 / 0)");
+    await evaluator.evaluateChunk("print(x)");
+
+    expect(errors).toHaveLength(1);
+    expect(outputs).toEqual(["10\n"]);
+  });
+
+  test("a name unknown to the resolver is reported per-chunk, not fatal to the session", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new PyCseEvaluator1(conductor);
+
+    await evaluator.evaluateChunk("x = 1");
+    await evaluator.evaluateChunk("print(nope)");
+    await evaluator.evaluateChunk("print(x)");
+
+    expect(errors).toHaveLength(1);
+    expect(outputs).toEqual(["1\n"]);
+  });
+});
+
+describe("PyCseEvaluator3/4 (CSE snapshots)", () => {
+  test("sendSnapshots is called once per chunk, each reflecting only that chunk's own control/stash", async () => {
+    const { conductor, errors, outputs, sendSnapshots } = makeMockConductor();
+    const evaluator = new PyCseEvaluator3(conductor);
+
+    await evaluator.evaluateChunk("x = 1");
+    await evaluator.evaluateChunk("print(x + 1)");
+
+    expect(errors).toEqual([]);
+    expect(outputs).toEqual(["2\n"]);
+    expect(sendSnapshots).toHaveBeenCalledTimes(2);
+    // Each call's snapshot list is non-empty (the CSE machine actually ran, on a control/stash
+    // reinitialized for that chunk alone) - a stale/shared control between chunks would either
+    // throw (re-running an already-consumed Control) or silently replay chunk 1's assignment.
+    for (const [snapshots] of sendSnapshots.mock.calls) {
+      expect(Array.isArray(snapshots)).toBe(true);
+      expect(snapshots.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("breakpoint() steps from one chunk don't leak into the next chunk's snapshot batch", async () => {
+    const { conductor, errors, sendSnapshots } = makeMockConductor();
+    const evaluator = new PyCseEvaluator3(conductor);
+
+    await evaluator.evaluateChunk("x = 1\nbreakpoint()\nx = 2");
+    await evaluator.evaluateChunk("x = 3");
+
+    expect(errors).toEqual([]);
+    expect(sendSnapshots).toHaveBeenCalledTimes(2);
+    const [, firstBreakpointSteps] = sendSnapshots.mock.calls[0];
+    const [, secondBreakpointSteps] = sendSnapshots.mock.calls[1];
+    expect(firstBreakpointSteps.length).toBeGreaterThan(0);
+    expect(secondBreakpointSteps).toEqual([]);
+  });
+});
+
+// PyCseEvaluator1..4 wire the CSE machine to a specific SICPy chapter's
+// validators + stdlib groups (see VARIANT_GROUPS in ../runner.ts). These
+// smoke tests exist to confirm chapter selection works end to end through
+// the real evaluateChunk() path - not to re-litigate what each chapter
+// allows (see src/validator/sublanguages.ts for that).
+describe("PyCseEvaluator1..4 (chapter selection)", () => {
+  test("chapter 1: list literals are rejected by the chapter's validators", async () => {
+    const { conductor, errors } = makeMockConductor();
+    const evaluator = new PyCseEvaluator1(conductor);
+
+    await evaluator.evaluateChunk("[1, 2, 3]");
+
+    expect(errors).toHaveLength(1);
+  });
+
+  test("chapter 2: linked-list prelude is available", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new PyCseEvaluator2(conductor);
+
+    await evaluator.evaluateChunk("print(head(pair(1, 2)))");
+
+    expect(errors).toEqual([]);
+    expect(outputs).toEqual(["1\n"]);
+  });
+
+  test("chapter 3: list literals and for-loops over range() work", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new PyCseEvaluator3(conductor);
+
+    await evaluator.evaluateChunk("print([1, 2, 3][0])");
+    await evaluator.evaluateChunk("total = 0\nfor i in range(3):\n    total = total + i\nprint(total)");
+
+    expect(errors).toEqual([]);
+    expect(outputs).toEqual(["1\n", "3\n"]);
+  });
+
+  test("chapter 4: closures and `is` work across chunks", async () => {
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new PyCseEvaluator4(conductor);
+
+    await evaluator.evaluateChunk(
+      "def make_adder(n):\n    def add(x):\n        return x + n\n    return add\nadd3 = make_adder(3)",
+    );
+    await evaluator.evaluateChunk("print(add3(7))");
+    await evaluator.evaluateChunk("print(1 is 1)");
+
+    expect(errors).toEqual([]);
+    expect(outputs).toEqual(["10\n", "True\n"]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1700,10 +1700,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sourceacademy/conductor@npm:^0.8.2":
-  version: 0.8.2
-  resolution: "@sourceacademy/conductor@npm:0.8.2"
-  checksum: 10c0/a37dbed6c9ff1f92cb1b7938366c4647cc7c89aaa54b9b843ceaa2088933e251b84b2acae61753bad599c11f0becf95013a771bd7c999735ed8896c3195c9f53
+"@sourceacademy/conductor@npm:^0.8.3":
+  version: 0.8.3
+  resolution: "@sourceacademy/conductor@npm:0.8.3"
+  checksum: 10c0/25a35004fd92abc3f9342c1928a6be884388d3a8465cdc26491ccf56566121dd7a68a0c305defe668dfe7b96eebe61e93059631f80a92e0d9a4dc2775090f3e5
   languageName: node
   linkType: hard
 
@@ -1724,7 +1724,7 @@ __metadata:
     "@sourceacademy/common-cse-machine": "npm:^0.3.0"
     "@sourceacademy/common-data-visualizer": "npm:^0.0.1"
     "@sourceacademy/common-stepper": "npm:^0.0.1"
-    "@sourceacademy/conductor": "npm:^0.8.2"
+    "@sourceacademy/conductor": "npm:^0.8.3"
     "@sourceacademy/pynter-wasm": "npm:^0.2.0"
     "@sourceacademy/runner-autocomplete": "npm:^0.0.2"
     "@sourceacademy/runner-cse-machine": "npm:^3.0.0"


### PR DESCRIPTION
## Summary
- `Py2JsEvaluator.test.ts` and `PyPvmlEvaluator.test.ts` already drove their evaluators through multiple `evaluateChunk()` calls (persistence, error recovery), but `PyCseEvaluatorBase` (the CSE machine's evaluator) had no equivalent test.
- Adds `src/tests/PyCseEvaluator.test.ts`: variable/function persistence across chunks, an erroring chunk reporting via `sendError` without ending the session, and two CSE-specific checks the shared `evaluateChunk()` path is responsible for per chunk:
  - CSE snapshot collection (`csePlugin.sendSnapshots`) runs against a `control`/`stash` reinitialized for that chunk alone, not a stale/shared one from an earlier chunk.
  - `breakpoint()` step indices recorded in one chunk's snapshot batch don't leak into the next chunk's batch.
- Bumps `@sourceacademy/conductor` to `0.8.3`, which picks up source-academy/conductor#66 (`BasicEvaluator.startEvaluator` now loops on further chunks instead of stopping after the first). Folded in here (was briefly its own PR, #374) since it's logically part of the same effort, not a separate concern.

## Context
Part of getting a REPL that remembers previous declarations (source-academy/py-slang#359). `PyCseEvaluatorBase`/`Py2JsEvaluator`/`PyPvmlEvaluatorBase` already keep interpreter state alive across `evaluateChunk()` calls at the class level - this closes the one evaluator that had no test coverage for it, and brings in the conductor version that actually lets a live evaluator receive more than one chunk. The frontend half of this (source-academy/frontend#4213 - keeping a Worker alive across Run and REPL chunks) is already merged.

## Test plan
- [x] `yarn jest src/tests/PyCseEvaluator.test.ts` - 10/10 passing
- [x] `yarn jest` (full suite) - 71 passed, 2 skipped (opt-in CPython/native-Pynter suites, unaffected), against conductor 0.8.3
- [x] `yarn tsc --noEmit` - clean
- [x] `yarn eslint src/tests/PyCseEvaluator.test.ts` - clean
- [x] `yarn format:ci` - clean