### PR TITLE
Fix Py2JS stack overflow on cyclic list print/str/repr

### DIFF
--- a/src/engines/py2js/runtime.ts
+++ b/src/engines/py2js/runtime.ts
@@ -52,7 +52,7 @@
  */
 import { DataType, TypedValue } from "@sourceacademy/conductor/types";
 import { numericCompare, pythonMod } from "../cse/utils";
-import type { Value } from "../cse/stash";
+import type { ListValue, Value } from "../cse/stash";
 import { toPythonFloat, toPythonString } from "../../stdlib/utils";
 import { PyComplexNumber } from "../../types";
 import { stringify } from "../../utils/stringify";
@@ -198,8 +198,18 @@ function unsupported(op: string, l: PyValue, r?: PyValue, sayPair = false): neve
  * structured print — by reusing the actual algorithm, not a second
  * hand-written copy that could quietly drift. Only reached for pairs (and
  * whatever they contain); every other pyStr case keeps its own fast path.
+ *
+ * `memo` maps a PyList already being converted to its (still being filled
+ * in) ListValue, keyed by identity and populated *before* recursing into the
+ * list's elements — a chapter-3 `a[0] = a` self-reference is a real cyclic
+ * JS array, and without this a naive `v.map(toDisplayValue)` recurses
+ * forever (issue #341). Populating the memo before descending means a
+ * PyList reachable from itself converts to a ListValue reachable from
+ * itself — the same cyclic-graph shape stringify.ts's own ancestor
+ * tracking already knows how to render (as CPython does) without
+ * stringify needing to know anything py2js-specific.
  */
-function toDisplayValue(v: PyValue): Value {
+function toDisplayValue(v: PyValue, memo: Map<PyList, Value> = new Map()): Value {
   if (v === null) return { type: "none" };
   switch (typeof v) {
     case "bigint":
@@ -218,7 +228,12 @@ function toDisplayValue(v: PyValue): Value {
       ) as Value;
     default:
       if (Array.isArray(v)) {
-        return { type: "list", value: v.map(toDisplayValue) };
+        const memoized = memo.get(v);
+        if (memoized !== undefined) return memoized;
+        const listValue: ListValue = { type: "list", value: [] };
+        memo.set(v, listValue);
+        listValue.value = v.map(elem => toDisplayValue(elem, memo));
+        return listValue;
       }
       // stringify()'s convert() has no dedicated "opaque" case — it falls to
       // the generic `<${type} object>` fallback, matching pyStr's own

--- a/src/engines/py2js/stdlibBridge.ts
+++ b/src/engines/py2js/stdlibBridge.ts
@@ -51,7 +51,7 @@ import { GroupName } from "../../stdlib/utils";
 import type { Group } from "../../stdlib/utils";
 import { Context } from "../cse/context";
 import type { Environment } from "../cse/environment";
-import type { BuiltinValue, Value } from "../cse/stash";
+import type { BuiltinValue, ListValue, Value } from "../cse/stash";
 import {
   isPairShaped,
   Py2JsRuntime,
@@ -74,7 +74,20 @@ function syntheticCallNode(name: string): ExprNS.Call {
  * it stands in for — see the file header's note on lossless pass-through. */
 const functionOrigin = new WeakMap<object, PyFunction>();
 
-function toTagged(v: PyValue): Value {
+/**
+ * `memo` maps a PyList already being converted to its (still being filled
+ * in) tagged ListValue, keyed by identity and populated *before* recursing
+ * into the list's elements/spine — chapter 3's set_head/set_tail, or a
+ * literal-list subscript assignment (`a[0] = a`), can build a genuinely
+ * cyclic PyList (issue #341), and without this a bridged builtin's argument
+ * conversion recurses/loops forever converting it. Populating the memo
+ * before descending means a PyList reachable from itself converts to a
+ * ListValue reachable from itself, so whatever CSE builtin receives it sees
+ * the same kind of cyclic Value graph its own native (non-bridged) callers
+ * already have to cope with (e.g. stringify.ts's ancestor tracking) —
+ * cycle-handling stays the shared builtin's job, not this bridge's.
+ */
+function toTagged(v: PyValue, memo: Map<PyList, Value> = new Map()): Value {
   switch (typeof v) {
     case "bigint":
       return { type: "bigint", value: v };
@@ -120,7 +133,7 @@ function toTagged(v: PyValue): Value {
       // reproduces CSE's own is_list/list_length answers exactly, including
       // on a 2-element list (which CSE cannot tell apart from a pair
       // either — see runtime.ts's PyList doc comment).
-      if (Array.isArray(v)) return toTaggedList(v);
+      if (Array.isArray(v)) return toTaggedList(v, memo);
       // No chapter-1/2 stdlib builtin accepts an opaque module value as an
       // argument (abs/math_sqrt/etc. all type-check against "opaque" being
       // absent from their accepted types), so this just needs to produce
@@ -143,27 +156,49 @@ function toTagged(v: PyValue): Value {
  * tail-recursive the user's own Python is (its own tail calls go through
  * py2js's trampoline; this bridge conversion does not). The walk continues
  * exactly as long as the current node is itself a 2-element list (a chain
- * link); it stops — falling through to a plain `.map()` — the moment that
- * shape breaks, which correctly covers a flat N-element (N≠2) literal list
- * (zero iterations) and a pair whose tail isn't itself a pair (one
- * iteration) with no separate case needed for either. `heads[i]`/the final
- * tail are still converted via the ordinary (recursive) toTagged, since each
- * head is normally a scalar leaf; a list-of-lists nested arbitrarily deep
- * through a head position remains a (much rarer) recursion, same as before.
+ * link) not already seen this walk; it stops — falling through to the final
+ * tail conversion — the moment that shape breaks (a flat N-element (N≠2)
+ * literal list: zero iterations; a pair whose tail isn't itself a pair: one
+ * iteration) or the chain loops back on itself (chapter 3's set_tail, or an
+ * N-element list looping back into itself, e.g. `a[0] = a`). `heads[i]`/the
+ * final tail are still converted via the ordinary (recursive) toTagged,
+ * since each head is normally a scalar leaf; a list-of-lists nested
+ * arbitrarily deep through a head position remains a (much rarer)
+ * recursion, same as before.
+ *
+ * Each spine node gets its ListValue placeholder allocated (and memoized)
+ * before its tail is known, exactly like toTagged's memo contract — so
+ * closing a cycle back onto an earlier node just reuses that node's
+ * placeholder as the tail, producing a genuinely cyclic Value graph instead
+ * of looping forever building `heads`.
  */
-function toTaggedList(v: PyList): Value {
-  if (!isPairShaped(v)) return { type: "list", value: v.map(toTagged) };
-  const heads: PyValue[] = [];
+function toTaggedList(v: PyList, memo: Map<PyList, Value>): Value {
+  const memoized = memo.get(v);
+  if (memoized !== undefined) return memoized;
+  if (!isPairShaped(v)) {
+    const listValue: ListValue = { type: "list", value: [] };
+    memo.set(v, listValue);
+    listValue.value = v.map(elem => toTagged(elem, memo));
+    return listValue;
+  }
+  const nodes: PyList[] = [];
+  const placeholders: ListValue[] = [];
   let current: PyValue = v;
   while (isPairShaped(current)) {
-    heads.push(current[0]);
+    const seen = memo.get(current);
+    if (seen !== undefined) break;
+    const placeholder: ListValue = { type: "list", value: [] };
+    memo.set(current, placeholder);
+    nodes.push(current);
+    placeholders.push(placeholder);
     current = current[1];
   }
-  let tail = toTagged(current);
-  for (let i = heads.length - 1; i >= 0; i--) {
-    tail = { type: "list", value: [toTagged(heads[i]), tail] };
+  let tail = isPairShaped(current) ? memo.get(current)! : toTagged(current, memo);
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    placeholders[i].value = [toTagged(nodes[i][0], memo), tail];
+    tail = placeholders[i];
   }
-  return tail;
+  return memo.get(v)!;
 }
 
 function fromTagged(name: string, v: Value): PyValue {
@@ -242,7 +277,12 @@ function bridgeBuiltin(
   const f = rt.def(name, -1, (...args: PyValue[]) => {
     let result: Value | undefined | Promise<Value | undefined>;
     try {
-      result = call(args.map(toTagged), source, command, context);
+      result = call(
+        args.map(a => toTagged(a)),
+        source,
+        command,
+        context,
+      );
     } catch (e) {
       // handleRuntimeError (src/engines/cse/error.ts) throws a
       // RuntimeSourceError — a plain object implementing SourceError, not

--- a/src/tests/py2js-lists.test.ts
+++ b/src/tests/py2js-lists.test.ts
@@ -259,3 +259,39 @@ describe('error messages say "pair" at chapter 2, "list" at chapter 3+ (matching
     // parameter didn't break the ordinary (non-list) error path.
   });
 });
+
+describe("printing a self-referential list mirrors CPython's cycle marker, not a stack overflow (issue #341)", () => {
+  test.each([
+    // Cycle at the top-level list's own position [0].
+    ["a = [1]\na[0] = a\nprint(a)", "[[...]]\n"],
+    // Cycle at position [1] of a 2-element list.
+    ["p = [1, 2]\np[1] = p\nprint(p)", "[1, [...]]\n"],
+    // Cycle at position [2] of a 3-element list.
+    ["q = [1, 2, 3]\nq[2] = q\nprint(q)", "[1, 2, [...]]\n"],
+    // Cycle one level down, not at the top level: the *inner* list (at
+    // outer[1]) refers to itself at its own position [1].
+    ["outer = [0, [1, 2]]\nouter[1][1] = outer[1]\nprint(outer)", "[0, [1, [...]]]\n"],
+    // Same, but the inner list's self-reference is at its position [2].
+    ["outer = [0, [1, 2, 3]]\nouter[1][2] = outer[1]\nprint(outer)", "[0, [1, 2, [...]]]\n"],
+    // Cycle two levels down: a[1][1] is a nested list that refers back to
+    // its own parent (a[1]), not to itself or to the top-level list.
+    ["a = [10, [20, [30, 0]]]\na[1][1][1] = a[1]\nprint(a)", "[10, [20, [30, [...]]]]\n"],
+    // Indirect (mutual) cycle across two top-level lists, neither of which
+    // refers to itself directly.
+    [
+      "b = [1, 0]\nc = [2, 0]\nb[1] = c\nc[1] = b\nprint(b)\nprint(c)",
+      "[1, [2, [...]]]\n[2, [1, [...]]]\n",
+    ],
+    // A value shared by two positions (not a cycle) still prints in full
+    // both times — the marker is only for a genuine ancestor cycle.
+    ["shared = [1, 2]\nf = [shared, shared]\nprint(f)", "[[1, 2], [1, 2]]\n"],
+  ])("%s", async (code, expected) => {
+    expect(await runCode(code, 3)).toBe(expected);
+    expect(runCodePy2Js(code, 3).output).toBe(expected);
+  });
+
+  test.each(["str", "repr"])("%s() of a self-referential list also avoids the overflow", name => {
+    const code = `a = [1]\na[0] = a\nprint(${name}(a))`;
+    expect(runCodePy2Js(code, 3).output).toBe("[[...]]\n");
+  });
+});

--- a/src/tests/py2js-lists.test.ts
+++ b/src/tests/py2js-lists.test.ts
@@ -290,8 +290,12 @@ describe("printing a self-referential list mirrors CPython's cycle marker, not a
     expect(runCodePy2Js(code, 3).output).toBe(expected);
   });
 
-  test.each(["str", "repr"])("%s() of a self-referential list also avoids the overflow", name => {
-    const code = `a = [1]\na[0] = a\nprint(${name}(a))`;
-    expect(runCodePy2Js(code, 3).output).toBe("[[...]]\n");
-  });
+  test.each(["str", "repr"])(
+    "%s() of a self-referential list also avoids the overflow",
+    async name => {
+      const code = `a = [1]\na[0] = a\nprint(${name}(a))`;
+      expect(await runCode(code, 3)).toBe("[[...]]\n");
+      expect(runCodePy2Js(code, 3).output).toBe("[[...]]\n");
+    },
+  );
 });

--- a/src/utils/stringify.ts
+++ b/src/utils/stringify.ts
@@ -177,7 +177,11 @@ export function valueToStringDag(value: Value): StringDag {
     if (v.type === "none") {
       return [{ type: "terminal", str: "None", length: 4 }, false];
     } else if (ancestors.has(v)) {
-      return [{ type: "terminal", str: "...<circular>", length: 13 }, true];
+      // Mirrors CPython's Py_ReprEnter guard (Objects/listobject.c): a list
+      // reached again while already being rendered — a genuine ancestor
+      // cycle, not merely a value shared by two unrelated positions — repr's
+      // as the container's own placeholder rather than recursing forever.
+      return [{ type: "terminal", str: "[...]", length: 5 }, true];
     } else if (v.type === "bool") {
       const s = v.value ? "True" : "False";
       return [{ type: "terminal", str: s, length: s.length }, false];


### PR DESCRIPTION
## Summary

Fixes #341. `print`, `str()`, and `repr()` in the Py2JS engine crashed with `RangeError: Maximum call stack size exceeded` on a self-referential list (e.g. `a = [1]; a[0] = a`), instead of printing CPython's cycle marker.

- **Root cause**: two separate PyValue→CSE-Value conversion paths — `toDisplayValue` (`runtime.ts`, used by `print`) and `toTagged`/`toTaggedList` (`stdlibBridge.ts`, used by every generically-bridged builtin including `str`/`repr`) — rebuilt a fresh `Value` tree on every call with no cycle awareness, so a self-referential JS array recursed forever *before* the shared `stringify()` renderer's own, already-correct ancestor-cycle detection ever got a chance to run.
- **Fix**: both conversions now memoize by object identity, allocating each list's placeholder *before* descending into its elements/spine, so a cyclic `PyValue` converts into a genuinely cyclic `Value` graph — the same shape `stringify()` already knows how to render safely. `toTaggedList`'s iterative long-list optimization (avoiding one JS stack frame per element for long proper lists) is preserved.
- Also updates `stringify.ts`'s cycle marker text from `"...<circular>"` to CPython's actual `"[...]"`, verified against real CPython's `Py_ReprEnter` behavior (each nesting level of a cycle gets its own bracket pair, e.g. `[[...]]` for direct self-reference). This is a shared file also used by the CSE machine, so its cyclic-print output becomes CPython-accurate too — no existing tests depended on the old text.

## Test plan

- [x] Added `describe("printing a self-referential list mirrors CPython's cycle marker...")` in `src/tests/py2js-lists.test.ts`, covering: cycle at top level, cycle at list position `[1]`, cycle at position `[2]`, cycle nested one level down (not at top level), cycle nested two levels down, indirect/mutual cycles between two lists, and a shared-but-acyclic control case (must NOT trigger the marker) — each cross-checked against the CSE machine (`runCode`) and manually verified against real CPython.
- [x] Added `str()`/`repr()` cases confirming they no longer overflow either.
- [x] Full existing test suite passes (19,466 tests, no regressions), including the stdlib/operator conformance sweeps that already exercise `str`/`repr` over the full type universe.
- [x] `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PChZPg9vbWzAJrxDV9YQvk