### PR TITLE
Add local-file ("folder") imports for py2js (§2+)

### DIFF
--- a/src/ast-types.ts
+++ b/src/ast-types.ts
@@ -365,15 +365,18 @@ export namespace StmtNS {
     readonly kind = "FromImport";
     module: Token;
     names: { name: Token; alias: Token | null }[];
+    level: number;
     constructor(
       startToken: Token,
       endToken: Token,
       module: Token,
       names: { name: Token; alias: Token | null }[],
+      level: number,
     ) {
       super(startToken, endToken);
       this.module = module;
       this.names = names;
+      this.level = level;
     }
     override accept(visitor: Visitor<any>): any {
       return visitor.visitFromImportStmt(this);

--- a/src/conductor/Py2JsEvaluator.ts
+++ b/src/conductor/Py2JsEvaluator.ts
@@ -77,9 +77,35 @@ abstract class Py2JsEvaluatorBase extends BasicEvaluator {
       onOutput: line => this.conductor.sendOutput(line),
       onPendingWorkChange: delta => (delta > 0 ? this.beginPendingWork() : this.endPendingWork()),
       requestInput: prompt => this.conductor.requestInput(prompt),
+      // A local import (`from .foo import x`, source-academy/py-slang#378)
+      // resolves a sibling file through this — conductor's own
+      // requestFile(fileName), already backed by whatever multi-file store
+      // the host has (e.g. the frontend's folder-mode BrowserFS), the same
+      // primitive BasicEvaluator.startEvaluator already uses to fetch the
+      // entrypoint itself. No new host-side protocol needed.
+      fileGetter: path => this.conductor.requestFile(path),
       dataHandler,
       dataVisualizer: this.dataVisualizerPlugin,
     });
+  }
+
+  /**
+   * The host's own entrypoint file name (e.g. "/main.py" in a folder-mode
+   * program) — BasicEvaluator's default evaluateFile discards it, but a
+   * local import needs to know what directory "." means, so this override
+   * captures it on the session before delegating exactly as the default
+   * implementation would.
+   *
+   * (`__program__` needs no help from here: Py2JsSession.runChunkInternal
+   * sets it itself, automatically, from whatever text it's actually about
+   * to compile — see that method's own comment. This evaluator used to
+   * never supply it at all, which crashed every reference to `__program__`
+   * with a raw ReferenceError rather than a Python-level NameError; fixed
+   * at the source rather than by adding another external call here.)
+   */
+  async evaluateFile(fileName: string, fileContent: string): Promise<void> {
+    this.session.setEntrypointFilePath(fileName);
+    return this.evaluateChunk(fileContent);
   }
 
   async evaluateChunk(chunk: string): Promise<void> {

--- a/src/conductor/PyPvmlEvaluator.ts
+++ b/src/conductor/PyPvmlEvaluator.ts
@@ -134,6 +134,14 @@ abstract class PyPvmlEvaluatorBase extends BasicEvaluator {
     const importsByModule = new Map<string, { name: string; alias: string | undefined }[]>();
     for (const stmt of ast.statements) {
       if (stmt instanceof StmtNS.FromImport) {
+        if (stmt.level > 0) {
+          // Local-file imports (leading dots) aren't implemented on PVML yet
+          // (see py2js for the supported engine) — reject explicitly rather
+          // than treating the dotted path as a conductor module name.
+          throw new Error(
+            "ImportError: relative imports (e.g. 'from .module import name') are not yet supported by this engine.",
+          );
+        }
         const moduleName = stmt.module.lexeme;
         if (!importsByModule.has(moduleName)) {
           importsByModule.set(moduleName, []);

--- a/src/conductor/PyPvmlEvaluator.ts
+++ b/src/conductor/PyPvmlEvaluator.ts
@@ -5,6 +5,7 @@ import { moduleToPvml } from "../engines/pvml/modules";
 import { PVMLBoxType } from "../engines/pvml/types";
 import { PVMLCompiler } from "../engines/pvml/pvml-compiler";
 import { PVMLInterpreter } from "../engines/pvml/pvml-interpreter";
+import { RELATIVE_IMPORT_NOT_SUPPORTED_MESSAGE } from "../errors";
 import { parse } from "../parser/parser-adapter";
 import { analyzeWithEnvironments } from "../resolver";
 import linkedList from "../stdlib/linked-list";
@@ -138,9 +139,7 @@ abstract class PyPvmlEvaluatorBase extends BasicEvaluator {
           // Local-file imports (leading dots) aren't implemented on PVML yet
           // (see py2js for the supported engine) — reject explicitly rather
           // than treating the dotted path as a conductor module name.
-          throw new Error(
-            "ImportError: relative imports (e.g. 'from .module import name') are not yet supported by this engine.",
-          );
+          throw new Error(RELATIVE_IMPORT_NOT_SUPPORTED_MESSAGE);
         }
         const moduleName = stmt.module.lexeme;
         if (!importsByModule.has(moduleName)) {

--- a/src/conductor/PyWasmEvaluator.ts
+++ b/src/conductor/PyWasmEvaluator.ts
@@ -68,6 +68,15 @@ class PyWasmEvaluator extends BasicEvaluator {
     const importsByModule = new Map<string, { name: string; alias: string | undefined }[]>();
     for (const stmt of ast.statements) {
       if (stmt instanceof StmtNS.FromImport) {
+        if (stmt.level > 0) {
+          // Local-file imports (leading dots) aren't implemented on the WASM
+          // engine yet (see py2js for the supported engine) — reject
+          // explicitly rather than treating the dotted path as a conductor
+          // module name.
+          throw new Error(
+            "ImportError: relative imports (e.g. 'from .module import name') are not yet supported by this engine.",
+          );
+        }
         const moduleName = stmt.module.lexeme;
         if (!importsByModule.has(moduleName)) {
           importsByModule.set(moduleName, []);

--- a/src/conductor/PyWasmEvaluator.ts
+++ b/src/conductor/PyWasmEvaluator.ts
@@ -8,6 +8,7 @@ import { ModuleLoaderRunnerPlugin } from "@sourceacademy/runner-module-loader";
 import { StmtNS } from "../ast-types";
 import { compileToWasmAndRun } from "../engines/wasm";
 import { prepareModuleBindings, PreparedModuleBindings } from "../engines/wasm/moduleInterop";
+import { RELATIVE_IMPORT_NOT_SUPPORTED_MESSAGE } from "../errors";
 import { parse } from "../parser/parser-adapter";
 import linkedList from "../stdlib/linked-list";
 import list from "../stdlib/list";
@@ -73,9 +74,7 @@ class PyWasmEvaluator extends BasicEvaluator {
           // engine yet (see py2js for the supported engine) — reject
           // explicitly rather than treating the dotted path as a conductor
           // module name.
-          throw new Error(
-            "ImportError: relative imports (e.g. 'from .module import name') are not yet supported by this engine.",
-          );
+          throw new Error(RELATIVE_IMPORT_NOT_SUPPORTED_MESSAGE);
         }
         const moduleName = stmt.module.lexeme;
         if (!importsByModule.has(moduleName)) {

--- a/src/engines/cse/interpreter.ts
+++ b/src/engines/cse/interpreter.ts
@@ -26,7 +26,7 @@ import {
 } from "./environment";
 import { handleRuntimeError, UnknownEvaluatorError } from "./error";
 import * as instrCreator from "./instrCreator";
-import { loadModules, moduleToPython } from "./modules";
+import { loadModules, moduleToPython, RelativeImportNotSupportedError } from "./modules";
 import { evaluateBinaryExpression, evaluateUnaryExpression, isFalsy } from "./operators";
 import { Stash, Value } from "./stash";
 import { displayError } from "./streams";
@@ -200,6 +200,12 @@ async function evaluateImports(
   }
   if (context.evaluator === null || context.conductor === null) {
     throw new Error("Context is not properly initialized with evaluator and conductor");
+  }
+
+  for (const nodes of importNodeMap.values()) {
+    if (nodes.some(n => n.node.level > 0)) {
+      handleRuntimeError(context, new RelativeImportNotSupportedError());
+    }
   }
 
   await loadModules(context, [...importNodeMap.keys()]);

--- a/src/engines/cse/interpreter.ts
+++ b/src/engines/cse/interpreter.ts
@@ -203,8 +203,9 @@ async function evaluateImports(
   }
 
   for (const nodes of importNodeMap.values()) {
-    if (nodes.some(n => n.node.level > 0)) {
-      handleRuntimeError(context, new RelativeImportNotSupportedError());
+    const offending = nodes.find(n => n.node.level > 0);
+    if (offending !== undefined) {
+      handleRuntimeError(context, new RelativeImportNotSupportedError(offending.node));
     }
   }
 

--- a/src/engines/cse/modules.ts
+++ b/src/engines/cse/modules.ts
@@ -5,7 +5,7 @@ import {
   TypedValue,
 } from "@sourceacademy/conductor/types";
 import { ModuleLoaderRunnerPlugin } from "@sourceacademy/runner-module-loader";
-import { ExprNS } from "../../ast-types";
+import { ExprNS, StmtNS } from "../../ast-types";
 import { RuntimeSourceError } from "../../errors";
 import { Context } from "./context";
 import { handleRuntimeError } from "./error";
@@ -26,8 +26,8 @@ export class ModuleNotFoundError extends RuntimeSourceError {
  * path as a conductor module name, which would either 404 confusingly or,
  * worse, collide with an unrelated real module of the same bare name. */
 export class RelativeImportNotSupportedError extends RuntimeSourceError {
-  constructor() {
-    super();
+  constructor(node?: StmtNS.FromImport) {
+    super(node);
     this.message =
       "ImportError: relative imports (e.g. 'from .module import name') are not yet supported by this engine.";
   }

--- a/src/engines/cse/modules.ts
+++ b/src/engines/cse/modules.ts
@@ -6,7 +6,7 @@ import {
 } from "@sourceacademy/conductor/types";
 import { ModuleLoaderRunnerPlugin } from "@sourceacademy/runner-module-loader";
 import { ExprNS, StmtNS } from "../../ast-types";
-import { RuntimeSourceError } from "../../errors";
+import { RELATIVE_IMPORT_NOT_SUPPORTED_MESSAGE, RuntimeSourceError } from "../../errors";
 import { Context } from "./context";
 import { handleRuntimeError } from "./error";
 import { appInstr } from "./instrCreator";
@@ -28,8 +28,7 @@ export class ModuleNotFoundError extends RuntimeSourceError {
 export class RelativeImportNotSupportedError extends RuntimeSourceError {
   constructor(node?: StmtNS.FromImport) {
     super(node);
-    this.message =
-      "ImportError: relative imports (e.g. 'from .module import name') are not yet supported by this engine.";
+    this.message = RELATIVE_IMPORT_NOT_SUPPORTED_MESSAGE;
   }
 }
 

--- a/src/engines/cse/modules.ts
+++ b/src/engines/cse/modules.ts
@@ -20,6 +20,19 @@ export class ModuleNotFoundError extends RuntimeSourceError {
   }
 }
 
+/** `from .foo import x` / `from ..pkg.foo import x` (level > 0): local-file
+ * imports are not implemented on the CSE machine yet (see py2js for the
+ * supported engine) — reject explicitly rather than treating the dotted
+ * path as a conductor module name, which would either 404 confusingly or,
+ * worse, collide with an unrelated real module of the same bare name. */
+export class RelativeImportNotSupportedError extends RuntimeSourceError {
+  constructor() {
+    super();
+    this.message =
+      "ImportError: relative imports (e.g. 'from .module import name') are not yet supported by this engine.";
+  }
+}
+
 export async function loadModules(context: Context, moduleNames: string[]): Promise<void> {
   await Promise.all(
     moduleNames.map(async moduleName => {

--- a/src/engines/pvml/pvml-compiler.ts
+++ b/src/engines/pvml/pvml-compiler.ts
@@ -1118,6 +1118,17 @@ export class PVMLCompiler
   }
 
   visitFromImportStmt(_stmt: StmtNS.FromImport): ExpressionResult {
+    if (_stmt.level > 0) {
+      // Local-file imports (leading dots) aren't implemented on PVML yet —
+      // reject explicitly rather than silently no-op'ing, which would leave
+      // the imported name unbound instead of raising a clear error (see
+      // PyPvmlEvaluator.ts's loadImports, which already rejects this earlier
+      // for the conductor entrypoint; this is the same guard for any direct,
+      // non-conductor caller).
+      throw new Error(
+        "ImportError: relative imports (e.g. 'from .module import name') are not yet supported by this engine.",
+      );
+    }
     // A genuine no-op, matching the CSE machine's own FromImport handler
     // (src/engines/cse/interpreter.ts): SICPy has no real per-file module
     // system — every stdlib group's names are preloaded into the global

--- a/src/engines/pvml/pvml-compiler.ts
+++ b/src/engines/pvml/pvml-compiler.ts
@@ -1,4 +1,5 @@
 import { ExprNS, StmtNS } from "../../ast-types";
+import { RELATIVE_IMPORT_NOT_SUPPORTED_MESSAGE } from "../../errors";
 import { Environment, FunctionEnvironments, Resolver } from "../../resolver";
 import math from "../../stdlib/math";
 import misc from "../../stdlib/misc";
@@ -1125,9 +1126,7 @@ export class PVMLCompiler
       // PyPvmlEvaluator.ts's loadImports, which already rejects this earlier
       // for the conductor entrypoint; this is the same guard for any direct,
       // non-conductor caller).
-      throw new Error(
-        "ImportError: relative imports (e.g. 'from .module import name') are not yet supported by this engine.",
-      );
+      throw new Error(RELATIVE_IMPORT_NOT_SUPPORTED_MESSAGE);
     }
     // A genuine no-op, matching the CSE machine's own FromImport handler
     // (src/engines/cse/interpreter.ts): SICPy has no real per-file module

--- a/src/engines/py2js/index.ts
+++ b/src/engines/py2js/index.ts
@@ -293,7 +293,12 @@ async function prepareDual(
   if (hasLocalImports(ast.statements)) {
     const entrypointFilePath = options.entrypointFilePath ?? "/main.py";
     try {
-      effectiveScript = await bundleLocalImports(script, entrypointFilePath, toFileGetter(options), variant);
+      effectiveScript = await bundleLocalImports(
+        script,
+        entrypointFilePath,
+        toFileGetter(options),
+        variant,
+      );
     } catch (e: unknown) {
       throw new Py2JsRunError("analysis", (e as Error)?.message ?? String(e));
     }

--- a/src/engines/py2js/index.ts
+++ b/src/engines/py2js/index.ts
@@ -27,6 +27,8 @@ import parser from "../../stdlib/parser";
 import stream from "../../stdlib/stream";
 import type { Group } from "../../stdlib/utils";
 import { makeValidatorsForChapter } from "../../validator";
+import { StmtNS } from "../../ast-types";
+import { bundleLocalImports } from "../../modules/localImports";
 import { CompileMode, compileProgram, Py2JsCompileError } from "./compiler";
 import { hasImports, loadChunkImports } from "./moduleInterop";
 import { annotateHostFunction, Py2JsRuntime, Py2JsRuntimeError, PyValue } from "./runtime";
@@ -68,11 +70,56 @@ export interface RunPy2JsOptions {
    * callSync / acall).
    */
   extraBuiltins?: Record<string, PyValue> | ((rt: Py2JsRuntime) => Record<string, PyValue>);
+  /**
+   * Sibling files `code` (the entrypoint) can locally import from
+   * (`from .foo import x`), keyed by absolute path (e.g. `"/utils.py"`) —
+   * see src/modules/localImports.ts. Only honored by
+   * runCodePy2JsDual/Py2JsSession: a local import may need to compile and
+   * run another file first, which is inherently async, so runCodePy2Js's
+   * synchronous contract cannot support it (the same pre-existing
+   * limitation it already has for conductor-module imports). Ignored when
+   * `fileGetter` is supplied.
+   */
+  files?: Record<string, string>;
+  /**
+   * Resolves a sibling file on demand instead of requiring the whole
+   * program up front — e.g. the conductor evaluator passes
+   * `path => conductor.requestFile(path)`, backed by whatever multi-file
+   * store the host (the frontend's folder-mode BrowserFS) already has.
+   * Takes priority over `files` when both are given.
+   */
+  fileGetter?: (path: string) => Promise<string | undefined>;
+  /** The entrypoint's own key into `files` (and, for Py2JsSession, into
+   * every chunk it runs against the same persistent environment) — what a
+   * sibling file's relative import is resolved against. Defaults to
+   * `"/main.py"`. */
+  entrypointFilePath?: string;
 }
 
 export interface RunPy2JsResult {
   /** Everything the program printed via print(), concatenated. */
   output: string;
+}
+
+/** `fileGetter` wins when both are given (see RunPy2JsOptions doc); a plain
+ * `files` map is just wrapped into the same async shape
+ * src/modules/localImports.ts expects — always defined, even with neither
+ * option set (a program with no local imports never calls it). */
+function toFileGetter(
+  options: Pick<RunPy2JsOptions, "files" | "fileGetter">,
+): (path: string) => Promise<string | undefined> {
+  if (options.fileGetter) return options.fileGetter;
+  const files = options.files ?? {};
+  return path => Promise.resolve(files[path]);
+}
+
+/** True iff `statements` contains a local (level > 0) import — the signal
+ * to bundle before doing anything else (see bundleLocalImports). A program
+ * with only level === 0 (conductor-module) imports, or none at all, is
+ * completely unaffected — bundleLocalImports itself would also no-op for
+ * these, but checking here avoids even parsing/walking for it. */
+function hasLocalImports(statements: StmtNS.Stmt[]): boolean {
+  return statements.some(s => s.kind === "FromImport" && (s as StmtNS.FromImport).level > 0);
 }
 
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
@@ -129,12 +176,19 @@ function compileScript(
   }
 }
 
-function prepare(
+/**
+ * Builds a fresh runtime for `code` at `variant`: bridges the chapter's
+ * stdlib groups and extraBuiltins, then runs the chapter's group preludes
+ * (always sync — see the inline comment below). Shared by both `prepare()`
+ * (sync path) and `prepareDual()` (async path, so local-file imports in the
+ * main script itself can be resolved with an `await` in between this setup
+ * and compiling that script — see prepareDual's own doc comment).
+ */
+function setupRuntime(
   code: string,
   variant: number,
-  mode: CompileMode,
   options: RunPy2JsOptions,
-): { rt: Py2JsRuntime; js: string } {
+): { rt: Py2JsRuntime; script: string } {
   if (!SUPPORTED_CHAPTERS.includes(variant)) {
     throw new Py2JsRunError(
       "parse",
@@ -191,8 +245,90 @@ function prepare(
     }
   }
 
+  return { rt, script };
+}
+
+function prepare(
+  code: string,
+  variant: number,
+  mode: CompileMode,
+  options: RunPy2JsOptions,
+): { rt: Py2JsRuntime; js: string } {
+  const { rt, script } = setupRuntime(code, variant, options);
   const js = compileScript(rt, script, variant, mode);
   return { rt, js };
+}
+
+/**
+ * Async counterpart to `prepare()`, used only by runCodePy2JsDual: after
+ * `setupRuntime`, parses the main script and — only if it has a local
+ * (level > 0) import anywhere — flattens it first via bundleLocalImports
+ * (src/modules/localImports.ts), a pure source-to-source transform, and
+ * reparses the result; `__program__` is updated to that flattened text so
+ * it can be shown to students. Either way, what gets resolved/compiled from
+ * here on is just an ordinary single-file program — level === 0
+ * (conductor-module) imports are a separate, pre-existing concern this
+ * function has never touched (and still doesn't): the one-shot API has no
+ * async pre-pass for those, on purpose, matching its behavior before this
+ * feature existed. This is why the sync `prepare()`/`runCodePy2Js` above
+ * cannot support `options.files`/`fileGetter` at all: resolving a local
+ * import may need to bundle another file's contents in first, which is
+ * inherently async.
+ */
+async function prepareDual(
+  code: string,
+  variant: number,
+  options: RunPy2JsOptions,
+): Promise<{ rt: Py2JsRuntime; js: string }> {
+  const { rt, script } = setupRuntime(code, variant, options);
+
+  let ast;
+  try {
+    ast = parse(script);
+  } catch (e: unknown) {
+    throw new Py2JsRunError("parse", String((e as { message?: string })?.message ?? e));
+  }
+
+  let effectiveScript = script;
+  if (hasLocalImports(ast.statements)) {
+    const entrypointFilePath = options.entrypointFilePath ?? "/main.py";
+    try {
+      effectiveScript = await bundleLocalImports(script, entrypointFilePath, toFileGetter(options), variant);
+    } catch (e: unknown) {
+      throw new Py2JsRunError("analysis", (e as Error)?.message ?? String(e));
+    }
+    rt.builtins.__program__ = effectiveScript;
+    try {
+      ast = parse(effectiveScript);
+    } catch (e: unknown) {
+      throw new Py2JsRunError("parse", String((e as { message?: string })?.message ?? e));
+    }
+  }
+
+  const priorGlobals = Object.keys(rt.globals);
+  const resolver = new Resolver(
+    effectiveScript,
+    ast,
+    makeValidatorsForChapter(variant),
+    [],
+    Object.keys(rt.builtins),
+    priorGlobals,
+  );
+  const errors = resolver.resolve(ast);
+  if (errors.length > 0) {
+    throw new Py2JsRunError("analysis", errors.map(e => e.message).join("\n"));
+  }
+
+  try {
+    const js = compileProgram(ast, Object.keys(rt.builtins), {
+      mode: "dual",
+      repl: { priorGlobals },
+    });
+    return { rt, js };
+  } catch (e: unknown) {
+    if (e instanceof Py2JsCompileError) throw new Py2JsRunError("analysis", e.message);
+    throw e;
+  }
 }
 
 /**
@@ -228,7 +364,7 @@ export async function runCodePy2JsDual(
   variant: number,
   options: RunPy2JsOptions = {},
 ): Promise<RunPy2JsResult> {
-  const { rt, js } = prepare(code, variant, "dual", options);
+  const { rt, js } = await prepareDual(code, variant, options);
   try {
     await new AsyncFunction("__py", js)(rt);
   } catch (e: unknown) {
@@ -281,15 +417,6 @@ export interface Py2JsSessionOptions extends RunPy2JsOptions {
    * al. never pass one), in which case draw_data is a silent no-op.
    */
   dataVisualizer?: BaseDataVisualizerRunnerPlugin<PyValue>;
-  /**
-   * `__program__`'s value for this session — "the string representation of
-   * the editor content at the time when 'Run' was last pressed" per
-   * docs/specs/python_interpreter.tex, for the REPL case. Mirrors
-   * PVMLInterpreter's own `programText` option (pvml-interpreter.ts). Left
-   * unset (rather than defaulting to e.g. an empty string) if the caller
-   * never supplies one, matching PVML's own conditional-set behavior.
-   */
-  programText?: string;
 }
 
 /**
@@ -306,19 +433,38 @@ export interface Py2JsSessionOptions extends RunPy2JsOptions {
  * or the runtime's Py2JsRuntimeError — so callers like the conductor
  * evaluator keep the error's name and any source location it carries.
  *
- * A chunk with `from X import y` is loaded (module requested, exports
- * converted to native values — moduleInterop.ts's loadChunkImports) in an
- * async pre-pass before it compiles, and that one chunk compiles in dual
- * mode so its FromImport-bound module functions are callable via `acall`;
- * every other chunk stays on the fast sync path (see compiler.ts's mode doc
- * and the engine README's module-interop notes on why this crosses one
- * unavoidable microtask per call regardless).
+ * A chunk with `from X import y` is loaded before it compiles: `level > 0`
+ * (a local file) is flattened away entirely by bundleLocalImports
+ * (src/modules/localImports.ts, a pure source-to-source transform — see its
+ * own doc comment) before this chunk is even parsed for real; `level === 0`
+ * (a conductor module — including one hoisted out of a bundled dependency
+ * file) is loaded the same way it always has been, via
+ * moduleInterop.ts's loadChunkImports. Either kind of import forces this
+ * chunk onto the dual (async) compile spine so its FromImport-bound
+ * bindings are callable via `acall`; every other chunk stays on the fast
+ * sync path (see compiler.ts's mode doc and the engine README's module-
+ * interop notes on why this crosses one unavoidable microtask per call
+ * regardless).
  */
 export class Py2JsSession {
   readonly rt: Py2JsRuntime;
   private readonly variant: number;
   private readonly groups: Group[];
   private readonly dataHandler: IDataHandler;
+  /** Every chunk this session runs is resolved as if it were this path's own
+   * content, for the purposes of relative-import resolution (what directory
+   * "." means). Mutable: the conductor evaluator doesn't learn the real
+   * entrypoint path until its own evaluateFile(fileName, ...) override — the
+   * host's own file-naming choice, called after this session already
+   * exists — so it calls setEntrypointFilePath() first. Defaults to
+   * "/main.py" for callers (runCodePy2JsDual, tests) that never do. */
+  private entrypointFilePath: string;
+  /** Resolves a sibling file a local import needs — see
+   * src/modules/localImports.ts's LocalFileGetter. Fixed at construction
+   * (unlike entrypointFilePath):
+   * the conductor evaluator already has `conductor` in its own constructor,
+   * so `path => conductor.requestFile(path)` is available immediately. */
+  private readonly fileGetter: (path: string) => Promise<string | undefined>;
   private preludeLoaded = false;
 
   constructor(variant: number, options: Py2JsSessionOptions = {}) {
@@ -331,13 +477,12 @@ export class Py2JsSession {
     this.variant = variant;
     this.groups = PY2JS_GROUPS[variant] ?? [];
     this.dataHandler = options.dataHandler ?? new GenericDataHandler();
+    this.entrypointFilePath = options.entrypointFilePath ?? "/main.py";
+    this.fileGetter = toFileGetter(options);
     this.rt = new Py2JsRuntime(variant >= 3);
     this.rt.onOutput = options.onOutput;
     this.rt.onPendingWorkChange = options.onPendingWorkChange;
     this.rt.requestInput = options.requestInput;
-    if (options.programText !== undefined) {
-      this.rt.builtins.__program__ = options.programText;
-    }
 
     // Same builtin layering as prepare(): bridged stdlib under the native
     // core, extraBuiltins over everything. The bridge's source string is
@@ -351,6 +496,25 @@ export class Py2JsSession {
     for (const [name, value] of Object.entries(extraResolved)) {
       this.rt.builtins[name] = annotateHostFunction(name, value);
     }
+  }
+
+  /** Sets what path a relative import (`from .foo import x`) run against this
+   * session resolves against — the conductor evaluator calls this from its
+   * evaluateFile(fileName, ...) override, since it only learns the host's
+   * chosen entrypoint path then, after this session already exists. */
+  setEntrypointFilePath(path: string): void {
+    this.entrypointFilePath = path;
+  }
+
+  /** `__program__` is simply "the single string Python program that gets
+   * compiled to JS" — runChunkInternal is the only caller, setting this
+   * from whatever text it's actually about to compile for a given chunk
+   * (see its own comment); no external caller needs to (or should) manage
+   * this separately, exactly mirroring how the CSE machine keeps its own
+   * `__program__` current internally (interpreter.ts's own
+   * pyDefineVariable("__program__", ...)). */
+  private setProgramText(text: string): void {
+    this.rt.builtins.__program__ = text;
   }
 
   /** Compile and run one chunk against the persistent globals. */
@@ -367,8 +531,34 @@ export class Py2JsSession {
   }
 
   private async runChunkInternal(code: string): Promise<void> {
-    const script = code.endsWith("\n") ? code : code + "\n";
-    const ast = parse(script);
+    let script = code.endsWith("\n") ? code : code + "\n";
+    let ast = parse(script);
+
+    // Local (level > 0) imports are flattened away entirely before anything
+    // else happens — a pure source-to-source transform (see
+    // src/modules/localImports.ts), so everything below sees an ordinary
+    // single-file program either way. `priorGlobalNames` (this session's
+    // existing globals) lets a dependency already bundled by an earlier
+    // chunk be recognized and skipped rather than re-bundled/re-run.
+    if (hasLocalImports(ast.statements)) {
+      script = await bundleLocalImports(
+        script,
+        this.entrypointFilePath,
+        this.fileGetter,
+        this.variant,
+        new Set(Object.keys(this.rt.globals)),
+      );
+      ast = parse(script);
+    }
+
+    // __program__ is simply "the single string Python program that gets
+    // compiled to JS" — set here, unconditionally, from whatever that
+    // actually is for this call (the chunk's own text, or the flattened
+    // text if it just got bundled), exactly mirroring the CSE machine's own
+    // pyDefineVariable("__program__", ...) (interpreter.ts): the engine
+    // itself keeps this current, so no external caller (the conductor
+    // evaluator's evaluateFile, in particular) has to remember to.
+    this.setProgramText(script);
 
     // Prior chunks' global names are passed as the resolver's module-level
     // names (its REPL parameter), exactly how the PVML evaluator seeds
@@ -385,6 +575,9 @@ export class Py2JsSession {
     const errors = resolver.resolve(ast);
     if (errors.length > 0) throw errors[0];
 
+    // level === 0 (conductor-module) imports — including any the flattening
+    // above hoisted out of a bundled dependency file — are unaffected by
+    // any of this: still loaded and bound exactly as they always have been.
     const imports = hasImports(ast.statements);
     if (imports) {
       const bindings = await loadChunkImports(this.rt, this.dataHandler, ast.statements);

--- a/src/engines/py2js/runtime.ts
+++ b/src/engines/py2js/runtime.ts
@@ -573,6 +573,7 @@ export class Py2JsRuntime {
     return this.pendingImports[name];
   }
 
+
   /** None singleton alias so compiled code can say __py.None. */
   readonly None = null;
 

--- a/src/engines/py2js/runtime.ts
+++ b/src/engines/py2js/runtime.ts
@@ -573,7 +573,6 @@ export class Py2JsRuntime {
     return this.pendingImports[name];
   }
 
-
   /** None singleton alias so compiled code can say __py.None. */
   readonly None = null;
 

--- a/src/engines/wasm/builderGenerator.ts
+++ b/src/engines/wasm/builderGenerator.ts
@@ -13,6 +13,7 @@ import {
   type WasmRaw,
 } from "@sourceacademy/wasm-util";
 import { ExprNS, StmtNS } from "../../ast-types";
+import { RELATIVE_IMPORT_NOT_SUPPORTED_MESSAGE } from "../../errors";
 import { TokenType } from "../../tokenizer";
 import { LibFuncType } from "./library";
 import {
@@ -986,9 +987,7 @@ export class BuilderGenerator implements BuilderVisitor<WasmInstruction, WasmNum
       // as a conductor module name (see PyWasmEvaluator.ts's loadImports,
       // which already rejects this earlier for the conductor entrypoint;
       // this is the same guard for any direct, non-conductor caller).
-      throw new Error(
-        "ImportError: relative imports (e.g. 'from .module import name') are not yet supported by this engine.",
-      );
+      throw new Error(RELATIVE_IMPORT_NOT_SUPPORTED_MESSAGE);
     }
     return wasm.raw`${stmt.names.map(spec => {
       const boundName = (spec.alias ?? spec.name).lexeme;

--- a/src/engines/wasm/builderGenerator.ts
+++ b/src/engines/wasm/builderGenerator.ts
@@ -980,6 +980,16 @@ export class BuilderGenerator implements BuilderVisitor<WasmInstruction, WasmNum
    * also why it must run during main() rather than at instantiation time
    * (heap/shadow-stack globals are only live inside main). */
   visitFromImportStmt(stmt: StmtNS.FromImport): WasmInstruction {
+    if (stmt.level > 0) {
+      // Local-file imports (leading dots) aren't implemented on the WASM
+      // engine yet — reject explicitly rather than treating the dotted path
+      // as a conductor module name (see PyWasmEvaluator.ts's loadImports,
+      // which already rejects this earlier for the conductor entrypoint;
+      // this is the same guard for any direct, non-conductor caller).
+      throw new Error(
+        "ImportError: relative imports (e.g. 'from .module import name') are not yet supported by this engine.",
+      );
+    }
     return wasm.raw`${stmt.names.map(spec => {
       const boundName = (spec.alias ?? spec.name).lexeme;
       const bindingIndex = this.moduleBindingIndices.get(boundName);

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -693,7 +693,14 @@ export class ModuleFunctionNotFoundError extends RuntimeSourceError {
 }
 
 /*
-    The offset is calculated as follows:    
+    The offset is calculated as follows:
     Current position is one after real position of end of token: 1
 */
 export const MAGIC_OFFSET = 1;
+
+/** `from .foo import x` / `from ..pkg.foo import x` (level > 0): the message
+ * every engine that doesn't implement local-file imports (see py2js, the
+ * only engine that does — src/modules/localImports.ts) rejects with, kept
+ * in one place so CSE/PVML/WASM's guards can't drift out of sync. */
+export const RELATIVE_IMPORT_NOT_SUPPORTED_MESSAGE =
+  "ImportError: relative imports (e.g. 'from .module import name') are not yet supported by this engine.";

--- a/src/generate-ast.ts
+++ b/src/generate-ast.ts
@@ -89,7 +89,7 @@ export class AstWriter {
       "Break      -> ()",
       "Continue   -> ()",
       "Return     -> value: ExprNS.Expr | null",
-      "FromImport -> module: Token, names: { name: Token; alias: Token | null }[]",
+      "FromImport -> module: Token, names: { name: Token; alias: Token | null }[], level: number",
       "Global     -> name: Token",
       "NonLocal   -> name: Token",
       "Assert     -> value: ExprNS.Expr",

--- a/src/modules/localImports.ts
+++ b/src/modules/localImports.ts
@@ -210,7 +210,11 @@ interface SplitStatements {
   boundNames: Set<string>;
 }
 
-function splitStatements(source: string, statements: StmtNS.Stmt[], currentPath: string): SplitStatements {
+function splitStatements(
+  source: string,
+  statements: StmtNS.Stmt[],
+  currentPath: string,
+): SplitStatements {
   const pieces: string[] = [];
   const level0ImportTexts: string[] = [];
   const localImportTargets: string[] = [];
@@ -225,7 +229,9 @@ function splitStatements(source: string, statements: StmtNS.Stmt[], currentPath:
       const exportsVar = exportsVarName(targetPath);
       for (const spec of stmt.names) {
         const bound = (spec.alias ?? spec.name).lexeme;
-        pieces.push(`${bound} = ${ACCESS_HELPER_NAME}(${exportsVar}, ${JSON.stringify(spec.name.lexeme)})`);
+        pieces.push(
+          `${bound} = ${ACCESS_HELPER_NAME}(${exportsVar}, ${JSON.stringify(spec.name.lexeme)})`,
+        );
       }
       continue;
     }
@@ -257,7 +263,11 @@ interface BundleState {
   needsAccessHelper: boolean;
 }
 
-async function bundleFile(state: BundleState, source: string, path: string): Promise<SplitStatements> {
+async function bundleFile(
+  state: BundleState,
+  source: string,
+  path: string,
+): Promise<SplitStatements> {
   const script = source.endsWith("\n") ? source : source + "\n";
   const ast = parse(script);
   const split = splitStatements(script, ast.statements, path);

--- a/src/modules/localImports.ts
+++ b/src/modules/localImports.ts
@@ -1,0 +1,348 @@
+/**
+ * Local-file ("folder") imports — a genuine source-to-source transform,
+ * mirroring js-slang's own local-module preprocessor (js-slang's
+ * src/modules/preprocessor/) but literally: `from .foo import bar`
+ * (level > 0 — a leading-dot relative import, Python's own syntax for "a
+ * file relative to me", not a Source Academy module) resolves against a
+ * program's own file map, and the whole multi-file program is flattened
+ * into ONE Python source string — exactly the artifact a student could be
+ * shown, and exactly what every py-slang engine already knows how to parse
+ * and run, unmodified. See source-academy/py-slang#378.
+ *
+ * Each locally-imported file becomes a `def __module_<slug>__(): ...`
+ * wrapping that file's own statements (copied verbatim from its source),
+ * returning a genuine SICPy linked list of (name, value) pairs — Python has
+ * no `export` keyword, so every top-level binding qualifies, exactly
+ * mirroring js-slang's own local-import bundler down to the generated
+ * `__access_named_export__` helper being line-for-line the same walk as
+ * its `__access_named_export__` prelude function (js-slang's
+ * localImport.prelude.ts). This is why local imports need SICPy §2 or
+ * higher: chapter 1 has no pair/list library to build that transfer
+ * structure from — the identical restriction js-slang's own folders have on
+ * Source §1, and for the identical reason.
+ *
+ * `level === 0` (a bare name, e.g. `from rune import show`) is a Source
+ * Academy module, not a local file — hoisted verbatim to the top of the
+ * flattened program (mirroring js-slang's bundler.ts's own hoisting of
+ * Source-module imports across every bundled file), so whichever engine
+ * runs the flattened text still resolves it exactly as it always has: every
+ * engine's own module-loading pre-pass only ever looks at a program's
+ * top-level statements, and the grammar guarantees FromImport can only ever
+ * appear there anyway (program's own grammar rule parses a leading run of
+ * import statements before anything else, in every file) — so hoisting
+ * never needs to reach inside a nested block to find one.
+ *
+ * A dependency's `__exports_<slug>__` name is deterministic — the same
+ * absolute path always produces the same identifier — so a name already
+ * bound from an earlier chunk in the same persistent session (see
+ * `priorGlobalNames`) is recognized without needing any separate runtime
+ * cache: bundling simply skips re-declaring/re-invoking that file and
+ * reuses the existing binding, exactly the same mechanism REPL-mode
+ * compilation (compiler.ts) already uses for "does an earlier chunk already
+ * have this name" — no new runtime state needed anywhere.
+ *
+ * Known simplification: a top-level name that's only conditionally bound
+ * (e.g. assigned inside an `if` with no matching `else`, and that branch
+ * never runs) is referenced directly when building the returned pair list
+ * — if it was truly never assigned, this raises Python's own NameError, the
+ * same as referencing it directly in the file's own code would. There's no
+ * softer failure mode available: SICPy has neither `try`/`except` nor
+ * `locals()`/dict introspection to detect "bound or not" without one of
+ * those. This only surfaces for the (rare) combination of a conditionally-
+ * unbound top-level name that's also imported by another file.
+ */
+import { StmtNS } from "../ast-types";
+import { parse } from "../parser";
+
+/** Resolves an absolute path to its source, or `undefined` if no such file
+ * exists — the same shape as js-slang's own `FileGetter`. */
+export type LocalFileGetter = (path: string) => Promise<string | undefined>;
+
+export class LocalImportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LocalImportError";
+  }
+}
+
+const INDENT = "    ";
+
+/** Prepends `indent` to every non-empty line — blank lines stay blank
+ * rather than becoming trailing whitespace. */
+function indentBlock(text: string, indent: string = INDENT): string {
+  return text
+    .split("\n")
+    .map(line => (line.length > 0 ? indent + line : line))
+    .join("\n");
+}
+
+/** A statement's own original source text, unchanged — reusing the same
+ * span convention as errors.ts's snippet rendering. */
+function spanText(source: string, stmt: StmtNS.Stmt): string {
+  return source.substring(
+    stmt.startToken.indexInSource,
+    stmt.endToken.indexInSource + stmt.endToken.lexeme.length,
+  );
+}
+
+function isFromImport(s: StmtNS.Stmt): s is StmtNS.FromImport {
+  return s.kind === "FromImport";
+}
+
+/**
+ * Resolves a relative import's target file, mirroring CPython's own
+ * relative-import semantics: `level` is the number of leading dots (1 = the
+ * importing file's own directory, 2 = its parent, ...), and `moduleDotted`
+ * (e.g. `"pkg.utils"`) is a further dotted path under that directory. No
+ * `__init__.py` package semantics — every `.py` file is a flat, standalone
+ * module (a "folder of files" model, not a full Python package system),
+ * with a `.py` extension always implied on the final segment.
+ */
+export function resolveLocalModulePath(
+  fromPath: string,
+  level: number,
+  moduleDotted: string,
+): string {
+  const fromDirSegments = fromPath.split("/").filter(Boolean);
+  fromDirSegments.pop(); // drop the importing file's own name, keep its directory
+  const upCount = Math.max(0, level - 1);
+  const baseSegments = fromDirSegments.slice(0, Math.max(0, fromDirSegments.length - upCount));
+  const segments: string[] = [];
+  for (const seg of [...baseSegments, ...moduleDotted.split(".")]) {
+    if (seg === "" || seg === ".") continue;
+    if (seg === "..") segments.pop();
+    else segments.push(seg);
+  }
+  return "/" + segments.join("/") + ".py";
+}
+
+/** A stable, valid Python identifier fragment for `path` — the same input
+ * always produces the same output, which is what lets a file bundled in an
+ * earlier chunk of a persistent session be recognized from a later chunk's
+ * own bundling pass (see `priorGlobalNames`) with no separate cache. */
+function slugify(path: string): string {
+  return path.replace(/^\/+/, "").replace(/[^a-zA-Z0-9]+/g, "_");
+}
+
+function moduleFnName(path: string): string {
+  return `__module_${slugify(path)}__`;
+}
+
+function exportsVarName(path: string): string {
+  return `__exports_${slugify(path)}__`;
+}
+
+const ACCESS_HELPER_NAME = "__access_named_export__";
+
+/** Mirrors js-slang's own `__access_named_export__` (its local-import
+ * prelude, stdlib/localImport.prelude.ts) line for line: a linear walk
+ * through `pair(pair(name, value), rest)` nodes, `None`-terminated. */
+const ACCESS_HELPER_SRC = `def ${ACCESS_HELPER_NAME}(named_exports, lookup_name):
+    if named_exports == None:
+        return None
+    else:
+        name = head(head(named_exports))
+        value = tail(head(named_exports))
+        if name == lookup_name:
+            return value
+        else:
+            return ${ACCESS_HELPER_NAME}(tail(named_exports), lookup_name)
+`;
+
+/**
+ * Every name a plain top-level statement list binds — Python has no
+ * `export` keyword, so this *is* "this file's exports" (mirrors
+ * compiler.ts's own boundNames helper, minus its dual-mode-specific global-
+ * declaration scan, which has no equivalent need here — see this module's
+ * own doc comment on `global`/nested-function scoping not being addressed).
+ */
+function topLevelBoundNames(stmts: StmtNS.Stmt[], into: Set<string> = new Set()): Set<string> {
+  for (const s of stmts) {
+    if (s.kind === "Assign") {
+      const target = (s as StmtNS.Assign).target;
+      if (target.kind === "Variable") into.add(target.name.lexeme);
+    } else if (s.kind === "AnnAssign") {
+      into.add((s as StmtNS.AnnAssign).target.name.lexeme);
+    } else if (s.kind === "FunctionDef") {
+      into.add((s as StmtNS.FunctionDef).name.lexeme);
+    } else if (s.kind === "FromImport") {
+      for (const spec of (s as StmtNS.FromImport).names) {
+        into.add((spec.alias ?? spec.name).lexeme);
+      }
+    } else if (s.kind === "If") {
+      const i = s as StmtNS.If;
+      topLevelBoundNames(i.body, into);
+      if (i.elseBlock !== null) topLevelBoundNames(i.elseBlock, into);
+    } else if (s.kind === "While") {
+      topLevelBoundNames((s as StmtNS.While).body, into);
+    } else if (s.kind === "For") {
+      const f = s as StmtNS.For;
+      into.add(f.target.lexeme);
+      topLevelBoundNames(f.body, into);
+    }
+  }
+  return into;
+}
+
+/** `pair(pair(name1, value1), pair(pair(name2, value2), None))` — see the
+ * module doc's "known simplification" note on referencing names directly
+ * (no guard against an unbound one) rather than masking or catching it. */
+function buildReturnExpr(names: Set<string>): string {
+  let expr = "None";
+  for (const name of names) {
+    expr = `pair(pair(${JSON.stringify(name)}, ${name}), ${expr})`;
+  }
+  return expr;
+}
+
+interface SplitStatements {
+  /** Every non-import statement's own verbatim source text, plus an
+   * assignment line per name for each local (level > 0) import — in
+   * original statement order, not yet indented. */
+  bodyText: string;
+  /** Every level-0 FromImport's own verbatim source text (hoisted
+   * separately — see this module's doc comment). */
+  level0ImportTexts: string[];
+  /** Every level>0 import this file's statements need, resolved to an
+   * absolute path — walked (recursively) before this file's own def is
+   * emitted, so each target's `__exports_*__` already exists by then. */
+  localImportTargets: string[];
+  boundNames: Set<string>;
+}
+
+function splitStatements(source: string, statements: StmtNS.Stmt[], currentPath: string): SplitStatements {
+  const pieces: string[] = [];
+  const level0ImportTexts: string[] = [];
+  const localImportTargets: string[] = [];
+  for (const stmt of statements) {
+    if (isFromImport(stmt)) {
+      if (stmt.level === 0) {
+        level0ImportTexts.push(spanText(source, stmt));
+        continue;
+      }
+      const targetPath = resolveLocalModulePath(currentPath, stmt.level, stmt.module.lexeme);
+      localImportTargets.push(targetPath);
+      const exportsVar = exportsVarName(targetPath);
+      for (const spec of stmt.names) {
+        const bound = (spec.alias ?? spec.name).lexeme;
+        pieces.push(`${bound} = ${ACCESS_HELPER_NAME}(${exportsVar}, ${JSON.stringify(spec.name.lexeme)})`);
+      }
+      continue;
+    }
+    pieces.push(spanText(source, stmt));
+  }
+  return {
+    bodyText: pieces.join("\n"),
+    level0ImportTexts,
+    localImportTargets,
+    boundNames: topLevelBoundNames(statements),
+  };
+}
+
+interface BundleState {
+  fileGetter: LocalFileGetter;
+  variant: number;
+  /** Names already bound before this bundling pass even starts (an earlier
+   * chunk's own top-level names, for a persistent session) union every
+   * `__exports_*__` name emitted so far *in this pass* — the single source
+   * of truth for "already available, don't re-bundle" (handles both cross-
+   * chunk caching and an in-pass diamond dependency the same way). */
+  available: Set<string>;
+  inProgress: Set<string>;
+  /** Each newly-bundled file's `def ... / __exports_x__ = ...` text, in
+   * dependency order (a dependency's block always precedes its importer's). */
+  moduleDefs: string[];
+  /** Every hoisted level-0 FromImport's own verbatim text, file-visit order. */
+  hoistedImports: string[];
+  needsAccessHelper: boolean;
+}
+
+async function bundleFile(state: BundleState, source: string, path: string): Promise<SplitStatements> {
+  const script = source.endsWith("\n") ? source : source + "\n";
+  const ast = parse(script);
+  const split = splitStatements(script, ast.statements, path);
+
+  if (split.localImportTargets.length > 0 && state.variant < 2) {
+    throw new LocalImportError(
+      "local file imports ('from .module import name') require SICPy §2 or higher — they use " +
+        "pair/list (linked lists) to pass a file's exports to whatever imports from it.",
+    );
+  }
+
+  state.hoistedImports.push(...split.level0ImportTexts);
+  if (split.localImportTargets.length > 0) state.needsAccessHelper = true;
+
+  state.inProgress.add(path);
+  try {
+    for (const targetPath of split.localImportTargets) {
+      if (state.available.has(exportsVarName(targetPath))) continue;
+      if (state.inProgress.has(targetPath)) {
+        throw new LocalImportError(
+          `cannot import '${targetPath}': circular import (it is already being imported)`,
+        );
+      }
+      const targetSource = await state.fileGetter(targetPath);
+      if (targetSource === undefined) {
+        throw new LocalImportError(`Module "${targetPath}" not found.`);
+      }
+      const targetSplit = await bundleFile(state, targetSource, targetPath);
+      const fnName = moduleFnName(targetPath);
+      const exportsVar = exportsVarName(targetPath);
+      state.moduleDefs.push(
+        `def ${fnName}():\n${indentBlock(targetSplit.bodyText)}\n${INDENT}return ${buildReturnExpr(targetSplit.boundNames)}\n\n` +
+          `${exportsVar} = ${fnName}()\n`,
+      );
+      state.available.add(exportsVar);
+    }
+  } finally {
+    state.inProgress.delete(path);
+  }
+  return split;
+}
+
+/**
+ * Flattens `entrypointSource` (the file at `entrypointPath`) and everything
+ * it locally imports, transitively, into one Python source string — parse()
+ * and run that exactly like any ordinary single-file program; every engine
+ * already knows how to. Returns the entrypoint's own text unchanged (no
+ * bundling at all) if it has no local imports, so a program that never uses
+ * folders is completely unaffected.
+ *
+ * `priorGlobalNames` are names a persistent session (Py2JsSession) already
+ * has bound from an earlier chunk — a dependency already bundled then is
+ * recognized here (by its deterministic `__exports_*__` name) and neither
+ * re-declared nor re-invoked; pass an empty set for a one-shot run.
+ */
+export async function bundleLocalImports(
+  entrypointSource: string,
+  entrypointPath: string,
+  fileGetter: LocalFileGetter,
+  variant: number,
+  priorGlobalNames: Set<string> = new Set(),
+): Promise<string> {
+  const script = entrypointSource.endsWith("\n") ? entrypointSource : entrypointSource + "\n";
+  const ast = parse(script);
+  if (!ast.statements.some(s => isFromImport(s) && s.level > 0)) {
+    return entrypointSource;
+  }
+
+  const state: BundleState = {
+    fileGetter,
+    variant,
+    available: new Set(priorGlobalNames),
+    inProgress: new Set(),
+    moduleDefs: [],
+    hoistedImports: [],
+    needsAccessHelper: false,
+  };
+  const entrypointSplit = await bundleFile(state, entrypointSource, entrypointPath);
+
+  const parts: string[] = [];
+  if (state.needsAccessHelper && !priorGlobalNames.has(ACCESS_HELPER_NAME)) {
+    parts.push(ACCESS_HELPER_SRC);
+  }
+  parts.push(...state.hoistedImports);
+  parts.push(...state.moduleDefs);
+  parts.push(entrypointSplit.bodyText);
+  return parts.join("\n") + "\n";
+}

--- a/src/modules/localImports.ts
+++ b/src/modules/localImports.ts
@@ -67,12 +67,43 @@ export class LocalImportError extends Error {
 
 const INDENT = "    ";
 
+/** Matches the same triple-quoted string shape as the tokenizer's own
+ * `string_triple_double`/`string_triple_single` rules (src/parser/lexer.ts) —
+ * used only to find spans whose *content* must not be touched by
+ * indentation, not to re-lex the file. */
+const TRIPLE_QUOTED_STRING = /"""(?:[^\\]|\\.)*?"""|'''(?:[^\\]|\\.)*?'''/g;
+
+/** Line indices (0-based, within `text`) that fall on or after a multi-line
+ * triple-quoted string's *second* line. Prepending indentation to a line is
+ * only safe when the inserted whitespace lands before real code — on every
+ * line from a multi-line string's second line through its closing
+ * delimiter's own line, the entire line (up to the closing delimiter) is
+ * part of the string's own value, so indenting it would inject spaces into
+ * the string's content. The opening line is exempt: the indent there lands
+ * before whatever precedes the opening delimiter (e.g. `doc = """`), which
+ * is never part of the string's value. */
+function linesInsideMultilineStrings(text: string): Set<number> {
+  const lines = new Set<number>();
+  for (const match of text.matchAll(TRIPLE_QUOTED_STRING)) {
+    const startLine = text.slice(0, match.index).split("\n").length - 1;
+    const endLine = text.slice(0, match.index + match[0].length).split("\n").length - 1;
+    for (let line = startLine + 1; line <= endLine; line++) {
+      lines.add(line);
+    }
+  }
+  return lines;
+}
+
 /** Prepends `indent` to every non-empty line — blank lines stay blank
- * rather than becoming trailing whitespace. */
+ * rather than becoming trailing whitespace — except lines that are part of
+ * a multi-line triple-quoted string's own value (see
+ * `linesInsideMultilineStrings`), which are left untouched so the string's
+ * content survives bundling unchanged. */
 function indentBlock(text: string, indent: string = INDENT): string {
+  const protectedLines = linesInsideMultilineStrings(text);
   return text
     .split("\n")
-    .map(line => (line.length > 0 ? indent + line : line))
+    .map((line, i) => (line.length > 0 && !protectedLines.has(i) ? indent + line : line))
     .join("\n");
 }
 

--- a/src/modules/localImports.ts
+++ b/src/modules/localImports.ts
@@ -116,12 +116,27 @@ export function resolveLocalModulePath(
   return "/" + segments.join("/") + ".py";
 }
 
+/** A short, deterministic hash of `path` — distinguishes paths that sanitize
+ * to the same identifier fragment below (e.g. "/a/b.py" vs "/a_b.py", both
+ * of which collapse to "a_b_py" once non-alphanumeric runs become `_`). */
+function pathHash(path: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < path.length; i++) {
+    h ^= path.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(36);
+}
+
 /** A stable, valid Python identifier fragment for `path` — the same input
  * always produces the same output, which is what lets a file bundled in an
  * earlier chunk of a persistent session be recognized from a later chunk's
- * own bundling pass (see `priorGlobalNames`) with no separate cache. */
+ * own bundling pass (see `priorGlobalNames`) with no separate cache. The
+ * hash suffix keeps this injective even when two different paths sanitize
+ * to the same fragment. */
 function slugify(path: string): string {
-  return path.replace(/^\/+/, "").replace(/[^a-zA-Z0-9]+/g, "_");
+  const sanitized = path.replace(/^\/+/, "").replace(/[^a-zA-Z0-9]+/g, "_");
+  return `${sanitized}_${pathHash(path)}`;
 }
 
 function moduleFnName(path: string): string {
@@ -134,6 +149,19 @@ function exportsVarName(path: string): string {
 
 const ACCESS_HELPER_NAME = "__access_named_export__";
 
+/** Reserved aliases for the `pair`/`head`/`tail` primitives the generated
+ * code below depends on. Bare names would resolve dynamically against
+ * whatever the *current* global scope binds them to — if a bundled
+ * program's own top-level code ever rebinds `pair`/`head`/`tail` (e.g.
+ * `def pair(a, b): ...`), the generated export machinery would silently
+ * start calling the student's own function instead of the SICPy builtin.
+ * Captured once, alongside `ACCESS_HELPER_SRC`, before any of the bundled
+ * files' own statements run. */
+const ALIAS_PAIR = "__li_pair__";
+const ALIAS_HEAD = "__li_head__";
+const ALIAS_TAIL = "__li_tail__";
+const ALIASES_SRC = `${ALIAS_PAIR} = pair\n${ALIAS_HEAD} = head\n${ALIAS_TAIL} = tail\n`;
+
 /** Mirrors js-slang's own `__access_named_export__` (its local-import
  * prelude, stdlib/localImport.prelude.ts) line for line: a linear walk
  * through `pair(pair(name, value), rest)` nodes, `None`-terminated. */
@@ -141,12 +169,12 @@ const ACCESS_HELPER_SRC = `def ${ACCESS_HELPER_NAME}(named_exports, lookup_name)
     if named_exports == None:
         return None
     else:
-        name = head(head(named_exports))
-        value = tail(head(named_exports))
+        name = ${ALIAS_HEAD}(${ALIAS_HEAD}(named_exports))
+        value = ${ALIAS_TAIL}(${ALIAS_HEAD}(named_exports))
         if name == lookup_name:
             return value
         else:
-            return ${ACCESS_HELPER_NAME}(tail(named_exports), lookup_name)
+            return ${ACCESS_HELPER_NAME}(${ALIAS_TAIL}(named_exports), lookup_name)
 `;
 
 /**
@@ -190,9 +218,19 @@ function topLevelBoundNames(stmts: StmtNS.Stmt[], into: Set<string> = new Set())
 function buildReturnExpr(names: Set<string>): string {
   let expr = "None";
   for (const name of names) {
-    expr = `pair(pair(${JSON.stringify(name)}, ${name}), ${expr})`;
+    expr = `${ALIAS_PAIR}(${ALIAS_PAIR}(${JSON.stringify(name)}, ${name}), ${expr})`;
   }
   return expr;
+}
+
+/** A single level-0 (conductor-module) `from X import ...` statement,
+ * hoisted verbatim — kept structured (not just its source text) so hoisting
+ * can detect two files binding the same name from different modules (see
+ * `BundleState.hoistedBindings`). */
+interface Level0Import {
+  text: string;
+  module: string;
+  boundNames: string[];
 }
 
 interface SplitStatements {
@@ -200,9 +238,9 @@ interface SplitStatements {
    * assignment line per name for each local (level > 0) import — in
    * original statement order, not yet indented. */
   bodyText: string;
-  /** Every level-0 FromImport's own verbatim source text (hoisted
-   * separately — see this module's doc comment). */
-  level0ImportTexts: string[];
+  /** Every level-0 FromImport in this file, hoisted separately — see this
+   * module's doc comment. */
+  level0Imports: Level0Import[];
   /** Every level>0 import this file's statements need, resolved to an
    * absolute path — walked (recursively) before this file's own def is
    * emitted, so each target's `__exports_*__` already exists by then. */
@@ -216,12 +254,16 @@ function splitStatements(
   currentPath: string,
 ): SplitStatements {
   const pieces: string[] = [];
-  const level0ImportTexts: string[] = [];
+  const level0Imports: Level0Import[] = [];
   const localImportTargets: string[] = [];
   for (const stmt of statements) {
     if (isFromImport(stmt)) {
       if (stmt.level === 0) {
-        level0ImportTexts.push(spanText(source, stmt));
+        level0Imports.push({
+          text: spanText(source, stmt),
+          module: stmt.module.lexeme,
+          boundNames: stmt.names.map(spec => (spec.alias ?? spec.name).lexeme),
+        });
         continue;
       }
       const targetPath = resolveLocalModulePath(currentPath, stmt.level, stmt.module.lexeme);
@@ -239,7 +281,7 @@ function splitStatements(
   }
   return {
     bodyText: pieces.join("\n"),
-    level0ImportTexts,
+    level0Imports,
     localImportTargets,
     boundNames: topLevelBoundNames(statements),
   };
@@ -260,6 +302,12 @@ interface BundleState {
   moduleDefs: string[];
   /** Every hoisted level-0 FromImport's own verbatim text, file-visit order. */
   hoistedImports: string[];
+  /** Bound name -> the level-0 module it was hoisted from, for every
+   * hoisted import so far in this pass. Every bundled file shares one flat
+   * global scope once flattened, so two files importing the same name from
+   * two *different* modules cannot both be satisfied — caught here instead
+   * of silently letting the later binding win. */
+  hoistedBindings: Map<string, string>;
   needsAccessHelper: boolean;
 }
 
@@ -279,7 +327,20 @@ async function bundleFile(
     );
   }
 
-  state.hoistedImports.push(...split.level0ImportTexts);
+  for (const imp of split.level0Imports) {
+    for (const bound of imp.boundNames) {
+      const previous = state.hoistedBindings.get(bound);
+      if (previous !== undefined && previous !== imp.module) {
+        throw new LocalImportError(
+          `conflicting imports of '${bound}': one file imports it from module '${previous}', ` +
+            `another from module '${imp.module}'. Bundled files share one global scope, so use ` +
+            "an alias (`as ...`) to disambiguate.",
+        );
+      }
+      state.hoistedBindings.set(bound, imp.module);
+    }
+    if (!state.hoistedImports.includes(imp.text)) state.hoistedImports.push(imp.text);
+  }
   if (split.localImportTargets.length > 0) state.needsAccessHelper = true;
 
   state.inProgress.add(path);
@@ -343,15 +404,17 @@ export async function bundleLocalImports(
     inProgress: new Set(),
     moduleDefs: [],
     hoistedImports: [],
+    hoistedBindings: new Map(),
     needsAccessHelper: false,
   };
   const entrypointSplit = await bundleFile(state, entrypointSource, entrypointPath);
 
   const parts: string[] = [];
+  parts.push(...state.hoistedImports);
   if (state.needsAccessHelper && !priorGlobalNames.has(ACCESS_HELPER_NAME)) {
+    parts.push(ALIASES_SRC);
     parts.push(ACCESS_HELPER_SRC);
   }
-  parts.push(...state.hoistedImports);
   parts.push(...state.moduleDefs);
   parts.push(entrypointSplit.bodyText);
   return parts.join("\n") + "\n";

--- a/src/parser/python-grammar.ts
+++ b/src/parser/python-grammar.ts
@@ -143,17 +143,31 @@ const ParserRules = [
   },
   {
     name: "import_stmt",
-    symbols: [{ literal: "from" }, "dotted_name", { literal: "import" }, "import_clause"],
+    symbols: [{ literal: "from" }, "relative_module", { literal: "import" }, "import_clause"],
     postprocess: ([kw, mod, , names]: [
       moo.Token,
-      Token,
+      { name: Token; level: number },
       moo.Token,
       StmtNS.FromImport["names"],
     ]) => {
       const last = names[names.length - 1];
       const endTok = last.alias || last.name;
-      return new StmtNS.FromImport(toAstToken(kw), endTok, mod, names);
+      return new StmtNS.FromImport(toAstToken(kw), endTok, mod.name, names, mod.level);
     },
+  },
+  { name: "relative_module$ebnf$1", symbols: [] },
+  { name: "relative_module$ebnf$1$subexpression$1", symbols: [{ literal: "." }] },
+  {
+    name: "relative_module$ebnf$1",
+    symbols: ["relative_module$ebnf$1", "relative_module$ebnf$1$subexpression$1"],
+    postprocess: function arrpush<T>(d: [T[], T]) {
+      return d[0].concat([d[1]]);
+    },
+  },
+  {
+    name: "relative_module",
+    symbols: ["relative_module$ebnf$1", "dotted_name"],
+    postprocess: ([dots, name]: [moo.Token[], Token]) => ({ level: dots.length, name }),
   },
   { name: "dotted_name$ebnf$1", symbols: [] },
   { name: "dotted_name$ebnf$1$subexpression$1", symbols: [{ literal: "." }, { type: "name" }] },
@@ -413,11 +427,7 @@ const ParserRules = [
     symbols: ["if_statement$ebnf$2$subexpression$1"],
     postprocess: id,
   },
-  {
-    name: "if_statement$ebnf$2",
-    symbols: [],
-    postprocess: () => null,
-  },
+  { name: "if_statement$ebnf$2", symbols: [], postprocess: () => null },
   {
     name: "if_statement",
     symbols: [
@@ -716,11 +726,7 @@ const ParserRules = [
   },
   { name: "expressions$ebnf$2$subexpression$1", symbols: [{ type: "comma" }] },
   { name: "expressions$ebnf$2", symbols: ["expressions$ebnf$2$subexpression$1"], postprocess: id },
-  {
-    name: "expressions$ebnf$2",
-    symbols: [],
-    postprocess: () => null,
-  },
+  { name: "expressions$ebnf$2", symbols: [], postprocess: () => null },
   {
     name: "expressions",
     symbols: ["expression", "expressions$ebnf$1", "expressions$ebnf$2"],
@@ -744,11 +750,7 @@ const ParserRules = [
     symbols: ["spread_expressions$ebnf$2$subexpression$1"],
     postprocess: id,
   },
-  {
-    name: "spread_expressions$ebnf$2",
-    symbols: [],
-    postprocess: () => null,
-  },
+  { name: "spread_expressions$ebnf$2", symbols: [], postprocess: () => null },
   {
     name: "spread_expressions",
     symbols: ["spread_expression", "spread_expressions$ebnf$1", "spread_expressions$ebnf$2"],

--- a/src/parser/python.ne
+++ b/src/parser/python.ne
@@ -101,12 +101,19 @@ program -> (import_stmt %newline):* (statement | %newline):*
 # ============================================================================
 
 import_stmt ->
-    "from" dotted_name "import" import_clause
-      {% ([kw, mod,, names]: [moo.Token, Token, moo.Token, StmtNS.FromImport["names"]]) => {
+    "from" relative_module "import" import_clause
+      {% ([kw, mod,, names]: [moo.Token, { name: Token; level: number }, moo.Token, StmtNS.FromImport["names"]]) => {
            const last = names[names.length-1];
            const endTok = last.alias || last.name;
-           return new StmtNS.FromImport(toAstToken(kw), endTok, mod, names);
+           return new StmtNS.FromImport(toAstToken(kw), endTok, mod.name, names, mod.level);
          } %}
+
+# relative-module ::= "."... dotted-name   (leading dots address a local file
+# relative to the importing file's own directory - one dot per directory
+# level, mirroring CPython's relative-import syntax; a bare name with no
+# leading dots (level 0) keeps meaning a Source Academy module, as today.)
+relative_module -> ("."):* dotted_name
+  {% ([dots, name]: [moo.Token[], Token]) => ({ level: dots.length, name }) %}
 
 # dotted-name ::= name ( . name )...                     [python_1_bnf.tex line 20]
 dotted_name -> %name ("." %name):*

--- a/src/tests/PyCseEvaluator.test.ts
+++ b/src/tests/PyCseEvaluator.test.ts
@@ -89,6 +89,20 @@ describe("PyCseEvaluator1 (chapter 1, no CSE snapshots)", () => {
     expect(errors).toHaveLength(1);
     expect(outputs).toEqual(["1\n"]);
   });
+
+  test("a relative import ('from .foo import x') is rejected, not silently treated as a conductor module", async () => {
+    // CSE doesn't implement local-file imports (see py2js) — this must
+    // reject explicitly rather than requesting a conductor module literally
+    // named "foo".
+    const { conductor, errors, outputs } = makeMockConductor();
+    const evaluator = new PyCseEvaluator1(conductor);
+
+    await evaluator.evaluateChunk("from .foo import x\n");
+
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as { message: string }).message).toMatch(/relative imports/);
+    expect(outputs).toEqual([]);
+  });
 });
 
 describe("PyCseEvaluator3/4 (CSE snapshots)", () => {

--- a/src/tests/PyPvmlEvaluator.test.ts
+++ b/src/tests/PyPvmlEvaluator.test.ts
@@ -82,6 +82,19 @@ describe("PyPvmlEvaluator", () => {
 
     expect(errors).toHaveLength(1);
   });
+
+  test("a relative import ('from .foo import x') is rejected, not silently treated as a conductor module", async () => {
+    // PVML doesn't implement local-file imports (see py2js) — this must
+    // reject explicitly rather than requesting a conductor module literally
+    // named "foo".
+    const { conductor, errors } = makeMockConductor();
+    const evaluator = new PyPvmlEvaluator(conductor);
+
+    await evaluator.evaluateChunk("from .foo import x\n");
+
+    expect(errors).toHaveLength(1);
+    expect(String(errors[0])).toMatch(/relative imports/);
+  });
 });
 
 // PyPvmlEvaluator1..4 mirror PyCseEvaluator1..4 (see PyCseEvaluator.ts): each

--- a/src/tests/local-imports-bundler.test.ts
+++ b/src/tests/local-imports-bundler.test.ts
@@ -89,6 +89,34 @@ describe("bundleLocalImports", () => {
     expect(await runCode(bundled, 2)).toBe("hi\n");
   });
 
+  test("a multi-line triple-quoted string in a dependency survives bundling unchanged", async () => {
+    // Naively re-indenting a dependency's copied source text (to nest it
+    // inside `def __module_x__(): ...`) would inject the indent into the
+    // string's own interior lines and closing delimiter's line — corrupting
+    // its value even though nothing about the string itself changed.
+    const files: Record<string, string> = {
+      "/utils.py": 'doc = """\nline one\nline two\n"""\ndef helper():\n    return 1\n',
+    };
+    const bundled = await bundleLocalImports(
+      "from .utils import doc\nprint(doc)\n",
+      "/main.py",
+      p => Promise.resolve(files[p]),
+      2,
+    );
+    expect(await runCode(bundled, 2)).toBe("\nline one\nline two\n\n");
+  });
+
+  test("a single-line triple-quoted string in a dependency still gets indented normally", async () => {
+    const files: Record<string, string> = { "/utils.py": 'doc = """hello world"""\n' };
+    const bundled = await bundleLocalImports(
+      "from .utils import doc\nprint(doc)\n",
+      "/main.py",
+      p => Promise.resolve(files[p]),
+      2,
+    );
+    expect(await runCode(bundled, 2)).toBe("hello world\n");
+  });
+
   test("supports an alias", async () => {
     const files: Record<string, string> = { "/utils.py": "def square(x):\n    return x * x\n" };
     const bundled = await bundleLocalImports(

--- a/src/tests/local-imports-bundler.test.ts
+++ b/src/tests/local-imports-bundler.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests for the engine-agnostic local-file ("folder") import bundler
+ * (src/modules/localImports.ts) — a genuine source-to-source transform,
+ * mirroring js-slang's own local-module preprocessor. `from .foo import
+ * bar` (level > 0) resolves against a program's own file map; the whole
+ * multi-file program flattens into one Python source string that any
+ * py-slang engine parses and runs unmodified — no engine-specific plumbing
+ * involved. See source-academy/py-slang#378.
+ */
+import { bundleLocalImports, resolveLocalModulePath } from "../modules/localImports";
+import { runCode } from "../runner";
+
+describe("resolveLocalModulePath", () => {
+  test("level 1 resolves to a sibling in the importing file's own directory", () => {
+    expect(resolveLocalModulePath("/main.py", 1, "utils")).toBe("/utils.py");
+    expect(resolveLocalModulePath("/pkg/main.py", 1, "utils")).toBe("/pkg/utils.py");
+  });
+
+  test("level 2 walks up one directory before resolving", () => {
+    expect(resolveLocalModulePath("/pkg/main.py", 2, "utils")).toBe("/utils.py");
+    expect(resolveLocalModulePath("/pkg/sub/main.py", 2, "utils")).toBe("/pkg/utils.py");
+  });
+
+  test("a dotted module path becomes nested directory segments", () => {
+    expect(resolveLocalModulePath("/main.py", 1, "pkg.utils")).toBe("/pkg/utils.py");
+    expect(resolveLocalModulePath("/pkg/main.py", 2, "a.b")).toBe("/a/b.py");
+  });
+
+  test("level beyond the available directory depth clamps rather than throwing", () => {
+    expect(resolveLocalModulePath("/main.py", 5, "utils")).toBe("/utils.py");
+  });
+});
+
+describe("bundleLocalImports", () => {
+  test("a program with no local imports is returned completely unchanged", async () => {
+    const entrypoint = "print(1)\n";
+    const bundled = await bundleLocalImports(entrypoint, "/main.py", () => Promise.resolve(undefined), 1);
+    expect(bundled).toBe(entrypoint);
+  });
+
+  test("imports a value and a function from a sibling file, and it actually runs", async () => {
+    const files: Record<string, string> = {
+      "/test.py": "def square(x):\n    return x * x\n\nCONST = 4\n",
+    };
+    const entrypoint = "from .test import square, CONST\nprint(square(CONST))\n";
+    const bundled = await bundleLocalImports(entrypoint, "/main.py", p => Promise.resolve(files[p]), 2);
+
+    // The generated program is exactly what a student could be shown: a
+    // pair()/head()/tail()-based access helper, one wrapper function per
+    // dependency returning a pair-list of its own top-level bindings, and
+    // the entrypoint's own imports rewritten as plain lookups against it.
+    expect(bundled).toContain("def __access_named_export__(named_exports, lookup_name):");
+    expect(bundled).toContain("def __module_test_py__():");
+    expect(bundled).toContain('return pair(pair("CONST", CONST), pair(pair("square", square), None))');
+    expect(bundled).toContain("__exports_test_py__ = __module_test_py__()");
+    expect(bundled).toContain('square = __access_named_export__(__exports_test_py__, "square")');
+    expect(bundled).toContain('CONST = __access_named_export__(__exports_test_py__, "CONST")');
+    expect(bundled).not.toContain("__py."); // no engine-specific runtime plumbing anywhere
+
+    expect(await runCode(bundled, 2)).toBe("16\n");
+  });
+
+  test("resolves a nested directory via a dotted relative path", async () => {
+    const files: Record<string, string> = { "/pkg/utils.py": "def greet():\n    return 'hi'\n" };
+    const bundled = await bundleLocalImports(
+      "from .pkg.utils import greet\nprint(greet())\n",
+      "/main.py",
+      p => Promise.resolve(files[p]),
+      2,
+    );
+    expect(await runCode(bundled, 2)).toBe("hi\n");
+  });
+
+  test("supports an alias", async () => {
+    const files: Record<string, string> = { "/utils.py": "def square(x):\n    return x * x\n" };
+    const bundled = await bundleLocalImports(
+      "from .utils import square as sq\nprint(sq(3))\n",
+      "/main.py",
+      p => Promise.resolve(files[p]),
+      2,
+    );
+    expect(await runCode(bundled, 2)).toBe("9\n");
+  });
+
+  test("a diamond dependency's shared file is bundled and run exactly once", async () => {
+    const files: Record<string, string> = {
+      "/shared.py": "print('loading shared')\nVALUE = 1\n",
+      "/a.py": "from .shared import VALUE\na_val = VALUE\n",
+      "/b.py": "from .shared import VALUE\nb_val = VALUE\n",
+    };
+    const bundled = await bundleLocalImports(
+      "from .a import a_val\nfrom .b import b_val\nprint(a_val, b_val)\n",
+      "/main.py",
+      p => Promise.resolve(files[p]),
+      3,
+    );
+    // Exactly one def/invocation for the shared file, no matter how many
+    // importers reference it.
+    expect(bundled.match(/def __module_shared_py__\(\):/g)).toHaveLength(1);
+    expect(bundled.match(/__exports_shared_py__ = __module_shared_py__\(\)/g)).toHaveLength(1);
+    expect(await runCode(bundled, 3)).toBe("loading shared\n1 1\n");
+  });
+
+  test("a locally-imported file with its own from-import (transitive) works", async () => {
+    const files: Record<string, string> = {
+      "/b.py": "VALUE = 42\n",
+      "/a.py": "from .b import VALUE\na_val = VALUE\n",
+    };
+    const bundled = await bundleLocalImports(
+      "from .a import a_val\nprint(a_val)\n",
+      "/main.py",
+      p => Promise.resolve(files[p]),
+      3,
+    );
+    expect(await runCode(bundled, 3)).toBe("42\n");
+  });
+
+  test("circular imports raise an ImportError before running anything", async () => {
+    const files: Record<string, string> = {
+      "/a.py": "from .b import y\nx = 1\n",
+      "/b.py": "from .a import x\ny = 2\n",
+    };
+    await expect(
+      bundleLocalImports("from .a import x\n", "/main.py", p => Promise.resolve(files[p]), 3),
+    ).rejects.toThrow(/circular import/);
+  });
+
+  test("importing a missing file raises a clear error", async () => {
+    await expect(
+      bundleLocalImports("from .missing import x\n", "/main.py", () => Promise.resolve(undefined), 3),
+    ).rejects.toThrow(/not found/);
+  });
+
+  test("importing an undefined name silently gives None, matching js-slang's own __access_export__", async () => {
+    // Faithfully mirrors js-slang's local-import prelude: __access_named_export__
+    // walks off the end of the pair list and returns None rather than
+    // raising an ImportError — a deliberate parity choice, not an oversight.
+    const files: Record<string, string> = { "/utils.py": "x = 1\n" };
+    const bundled = await bundleLocalImports(
+      "from .utils import does_not_exist\nprint(does_not_exist)\n",
+      "/main.py",
+      p => Promise.resolve(files[p]),
+      3,
+    );
+    expect(await runCode(bundled, 3)).toBe("None\n");
+  });
+
+  test("rejected at chapter 1 — the exports transfer needs pair/list, unavailable there", async () => {
+    const files: Record<string, string> = { "/utils.py": "x = 1\n" };
+    await expect(
+      bundleLocalImports("from .utils import x\n", "/main.py", p => Promise.resolve(files[p]), 1),
+    ).rejects.toThrow(/require SICPy §2 or higher/);
+  });
+
+  test("a level === 0 (conductor module) import is hoisted verbatim, untouched", async () => {
+    const bundled = await bundleLocalImports(
+      "from .utils import helper\nfrom rune import show\nprint(1)\n",
+      "/main.py",
+      p => Promise.resolve(p === "/utils.py" ? "def helper():\n    return 1\n" : undefined),
+      2,
+    );
+    expect(bundled).toContain("from rune import show");
+    // Hoisted to the very top, ahead of every generated def/invocation.
+    const hoistedIndex = bundled.indexOf("from rune import show");
+    const moduleDefIndex = bundled.indexOf("def __module_utils_py__");
+    expect(hoistedIndex).toBeLessThan(moduleDefIndex);
+  });
+
+  test("priorGlobalNames skips re-bundling a file already available from an earlier chunk", async () => {
+    const files: Record<string, string> = { "/utils.py": "def square(x):\n    return x * x\n" };
+    const priorGlobalNames = new Set(["__exports_utils_py__", "__access_named_export__"]);
+    const bundled = await bundleLocalImports(
+      "from .utils import square\nprint(square(4))\n",
+      "/main.py",
+      p => Promise.resolve(files[p]),
+      2,
+      priorGlobalNames,
+    );
+    // Neither the helper nor the dependency's def/invocation are re-emitted —
+    // just the lookup against the (already-bound, from a prior chunk)
+    // __exports_utils_py__ name.
+    expect(bundled).not.toContain("def __access_named_export__");
+    expect(bundled).not.toContain("def __module_utils_py__");
+    expect(bundled).toContain('square = __access_named_export__(__exports_utils_py__, "square")');
+  });
+});

--- a/src/tests/local-imports-bundler.test.ts
+++ b/src/tests/local-imports-bundler.test.ts
@@ -9,6 +9,7 @@
  */
 import { bundleLocalImports, resolveLocalModulePath } from "../modules/localImports";
 import { runCode } from "../runner";
+import { parse } from "../parser";
 
 describe("resolveLocalModulePath", () => {
   test("level 1 resolves to a sibling in the importing file's own directory", () => {
@@ -59,14 +60,19 @@ describe("bundleLocalImports", () => {
     // pair()/head()/tail()-based access helper, one wrapper function per
     // dependency returning a pair-list of its own top-level bindings, and
     // the entrypoint's own imports rewritten as plain lookups against it.
+    // The module/exports names carry a deterministic path-hash suffix (not
+    // asserted exactly here) so distinct paths never collide — see the
+    // "slugify" describe block below.
     expect(bundled).toContain("def __access_named_export__(named_exports, lookup_name):");
-    expect(bundled).toContain("def __module_test_py__():");
-    expect(bundled).toContain(
-      'return pair(pair("CONST", CONST), pair(pair("square", square), None))',
+    expect(bundled).toMatch(/def __module_test_py_\w+__\(\):/);
+    expect(bundled).toMatch(
+      /return __li_pair__\(__li_pair__\("CONST", CONST\), __li_pair__\(__li_pair__\("square", square\), None\)\)/,
     );
-    expect(bundled).toContain("__exports_test_py__ = __module_test_py__()");
-    expect(bundled).toContain('square = __access_named_export__(__exports_test_py__, "square")');
-    expect(bundled).toContain('CONST = __access_named_export__(__exports_test_py__, "CONST")');
+    expect(bundled).toMatch(/__exports_test_py_\w+__ = __module_test_py_\w+__\(\)/);
+    expect(bundled).toMatch(
+      /square = __access_named_export__\(__exports_test_py_\w+__, "square"\)/,
+    );
+    expect(bundled).toMatch(/CONST = __access_named_export__\(__exports_test_py_\w+__, "CONST"\)/);
     expect(bundled).not.toContain("__py."); // no engine-specific runtime plumbing anywhere
 
     expect(await runCode(bundled, 2)).toBe("16\n");
@@ -108,8 +114,10 @@ describe("bundleLocalImports", () => {
     );
     // Exactly one def/invocation for the shared file, no matter how many
     // importers reference it.
-    expect(bundled.match(/def __module_shared_py__\(\):/g)).toHaveLength(1);
-    expect(bundled.match(/__exports_shared_py__ = __module_shared_py__\(\)/g)).toHaveLength(1);
+    expect(bundled.match(/def __module_shared_py_\w+__\(\):/g)).toHaveLength(1);
+    expect(bundled.match(/__exports_shared_py_\w+__ = __module_shared_py_\w+__\(\)/g)).toHaveLength(
+      1,
+    );
     expect(await runCode(bundled, 3)).toBe("loading shared\n1 1\n");
   });
 
@@ -135,6 +143,39 @@ describe("bundleLocalImports", () => {
     await expect(
       bundleLocalImports("from .a import x\n", "/main.py", p => Promise.resolve(files[p]), 3),
     ).rejects.toThrow(/circular import/);
+  });
+
+  test("two local files hoisting the same name from different conductor modules raise a clear error", async () => {
+    // Bundled files share one flat global scope once flattened, so /a.py's
+    // `from rune import show` and /b.py's `from curve import show` can't
+    // both be satisfied — the later hoisted binding would otherwise
+    // silently win for both files.
+    const files: Record<string, string> = {
+      "/a.py": "from rune import show\n",
+      "/b.py": "from curve import show\n",
+    };
+    await expect(
+      bundleLocalImports(
+        "from .a import x\nfrom .b import y\n",
+        "/main.py",
+        p => Promise.resolve(files[p]),
+        3,
+      ),
+    ).rejects.toThrow(/conflicting imports of 'show'/);
+  });
+
+  test("two local files hoisting the identical import are deduplicated, not rejected", async () => {
+    const files: Record<string, string> = {
+      "/a.py": "from rune import show\n",
+      "/b.py": "from rune import show\n",
+    };
+    const bundled = await bundleLocalImports(
+      "from .a import x\nfrom .b import y\n",
+      "/main.py",
+      p => Promise.resolve(files[p]),
+      3,
+    );
+    expect(bundled.match(/from rune import show/g)).toHaveLength(1);
   });
 
   test("importing a missing file raises a clear error", async () => {
@@ -177,15 +218,81 @@ describe("bundleLocalImports", () => {
       2,
     );
     expect(bundled).toContain("from rune import show");
-    // Hoisted to the very top, ahead of every generated def/invocation.
+    // Hoisted to the very top, ahead of the access-helper aliases and every
+    // generated def/invocation — a hoisted import must precede every
+    // statement (including `def`s) per the grammar's own leading-imports
+    // rule, so getting this ordering wrong makes the flattened program
+    // unparseable (see the regression test below).
     const hoistedIndex = bundled.indexOf("from rune import show");
-    const moduleDefIndex = bundled.indexOf("def __module_utils_py__");
+    const aliasIndex = bundled.indexOf("__li_pair__ = pair");
+    const moduleDefIndex = bundled.search(/def __module_utils_py_\w+__/);
+    expect(hoistedIndex).toBeGreaterThanOrEqual(0);
+    expect(hoistedIndex).toBeLessThan(aliasIndex);
     expect(hoistedIndex).toBeLessThan(moduleDefIndex);
+  });
+
+  test("a hoisted conductor-module import plus a local import actually runs (regression: emission order)", async () => {
+    // Regression test: an earlier version of the bundler emitted the access
+    // helper/aliases *before* the hoisted level-0 imports, which produced a
+    // `from ...` statement after a `def` — unparseable, since the grammar
+    // requires all imports to lead every other statement.
+    const bundled = await bundleLocalImports(
+      "from .utils import square\nfrom rune import show\nprint(square(3))\n",
+      "/main.py",
+      p => Promise.resolve(p === "/utils.py" ? "def square(x):\n    return x * x\n" : undefined),
+      2,
+    );
+    // A bare `parse()` check is enough here: `rune` isn't a real module in
+    // this test context, so running it end to end would need a conductor;
+    // parsing is exactly what the emission-order bug broke.
+    expect(() => parse(bundled)).not.toThrow();
+  });
+
+  test("two files whose paths sanitize to the same fragment don't collide", async () => {
+    // "/pkg/utils.py" and "/pkg_utils.py" both collapse to "pkg_utils_py"
+    // once non-alphanumeric runs become "_" — the path-hash suffix keeps
+    // them distinct.
+    const files: Record<string, string> = {
+      "/pkg/utils.py": "A = 1\n",
+      "/pkg_utils.py": "B = 2\n",
+    };
+    const bundled = await bundleLocalImports(
+      "from .pkg.utils import A\nfrom .pkg_utils import B\nprint(A, B)\n",
+      "/main.py",
+      p => Promise.resolve(files[p]),
+      2,
+    );
+    expect(await runCode(bundled, 2)).toBe("1 2\n");
+  });
+
+  test("a top-level 'pair' defined after the imports doesn't break the export machinery", async () => {
+    // The generated access helper/return-expr must not resolve `pair`/
+    // `head`/`tail` by bare name, since the entrypoint's own trailing code
+    // is free to rebind them at the global scope this all shares.
+    const files: Record<string, string> = { "/utils.py": "def square(x):\n    return x * x\n" };
+    const bundled = await bundleLocalImports(
+      "from .utils import square\ndef pair(a, b):\n    return a + b\nprint(square(3))\nprint(pair(1, 2))\n",
+      "/main.py",
+      p => Promise.resolve(files[p]),
+      2,
+    );
+    expect(await runCode(bundled, 2)).toBe("9\n3\n");
   });
 
   test("priorGlobalNames skips re-bundling a file already available from an earlier chunk", async () => {
     const files: Record<string, string> = { "/utils.py": "def square(x):\n    return x * x\n" };
-    const priorGlobalNames = new Set(["__exports_utils_py__", "__access_named_export__"]);
+    // Bundle once to learn this path's real (hash-suffixed) generated names,
+    // simulating what a first chunk in a persistent session would produce.
+    const firstBundle = await bundleLocalImports(
+      "from .utils import square\n",
+      "/main.py",
+      p => Promise.resolve(files[p]),
+      2,
+    );
+    const exportsVarMatch = firstBundle.match(/__exports_utils_py_\w+__/);
+    expect(exportsVarMatch).not.toBeNull();
+    const exportsVar = exportsVarMatch![0];
+    const priorGlobalNames = new Set([exportsVar, "__access_named_export__"]);
     const bundled = await bundleLocalImports(
       "from .utils import square\nprint(square(4))\n",
       "/main.py",
@@ -193,11 +300,14 @@ describe("bundleLocalImports", () => {
       2,
       priorGlobalNames,
     );
-    // Neither the helper nor the dependency's def/invocation are re-emitted —
-    // just the lookup against the (already-bound, from a prior chunk)
-    // __exports_utils_py__ name.
+    // Neither the helper, its aliases, nor the dependency's def/invocation
+    // are re-emitted — just the lookup against the (already-bound, from a
+    // prior chunk) exports name.
     expect(bundled).not.toContain("def __access_named_export__");
-    expect(bundled).not.toContain("def __module_utils_py__");
-    expect(bundled).toContain('square = __access_named_export__(__exports_utils_py__, "square")');
+    expect(bundled).not.toContain("__li_pair__ = pair");
+    expect(bundled).not.toMatch(/def __module_utils_py_\w+__/);
+    expect(bundled).toBe(
+      `square = __access_named_export__(${exportsVar}, "square")\nprint(square(4))\n`,
+    );
   });
 });

--- a/src/tests/local-imports-bundler.test.ts
+++ b/src/tests/local-imports-bundler.test.ts
@@ -34,7 +34,12 @@ describe("resolveLocalModulePath", () => {
 describe("bundleLocalImports", () => {
   test("a program with no local imports is returned completely unchanged", async () => {
     const entrypoint = "print(1)\n";
-    const bundled = await bundleLocalImports(entrypoint, "/main.py", () => Promise.resolve(undefined), 1);
+    const bundled = await bundleLocalImports(
+      entrypoint,
+      "/main.py",
+      () => Promise.resolve(undefined),
+      1,
+    );
     expect(bundled).toBe(entrypoint);
   });
 
@@ -43,7 +48,12 @@ describe("bundleLocalImports", () => {
       "/test.py": "def square(x):\n    return x * x\n\nCONST = 4\n",
     };
     const entrypoint = "from .test import square, CONST\nprint(square(CONST))\n";
-    const bundled = await bundleLocalImports(entrypoint, "/main.py", p => Promise.resolve(files[p]), 2);
+    const bundled = await bundleLocalImports(
+      entrypoint,
+      "/main.py",
+      p => Promise.resolve(files[p]),
+      2,
+    );
 
     // The generated program is exactly what a student could be shown: a
     // pair()/head()/tail()-based access helper, one wrapper function per
@@ -51,7 +61,9 @@ describe("bundleLocalImports", () => {
     // the entrypoint's own imports rewritten as plain lookups against it.
     expect(bundled).toContain("def __access_named_export__(named_exports, lookup_name):");
     expect(bundled).toContain("def __module_test_py__():");
-    expect(bundled).toContain('return pair(pair("CONST", CONST), pair(pair("square", square), None))');
+    expect(bundled).toContain(
+      'return pair(pair("CONST", CONST), pair(pair("square", square), None))',
+    );
     expect(bundled).toContain("__exports_test_py__ = __module_test_py__()");
     expect(bundled).toContain('square = __access_named_export__(__exports_test_py__, "square")');
     expect(bundled).toContain('CONST = __access_named_export__(__exports_test_py__, "CONST")');
@@ -127,7 +139,12 @@ describe("bundleLocalImports", () => {
 
   test("importing a missing file raises a clear error", async () => {
     await expect(
-      bundleLocalImports("from .missing import x\n", "/main.py", () => Promise.resolve(undefined), 3),
+      bundleLocalImports(
+        "from .missing import x\n",
+        "/main.py",
+        () => Promise.resolve(undefined),
+        3,
+      ),
     ).rejects.toThrow(/not found/);
   });
 

--- a/src/tests/nearley-parser.test.ts
+++ b/src/tests/nearley-parser.test.ts
@@ -772,6 +772,26 @@ describe("Import statement", () => {
     expect(imp.module.lexeme).toBe("math");
     expect(imp.names[0].name.lexeme).toBe("sqrt");
     expect(imp.names[0].alias).toBeNull();
+    expect(imp.level).toBe(0);
+  });
+
+  test("relative import: from .utils import foo has level 1", () => {
+    const stmts = parseStmts("from .utils import foo");
+    expect(stmts[0]).toBeInstanceOf(StmtNS.FromImport);
+    const imp = stmts[0] as StmtNS.FromImport;
+    expect(imp.level).toBe(1);
+    expect(imp.module.lexeme).toBe("utils");
+    expect(imp.names[0].name.lexeme).toBe("foo");
+  });
+
+  test("relative import: from ..pkg.utils import foo as bar has level 2", () => {
+    const stmts = parseStmts("from ..pkg.utils import foo as bar");
+    expect(stmts[0]).toBeInstanceOf(StmtNS.FromImport);
+    const imp = stmts[0] as StmtNS.FromImport;
+    expect(imp.level).toBe(2);
+    expect(imp.module.lexeme).toBe("pkg.utils");
+    expect(imp.names[0].name.lexeme).toBe("foo");
+    expect(imp.names[0].alias!.lexeme).toBe("bar");
   });
 
   test("from x import (a, b, c) produces FromImport with multiple names", () => {

--- a/src/tests/py2js-interpreter-support.test.ts
+++ b/src/tests/py2js-interpreter-support.test.ts
@@ -92,19 +92,23 @@ describe("__program__", () => {
     }
   });
 
-  test("a REPL/conductor session uses the caller-supplied programText", async () => {
+  test("a REPL/conductor session sets __program__ automatically, from the chunk it's actually running", async () => {
+    // No caller-supplied override needed or possible: __program__ is simply
+    // whatever text this chunk is — Py2JsSession keeps it current itself,
+    // the same way the CSE machine's own pyDefineVariable("__program__", ...)
+    // does internally, not something an external caller manages.
     const lines: string[] = [];
-    const session = new Py2JsSession(4, {
-      onOutput: l => lines.push(l),
-      programText: "the editor content at the time Run was last pressed",
-    });
+    const session = new Py2JsSession(4, { onOutput: l => lines.push(l) });
     await session.runChunk("print(__program__)\n");
-    expect(lines).toEqual(["the editor content at the time Run was last pressed"]);
+    expect(lines).toEqual(["print(__program__)\n"]);
   });
 
-  test("a REPL/conductor session with no programText leaves __program__ unbound (NameError)", async () => {
-    const session = new Py2JsSession(4);
-    await expect(session.runChunk("print(__program__)\n")).rejects.toThrow();
+  test("a later chunk sees its own text, not an earlier chunk's", async () => {
+    const lines: string[] = [];
+    const session = new Py2JsSession(4, { onOutput: l => lines.push(l) });
+    await session.runChunk("x = 1\n");
+    await session.runChunk("print(__program__)\n");
+    expect(lines).toEqual(["print(__program__)\n"]);
   });
 });
 

--- a/src/tests/py2js-local-imports.test.ts
+++ b/src/tests/py2js-local-imports.test.ts
@@ -117,8 +117,10 @@ describe("__program__ shows the flattened single-file program", () => {
     await session.runChunk("from .utils import square, CONST\nprint(__program__)\n");
     const program = output.join("\n");
     expect(program).toContain("def __access_named_export__(named_exports, lookup_name):");
-    expect(program).toContain("def __module_utils_py__():");
-    expect(program).toContain('square = __access_named_export__(__exports_utils_py__, "square")');
+    expect(program).toMatch(/def __module_utils_py_\w+__\(\):/);
+    expect(program).toMatch(
+      /square = __access_named_export__\(__exports_utils_py_\w+__, "square"\)/,
+    );
     // The raw multi-file entrypoint text (with its own `from .utils import`
     // line) is gone — replaced by the flattened program's own lookups.
     expect(program).not.toContain("from .utils import");

--- a/src/tests/py2js-local-imports.test.ts
+++ b/src/tests/py2js-local-imports.test.ts
@@ -17,9 +17,13 @@ import { runCodePy2JsDual, Py2JsSession } from "../engines/py2js";
 
 describe("runCodePy2JsDual local imports", () => {
   test("imports a value and a function from a sibling file", async () => {
-    const { output } = await runCodePy2JsDual("from .utils import CONST, square\nprint(square(CONST))\n", 3, {
-      files: { "/utils.py": "CONST = 4\ndef square(x):\n    return x * x\n" },
-    });
+    const { output } = await runCodePy2JsDual(
+      "from .utils import CONST, square\nprint(square(CONST))\n",
+      3,
+      {
+        files: { "/utils.py": "CONST = 4\ndef square(x):\n    return x * x\n" },
+      },
+    );
     expect(output).toBe("16\n");
   });
 
@@ -39,9 +43,13 @@ describe("runCodePy2JsDual local imports", () => {
   });
 
   test("supports an alias", async () => {
-    const { output } = await runCodePy2JsDual("from .utils import square as sq\nprint(sq(3))\n", 3, {
-      files: { "/utils.py": "def square(x):\n    return x * x\n" },
-    });
+    const { output } = await runCodePy2JsDual(
+      "from .utils import square as sq\nprint(sq(3))\n",
+      3,
+      {
+        files: { "/utils.py": "def square(x):\n    return x * x\n" },
+      },
+    );
     expect(output).toBe("9\n");
   });
 
@@ -72,9 +80,13 @@ describe("runCodePy2JsDual local imports", () => {
   });
 
   test("importing an undefined name silently gives None (matching js-slang's own __access_export__)", async () => {
-    const { output } = await runCodePy2JsDual("from .utils import does_not_exist\nprint(does_not_exist)\n", 3, {
-      files: { "/utils.py": "x = 1\n" },
-    });
+    const { output } = await runCodePy2JsDual(
+      "from .utils import does_not_exist\nprint(does_not_exist)\n",
+      3,
+      {
+        files: { "/utils.py": "x = 1\n" },
+      },
+    );
     expect(output).toBe("None\n");
   });
 

--- a/src/tests/py2js-local-imports.test.ts
+++ b/src/tests/py2js-local-imports.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Engine-level tests for py2js's local-file ("folder") imports — relative
+ * imports (`from .foo import bar`, `from ..pkg.foo import bar`, level > 0)
+ * that resolve against a program's own file map rather than a conductor
+ * module, via the engine-agnostic source-to-source bundler
+ * (src/modules/localImports.ts — see src/tests/local-imports-bundler.test.ts
+ * for unit tests of the bundler itself). These exercise the *engine's* own
+ * public API (runCodePy2JsDual/Py2JsSession) end to end: parsing, bundling,
+ * resolving, compiling, and running for real, not just calling the bundler
+ * directly. See source-academy/py-slang#378.
+ *
+ * level === 0 imports (`from rune import show`) go through the unchanged
+ * conductor-module path — src/tests/py2js-module-interop.test.ts already
+ * covers that conversion layer directly and is untouched by this feature.
+ */
+import { runCodePy2JsDual, Py2JsSession } from "../engines/py2js";
+
+describe("runCodePy2JsDual local imports", () => {
+  test("imports a value and a function from a sibling file", async () => {
+    const { output } = await runCodePy2JsDual("from .utils import CONST, square\nprint(square(CONST))\n", 3, {
+      files: { "/utils.py": "CONST = 4\ndef square(x):\n    return x * x\n" },
+    });
+    expect(output).toBe("16\n");
+  });
+
+  test("resolves a nested directory via a dotted relative path", async () => {
+    const { output } = await runCodePy2JsDual("from .pkg.utils import greet\nprint(greet())\n", 2, {
+      files: { "/pkg/utils.py": "def greet():\n    return 'hi'\n" },
+    });
+    expect(output).toBe("hi\n");
+  });
+
+  test("rejected at chapter 1 — the exports transfer needs pair/list, unavailable there", async () => {
+    await expect(
+      runCodePy2JsDual("from .utils import square\nprint(square(3))\n", 1, {
+        files: { "/utils.py": "def square(x):\n    return x * x\n" },
+      }),
+    ).rejects.toThrow(/require SICPy §2 or higher/);
+  });
+
+  test("supports an alias", async () => {
+    const { output } = await runCodePy2JsDual("from .utils import square as sq\nprint(sq(3))\n", 3, {
+      files: { "/utils.py": "def square(x):\n    return x * x\n" },
+    });
+    expect(output).toBe("9\n");
+  });
+
+  test("a diamond dependency runs its shared dependency exactly once", async () => {
+    const { output } = await runCodePy2JsDual(
+      "from .a import a_val\nfrom .b import b_val\nprint(a_val, b_val)\n",
+      3,
+      {
+        files: {
+          "/shared.py": "print('loading shared')\nVALUE = 1\n",
+          "/a.py": "from .shared import VALUE\na_val = VALUE\n",
+          "/b.py": "from .shared import VALUE\nb_val = VALUE\n",
+        },
+      },
+    );
+    expect(output).toBe("loading shared\n1 1\n");
+  });
+
+  test("circular imports raise an ImportError", async () => {
+    await expect(
+      runCodePy2JsDual("from .a import x\n", 3, {
+        files: {
+          "/a.py": "from .b import y\nx = 1\n",
+          "/b.py": "from .a import x\ny = 2\n",
+        },
+      }),
+    ).rejects.toThrow(/circular import/);
+  });
+
+  test("importing an undefined name silently gives None (matching js-slang's own __access_export__)", async () => {
+    const { output } = await runCodePy2JsDual("from .utils import does_not_exist\nprint(does_not_exist)\n", 3, {
+      files: { "/utils.py": "x = 1\n" },
+    });
+    expect(output).toBe("None\n");
+  });
+
+  test("importing a missing file raises ModuleNotFoundError", async () => {
+    await expect(runCodePy2JsDual("from .missing import x\n", 3, { files: {} })).rejects.toThrow(
+      /not found/,
+    );
+  });
+
+  test("a locally-imported file with its own from-import (transitive) works", async () => {
+    const { output } = await runCodePy2JsDual("from .a import a_val\nprint(a_val)\n", 3, {
+      files: {
+        "/b.py": "VALUE = 42\n",
+        "/a.py": "from .b import VALUE\na_val = VALUE\n",
+      },
+    });
+    expect(output).toBe("42\n");
+  });
+});
+
+describe("__program__ shows the flattened single-file program", () => {
+  test("__program__ is the bundled Python text, pair/list based, not the raw multi-file entrypoint", async () => {
+    const output: string[] = [];
+    const session = new Py2JsSession(2, {
+      onOutput: line => output.push(line),
+      files: { "/utils.py": "CONST = 4\ndef square(x):\n    return x * x\n" },
+    });
+    await session.runChunk("from .utils import square, CONST\nprint(__program__)\n");
+    const program = output.join("\n");
+    expect(program).toContain("def __access_named_export__(named_exports, lookup_name):");
+    expect(program).toContain("def __module_utils_py__():");
+    expect(program).toContain('square = __access_named_export__(__exports_utils_py__, "square")');
+    // The raw multi-file entrypoint text (with its own `from .utils import`
+    // line) is gone — replaced by the flattened program's own lookups.
+    expect(program).not.toContain("from .utils import");
+  });
+});
+
+describe("Py2JsSession local imports", () => {
+  test("runs an entrypoint chunk against a sibling file", async () => {
+    const output: string[] = [];
+    const session = new Py2JsSession(3, {
+      onOutput: line => output.push(line),
+      files: { "/utils.py": "def square(x):\n    return x * x\n" },
+    });
+    await session.runChunk("from .utils import square\nprint(square(6))\n");
+    expect(output.join("\n") + "\n").toBe("36\n");
+  });
+
+  test("a later chunk still sees an earlier chunk's local import", async () => {
+    const output: string[] = [];
+    const session = new Py2JsSession(3, {
+      onOutput: line => output.push(line),
+      files: { "/utils.py": "def square(x):\n    return x * x\n" },
+    });
+    await session.runChunk("from .utils import square\n");
+    await session.runChunk("print(square(5))\n");
+    expect(output.join("\n") + "\n").toBe("25\n");
+  });
+
+  test("a later chunk importing the same file doesn't re-run it (no duplicate side effects)", async () => {
+    const output: string[] = [];
+    const session = new Py2JsSession(3, {
+      onOutput: line => output.push(line),
+      files: { "/utils.py": "print('loading utils')\ndef square(x):\n    return x * x\n" },
+    });
+    await session.runChunk("from .utils import square\nprint(square(2))\n");
+    await session.runChunk("from .utils import square\nprint(square(3))\n");
+    expect(output.join("\n") + "\n").toBe("loading utils\n4\n9\n");
+  });
+});
+
+describe("fileGetter (conductor.requestFile shape)", () => {
+  // A host like the conductor evaluator never hands over a static
+  // Record<string,string> up front — it resolves each file on demand via an
+  // async call (conductor.requestFile). This exercises exactly that shape,
+  // not just the files: Record convenience wrapper the other tests use.
+  function requestFileLike(files: Record<string, string>) {
+    const requested: string[] = [];
+    return {
+      requested,
+      fileGetter: (path: string) => {
+        requested.push(path);
+        return Promise.resolve(files[path]);
+      },
+    };
+  }
+
+  test("runCodePy2JsDual resolves imports through an async fileGetter", async () => {
+    const { fileGetter, requested } = requestFileLike({
+      "/utils.py": "def square(x):\n    return x * x\n",
+    });
+    const { output } = await runCodePy2JsDual("from .utils import square\nprint(square(7))\n", 3, {
+      fileGetter,
+    });
+    expect(output).toBe("49\n");
+    expect(requested).toEqual(["/utils.py"]);
+  });
+
+  test("Py2JsSession.setEntrypointFilePath changes what a relative import resolves against", async () => {
+    const output: string[] = [];
+    const { fileGetter } = requestFileLike({
+      "/pkg/utils.py": "def square(x):\n    return x * x\n",
+      "/utils.py": "def square(x):\n    return x * 1000\n",
+    });
+    const session = new Py2JsSession(3, { onOutput: line => output.push(line), fileGetter });
+    // Mirrors Py2JsEvaluatorBase.evaluateFile: the host's real entrypoint
+    // path is only known once it calls evaluateFile(fileName, ...), after
+    // the session already exists.
+    session.setEntrypointFilePath("/pkg/main.py");
+    await session.runChunk("from .utils import square\nprint(square(3))\n");
+    expect(output.join("\n") + "\n").toBe("9\n");
+  });
+});

--- a/src/tests/wasm-modules.test.ts
+++ b/src/tests/wasm-modules.test.ts
@@ -174,6 +174,19 @@ describe("PyWasmEvaluator module imports", () => {
     expect(errors.length).toBeGreaterThan(0);
   });
 
+  test("a relative import ('from .foo import x') is rejected, not silently treated as a conductor module", async () => {
+    // WASM doesn't implement local-file imports (see py2js) — this must
+    // reject explicitly rather than requesting a conductor module literally
+    // named "foo".
+    const { conductor, errors } = makeMockConductor(false);
+    const evaluator = new PyWasmEvaluator3(conductor);
+
+    await evaluator.evaluateChunk("from .foo import x\n");
+
+    expect(errors).toHaveLength(1);
+    expect(String(errors[0])).toMatch(/relative imports/);
+  });
+
   // Calling an imported module *function* requires JSPI (WebAssembly.Suspending/
   // promising) — absent on this runtime, it's supposed to fail loudly (see
   // index.ts) rather than hang or silently misbehave; present, the call must


### PR DESCRIPTION
## Summary

Copies js-slang's own "folder" treatment — local, relative imports (`from .foo import bar`) resolved against a program's own multi-file map — scoped to the py2js engine. Closes #378.

- **No conductor changes needed.** Local file resolution goes through `IRunnerPlugin.requestFile`, which already exists in the published `@sourceacademy/conductor` package and is already backed by the frontend's folder-mode file store (`BasicEvaluator.startEvaluator` already uses it to fetch the entrypoint). `Py2JsEvaluatorBase` just passes `path => conductor.requestFile(path)` down.
- **A genuine source-to-source transform** (`src/modules/localImports.ts`, engine-agnostic — not tied to py2js internals): every locally-imported file becomes a `def __module_x__(): ...` wrapping that file's own statements, returning a real SICPy linked list of `(name, value)` pairs; the importer's `from .foo import bar` becomes a plain lookup against it via a generated `__access_named_export__` walk — line for line the same shape as js-slang's own local-import prelude (`localImport.prelude.ts`). The whole multi-file program flattens into one ordinary Python source string *before* anything is parsed or compiled, so:
  - it's exactly the artifact a student can be shown via `print(__program__)`,
  - it needs zero engine-specific runtime support (no new opcodes, no new native helpers beyond what the generated Python itself calls: `pair`/`head`/`tail`, already in the linked-list stdlib group).
- **Requires SICPy §2 or higher**, mirroring js-slang's own restriction to Source §2+ for the identical reason — the pair/list transfer structure doesn't exist below that chapter. CSE, PVML, and the WASM engine now reject a relative import explicitly (clear error) rather than silently mistreating a dotted path as a Source Academy module name — full support for those engines is out of scope here.
- **Also fixes a real, separate bug this surfaced**: `Py2JsEvaluatorBase` never supplied `__program__` at all, so referencing it crashed *every* chapter with a raw `ReferenceError` rather than working or failing gracefully. `Py2JsSession` now keeps `__program__` current itself, automatically, from whatever text it's actually compiling for a given chunk — mirroring how the CSE machine already handles this internally — rather than relying on an external caller to remember to wire it up.

## Test plan
- [x] `npm test` — full suite green (19,499 passed, 3,166 pre-existing skips, 0 failures)
- [x] New unit tests for the bundler itself (`src/tests/local-imports-bundler.test.ts`): two-file imports, nested/dotted paths, aliasing, diamond dependencies (shared file runs exactly once), circular imports, missing file/name, chapter-1 rejection, cross-chunk caching via `priorGlobalNames`
- [x] Engine-level tests (`src/tests/py2js-local-imports.test.ts`) via the real `runCodePy2JsDual`/`Py2JsSession` API, plus a `fileGetter` (conductor.requestFile shape) test and a `__program__`-shows-the-flattened-text test
- [x] `__program__` regression tests added/fixed (`src/tests/py2js-interpreter-support.test.ts`)
- [x] Verified live end-to-end in the real Source Academy frontend (Folder mode) against a locally-built `Py2JsEvaluator{1,2,3,4}.js`, unmodified conductor, and unmodified frontend: a two-file folder-mode program correctly imports a function and a value from a sibling file at §2/§3/§4, and is correctly rejected at §1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011b8eJsqoDGiuesf5uQ42oG