### PR TITLE
Fix NameReassignmentError's location to point at the original declaration

### DIFF
--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -21,6 +21,20 @@ export class Environment {
   // The parent of this environment
   enclosing: Environment | null;
   names: Map<string, Token>;
+  /**
+   * Where each name in `names` was *first* declared in this scope — for diagnostics only (e.g.
+   * NameReassignmentError's "already declared here" pointer). `names` itself gets overwritten on
+   * every hoist of a name (declareName has no "first wins" rule: `resolve(Stmt[])`'s hoisting pass
+   * runs unconditionally over every Assign/FunctionDef in a statement list, including a list
+   * re-hoisted more than once against the same environment, e.g. an if-arm and its else-arm, which
+   * share their enclosing scope's environment — see visitIfStmt), which is required for forward
+   * references to resolve but means `names.get(name)` can end up pointing at an unrelated later
+   * occurrence, or even the very statement the reassignment error is itself about, rather than the
+   * name's true original declaration (issue #211). Seeded from the environment's initial `names`
+   * (so a function/lambda parameter's own token is its own "first declared" location — see the
+   * constructor), then updated by declareName only the first time a name is set, never after.
+   */
+  firstDeclarations: Map<string, Token>;
   // Function names in the environment.
   functions: Set<string>;
   // Names that are from import bindings, like 'y' in `from x import y`.
@@ -58,6 +72,7 @@ export class Environment {
     this.source = source;
     this.enclosing = enclosing;
     this.names = names;
+    this.firstDeclarations = new Map(names);
     this.functions = new Set();
     this.moduleBindings = new Set();
     this.definedNames = new Set();
@@ -171,6 +186,9 @@ export class Environment {
   }
   declareName(identifier: Token) {
     this.names.set(identifier.lexeme, identifier);
+    if (!this.firstDeclarations.has(identifier.lexeme)) {
+      this.firstDeclarations.set(identifier.lexeme, identifier);
+    }
     this.definedNames.add(identifier.lexeme);
   }
   // Same as declareName but allowed to re-declare later.
@@ -375,7 +393,10 @@ export class Resolver implements StmtNS.Visitor<void>, ExprNS.Visitor<void> {
     let curr = this.environment;
     while (curr !== this.functionScope) {
       if (curr !== null && curr.names.has(identifier.lexeme)) {
-        const token = curr.names.get(identifier.lexeme);
+        // firstDeclarations (not names) so the reported location is the name's actual first
+        // declaration in curr, not whatever declareName last hoisted there — see firstDeclarations'
+        // doc comment.
+        const token = curr.firstDeclarations.get(identifier.lexeme);
         if (token === undefined) {
           this.errors.push(new Error("placeholder error"));
           return;

--- a/src/tests/resolver.test.ts
+++ b/src/tests/resolver.test.ts
@@ -256,4 +256,64 @@ print(outer())
       expect(() => toPythonAstAndResolve(code, 3)).not.toThrow();
     });
   });
+
+  // NameReassignmentError's "already declared here" pointer must reference the name's actual
+  // first declaration, not whichever occurrence declareName's hoisting pass happened to visit
+  // last against the shared environment (issue #211) — detection was already correct; only the
+  // reported location was wrong.
+  describe("NameReassignmentError points at the original declaration, not the reassignment (#211)", () => {
+    function reassignmentMessage(code: string, variant = 1): string {
+      try {
+        toPythonAstAndResolve(code, variant);
+        throw new Error("did not throw");
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(ResolverErrors.NameReassignmentError);
+        return e.message;
+      }
+    }
+
+    test("two reassignments: points at the first assignment (line 1), not the reassignment (line 2)", () => {
+      const message = reassignmentMessage("x = 1\nx = 2");
+      expect(message).toContain("already been declared in the same environment at line 1");
+      expect(message).not.toContain("already been declared in the same environment at line 2");
+    });
+
+    test("three reassignments: still points at the very first one (line 1), not the last hoisted one (line 3)", () => {
+      const message = reassignmentMessage("x = 1\nx = 2\nx = 3");
+      expect(message).toContain("already been declared in the same environment at line 1");
+    });
+
+    test("a parameter reassigned in its own function body points at the def line, not at the reassignment", () => {
+      const code = `
+def f(x):
+    x = 1
+    return x
+f(1)
+`;
+      const message = reassignmentMessage(code, 1);
+      expect(message).toContain("already been declared in the same environment at line 2");
+      expect(message).toContain("def f(x):");
+      expect(message).not.toContain("already been declared in the same environment at line 3");
+    });
+
+    test("same local assigned in both if/else arms points at the if-arm (its true first declaration)", () => {
+      const code = `
+def f(c):
+    if c:
+        x = 1
+    else:
+        x = 2
+    return x
+f(True)
+`;
+      // Source §1's no-reassignment rule is const-like: assigning the same name in both arms of
+      // an if/else counts as a reassignment even though the arms are exclusive (see
+      // py2js-unbound.test.ts's identical case) — only meaningful at chapter 1.
+      const message = reassignmentMessage(code, 1);
+      // "x = 1" (the if-arm, line 4) is the true first declaration; "x = 2" (the else-arm, line 6,
+      // where the error itself fires) must not be reported as its own "already declared" location.
+      expect(message).toContain("already been declared in the same environment at line 4");
+      expect(message).not.toContain("already been declared in the same environment at line 6");
+    });
+  });
 });

