### PR TITLE
Recognize breakpoint() with any number of arguments as a breakpoint

### DIFF
--- a/src/conductor/stepper/__tests__/getSteps.test.ts
+++ b/src/conductor/stepper/__tests__/getSteps.test.ts
@@ -1622,6 +1622,49 @@ describe("Python stepper — breakpoint() marks a debugger breakpoint (#188)", (
     );
     expect(flagged).toHaveLength(0);
   });
+
+  // Real Python's breakpoint(*args, **kws) takes any number of arguments (forwarded to
+  // sys.breakpointhook); the stepper's own no-op breakpoint entry already ignores them regardless
+  // (see builtins.ts), so the bare-statement form should still be recognised as a debugger target
+  // for any arity, not just zero (issue #257).
+  test.each([
+    ["one literal argument", "breakpoint(5)"],
+    ["several literal arguments", "breakpoint(1, 2, 3)"],
+  ])("%s: still evaluates as a no-op and is flagged as a breakpoint target", (_desc, call) => {
+    expect(result(`${call}\n1 + 1`)).toBe("2");
+    const flagged = steps(`${call}\n1 + 1`).filter(
+      step => step.markers?.[0]?.redexNodeType === "DebuggerStatement",
+    );
+    expect(flagged).toHaveLength(1);
+    expect(flagged[0].markers?.[0]?.explanation).toBe("Evaluating breakpoint statement");
+  });
+
+  test("an argument that is itself reducible is stepped through first, then flagged once all arguments are values", () => {
+    // breakpoint(1 + 2): the argument isn't a value yet, so the statement must not be flagged as the
+    // debugger target on the very first encounter — only once `1 + 2` has itself reduced to `3` (the
+    // point analogous to the CSE machine's APPLICATION instruction actually firing).
+    const src = "breakpoint(1 + 2)\n1 + 1";
+    const flagged = steps(src).filter(
+      step => step.markers?.[0]?.redexNodeType === "DebuggerStatement",
+    );
+    expect(flagged).toHaveLength(1);
+    expect(flagged[0].markers?.[0]?.explanation).toBe("Evaluating breakpoint statement");
+    // Confirm the argument really was reduced before the flagged step: the flagged step's own tree
+    // already shows `3`, not `1 + 2`.
+    const args = (flagged[0].ast as any).body[0].expression.arguments;
+    expect(args).toHaveLength(1);
+    expect(args[0].type).toBe("Literal");
+    expect(args[0].value).toBe(3n);
+  });
+
+  test("aliased and called with arguments is still flagged as a breakpoint target", () => {
+    const src = "bp = breakpoint\nbp(1, 2)\n1 + 1";
+    expect(result(src)).toBe("2");
+    const flagged = steps(src).filter(
+      step => step.markers?.[0]?.redexNodeType === "DebuggerStatement",
+    );
+    expect(flagged).toHaveLength(1);
+  });
 });
 
 describe("Python stepper — cumulative print output per step", () => {

--- a/src/conductor/stepper/reduce.ts
+++ b/src/conductor/stepper/reduce.ts
@@ -815,18 +815,23 @@ function stepHead(head: StepNode, rest: StepNode[]): HeadOutcome {
       // Python's `breakpoint()` is the stepper's analogue of JavaScript's `debugger;`: a no-op
       // statement (like `pass`) that also marks a step the host's breakpoint navigation (the
       // double-arrow) can jump to. Detected here against the *current*, already-substituted tree — a
-      // zero-arg call whose callee is (by now) literally the built-in identifier `breakpoint` —
-      // instead of the student's original syntax, so it behaves like every other built-in: reached
-      // directly (`breakpoint()`) or via aliasing (`bp = breakpoint; bp()`) is indistinguishable, just
-      // as `p = print; p(1)` already is. This only matches when the call is the *whole* of a bare
-      // statement; used any other way (`x = breakpoint()`, nested in a larger expression, passed
-      // around) it falls through to `reduceExpr` below and reduces as an ordinary built-in call
-      // yielding `None`, matching Python's real return value.
+      // call whose callee is (by now) literally the built-in identifier `breakpoint`, with every
+      // argument already reduced to a value — instead of the student's original syntax, so it behaves
+      // like every other built-in: reached directly (`breakpoint()`) or via aliasing
+      // (`bp = breakpoint; bp()`) is indistinguishable, just as `p = print; p(1)` already is. Real
+      // Python's `breakpoint(*args, **kws)` takes any number of arguments (forwarded to
+      // sys.breakpointhook, which the CSE/stepper's own no-op `breakpoint` already ignores either way —
+      // see stdlib/misc.ts), so this fires for any arity, not just zero — matching the point
+      // `contractCall` below would otherwise apply the builtin at (args not yet all values still takes
+      // an ordinary reduction step first, via `reduceExpr` below). This only matches when the call is
+      // the *whole* of a bare statement; used any other way (`x = breakpoint()`, nested in a larger
+      // expression, passed around) it falls through to `reduceExpr` below and reduces as an ordinary
+      // built-in call yielding `None`, matching Python's real return value.
       if (
         expr.type === "CallExpression" &&
         (expr.callee as StepNode).type === "Identifier" &&
         (expr.callee as StepNode).name === "breakpoint" &&
-        (expr.arguments as StepNode[]).length === 0
+        (expr.arguments as StepNode[]).every(isValue)
       ) {
         return {
           kind: "step",

--- a/src/engines/cse/interpreter.ts
+++ b/src/engines/cse/interpreter.ts
@@ -327,18 +327,16 @@ export async function* generateCSEMachineStateStream(
       context.runtime.changepointSteps.push(steps + 1);
     }
 
-    // A zero-arg call resolving to the `breakpoint` builtin, detected by identity (not source
-    // text) so aliasing (e.g. `bp = breakpoint; bp()`) is caught too — mirrors the stepper's
-    // breakpoint detection in reduce.ts. APPLICATION pops its callee off the stash itself, after
-    // popping `numOfArgs` args first; with zero args the callee is already on top of the stash,
-    // so it can be peeked here, before that instruction runs.
-    if (
-      !isPrelude &&
-      isInstr(command) &&
-      command.instrType === InstrType.APPLICATION &&
-      command.numOfArgs === 0
-    ) {
-      const callee = stash.peek();
+    // A call resolving to the `breakpoint` builtin, detected by identity (not source text) so
+    // aliasing (e.g. `bp = breakpoint; bp()`) is caught too — mirrors the stepper's breakpoint
+    // detection in reduce.ts. Real Python's `breakpoint(*args, **kws)` takes any number of
+    // arguments (forwarded to sys.breakpointhook, which this builtin already ignores either way —
+    // see stdlib/misc.ts), so this fires for any arity, not just zero. APPLICATION pops its callee
+    // off the stash itself, after popping `numOfArgs` args first — by the time this instruction is
+    // about to run, all `numOfArgs` args are already evaluated and sit on top of the callee, so
+    // peekAt(numOfArgs) reaches down past them to the callee, still before APPLICATION runs.
+    if (!isPrelude && isInstr(command) && command.instrType === InstrType.APPLICATION) {
+      const callee = stash.peekAt(command.numOfArgs);
       if (callee?.type === "builtin" && callee.name === "breakpoint") {
         // `steps` here is the count as of the end of the *previous* iteration — i.e. the
         // stepIndex (collectSnapshots stores `steps - 1` per yield) of the snapshot that has

--- a/src/engines/cse/stack.ts
+++ b/src/engines/cse/stack.ts
@@ -5,6 +5,7 @@ interface IStack<T> {
   push(...items: T[]): void;
   pop(): T | undefined;
   peek(): T | undefined;
+  peekAt(depthFromTop: number): T | undefined;
   size(): number;
   isEmpty(): boolean;
   getStack(): T[];
@@ -31,6 +32,15 @@ export class Stack<T> implements IStack<T> {
       return undefined;
     }
     return this.storage[this.size() - 1];
+  }
+
+  /** `peekAt(0)` is the top (same as `peek()`); `peekAt(n)` looks n items below it. */
+  public peekAt(depthFromTop: number): T | undefined {
+    const index = this.size() - 1 - depthFromTop;
+    if (index < 0) {
+      return undefined;
+    }
+    return this.storage[index];
   }
 
   public size(): number {

--- a/src/tests/PyCseMachinePlugin.test.ts
+++ b/src/tests/PyCseMachinePlugin.test.ts
@@ -739,4 +739,28 @@ f()`,
     const second = await run("x = 1");
     expect(second.breakpointSteps).toHaveLength(0);
   });
+
+  // Real Python's breakpoint(*args, **kws) takes any number of arguments (forwarded to
+  // sys.breakpointhook); the no-op CSE builtin already ignores them regardless (stdlib/misc.ts), so
+  // navigation should record the step the same way it does for breakpoint() (issue #257).
+  it.each([
+    ["one positional argument", "breakpoint(5)"],
+    ["several positional arguments", "breakpoint(1, 2, 3)"],
+    ["an argument that is itself a call", "breakpoint(1 + 2)"],
+  ])("is still recorded when called with %s", async (_desc, call) => {
+    const { breakpointSteps } = await runAndCollectWithBreakpoints(`${call}\nx = 1`);
+    expect(breakpointSteps.length).toBeGreaterThan(0);
+  });
+
+  it("is detected through an alias called with arguments", async () => {
+    const { breakpointSteps } = await runAndCollectWithBreakpoints("bp = breakpoint\nbp(1, 2)");
+    expect(breakpointSteps.length).toBeGreaterThan(0);
+  });
+
+  it("evaluates to None and ignores its arguments, same as the zero-arg form", async () => {
+    const snapshots = await runAndCollect("x = breakpoint(1, 2, 3)");
+    const last = snapshots[snapshots.length - 1];
+    const xBinding = last.environments.flatMap(e => e.bindings).find(b => b.name === "x");
+    expect(xBinding?.value.displayValue).toBe("None");
+  });
 });

--- a/src/tests/PyCseMachinePlugin.test.ts
+++ b/src/tests/PyCseMachinePlugin.test.ts
@@ -749,12 +749,12 @@ f()`,
     ["an argument that is itself a call", "breakpoint(1 + 2)"],
   ])("is still recorded when called with %s", async (_desc, call) => {
     const { breakpointSteps } = await runAndCollectWithBreakpoints(`${call}\nx = 1`);
-    expect(breakpointSteps.length).toBeGreaterThan(0);
+    expect(breakpointSteps).toHaveLength(1);
   });
 
   it("is detected through an alias called with arguments", async () => {
     const { breakpointSteps } = await runAndCollectWithBreakpoints("bp = breakpoint\nbp(1, 2)");
-    expect(breakpointSteps.length).toBeGreaterThan(0);
+    expect(breakpointSteps).toHaveLength(1);
   });
 
   it("evaluates to None and ignores its arguments, same as the zero-arg form", async () => {


### PR DESCRIPTION
## Summary

Fixes #257. Real Python's `breakpoint()` signature is `breakpoint(*args, **kws)` — it accepts any number of positional (and keyword) arguments, forwarded to `sys.breakpointhook`. Both the CSE machine's and the substitution stepper's own `breakpoint` builtin already reflected this (no arity validation at all, args silently ignored either way — see `stdlib/misc.ts` and `conductor/stepper/builtins.ts`).

The bug was purely in **breakpoint-navigation detection**: both engines only recognized a *zero-argument* call as a navigable breakpoint marker, so `breakpoint(5)` ran fine but the double-chevron navigation silently skipped it, with no error or indication to the student.

This takes the direction of matching CPython's actual signature (accept any arity, same as the argument-count-agnostic no-op `breakpoint` already does) rather than the issue's alternate "make it strictly zero-arg and raise a TypeError otherwise" suggestion — since real Python code calling `breakpoint(5)` is not doing anything wrong, it should just work, navigation included.

- **CSE machine** (`interpreter.ts`): the zero-arg restriction existed only because the callee sits on top of the stash at the point checked, which is true only when there are zero args (APPLICATION pops `numOfArgs` args before popping the callee). Added `Stack.peekAt(depthFromTop)` and used `peekAt(numOfArgs)` to reach the callee regardless of arity.
- **Stepper** (`reduce.ts`): generalized the `arguments.length === 0` check to `arguments.every(isValue)` — the same "is this argument already a value" predicate `contractCall` uses to decide when a call is ready to apply. A still-reducible argument (e.g. `breakpoint(1 + 2)`) now steps through normally first; the statement is flagged as the breakpoint-navigation target once every argument has become a value, mirroring the point the CSE machine's APPLICATION instruction would actually fire.

## Test plan

- [x] `PyCseMachinePlugin.test.ts`: `breakpoint()` with one/several/computed positional arguments, and via an alias, all still record a `breakpointSteps` entry; confirms it still evaluates to `None` and ignores its arguments.
- [x] `getSteps.test.ts` (stepper): `breakpoint(5)` / `breakpoint(1, 2, 3)` still evaluate as a no-op and are flagged as the "Evaluating breakpoint statement" debugger target; `breakpoint(1 + 2)` confirms the argument is reduced to a value (`3`) *before* the statement gets flagged, not on first encounter; aliasing (`bp = breakpoint; bp(1, 2)`) still works.
- [x] Full existing test suite passes (19,485 tests, no regressions).
- [x] `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PChZPg9vbWzAJrxDV9YQvk