--- a/src/validator/features/no-reassignment.ts
+++ b/src/validator/features/no-reassignment.ts
@@ -49,7 +49,10 @@ export function createNoReassignmentValidator(): FeatureValidator {
           env.source,
           target.indexInSource,
           target.indexInSource + name.length,
-          env.names.get(name)!,
+          // firstDeclarations (not names) so "already declared here" points at the name's actual
+          // first declaration in this scope — names.get(name) would instead give whichever
+          // occurrence declareName's hoisting pass happened to visit last (issue #211).
+          env.firstDeclarations.get(name)!,
         );
       }
       declared.add(name);


### PR DESCRIPTION
## Summary

Fixes #211. `NameReassignmentError`'s "already declared here" pointer was supposed to point at a name's *original* declaration, but instead pointed at whatever the resolver's hoisting pass happened to visit last for that name — sometimes the reassignment statement that's already flagged by the error's own primary location, sometimes a completely unrelated *later* occurrence.

**Root cause**: `env.names` is used for two purposes that don't compose. `Resolver.resolve()` hoists every `Assign`/`FunctionDef` in a statement list before validating any of it (so forward references within the same block resolve), calling `Environment.declareName()` unconditionally — last write wins, with no "first wins" rule. That's correct for "is this name bound in this scope," but `no-reassignment.ts`'s validator and `functionVarConstraint` both also read `env.names.get(name)` to report *where the name was first declared*, which by then has already been overwritten.

Concretely, for `x = 1; x = 2; x = 3`, both the `x = 2` and `x = 3` errors' "already declared here" pointed at line 3 (the last hoisted occurrence) — for the `x = 2` error, that's a location *after* the error itself, which is incoherent. A same-scope-reassignment case with only two statements happened to self-reference (pointing at the very statement already flagged), masking how wrong the general case was.

**Fix**: `Environment` gains `firstDeclarations`, a separate map seeded from the environment's initial `names` (so a function/lambda parameter's own token is correctly its own "first declared" location) and updated by `declareName` only the first time a name is set in that scope, never after. Both throw sites that report a reassignment's original location — `no-reassignment.ts`'s validator and `functionVarConstraint` (the same bug, reached via a different path: same local assigned in both arms of an `if`/`else`, or a nested function/lambda body shadowing an enclosing local) — now read from `firstDeclarations` instead of `names`.

## Test plan

- [x] Added a `resolver.test.ts` describe block covering: two reassignments (points at line 1, not line 2), three reassignments (still points at line 1, not the last-hoisted line 3), a parameter reassigned in its own function body (points at the `def` line, not the reassignment), and the same local assigned in both if/else arms (points at the if-arm, not the else-arm where the error fires).
- [x] Full existing test suite passes (19,479 tests, no regressions) — nothing asserted on the old (wrong) location text.
- [x] `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PChZPg9vbWzAJrxDV9YQvk