### PR TITLE
Fix syntax highlighting for `as` and Python Full's non-chapter keywords

### DIFF
--- a/src/conductor/PyodideEvaluator.ts
+++ b/src/conductor/PyodideEvaluator.ts
@@ -16,6 +16,7 @@ import stream from "../stdlib/stream";
 import { Group } from "../stdlib/utils";
 import { EvaluatorError } from "./errors";
 import { registerAutoCompletePlugin } from "./plugins/autocomplete";
+import { FULL_PYTHON_VARIANT } from "./plugins/autocomplete/keywords";
 
 /** Same per-chapter stdlib surface as every other engine (PyCseEvaluator.ts,
  * py2js's PY2JS_GROUPS) — used here so the Resolver recognizes names like
@@ -305,7 +306,7 @@ export class PyodideEvaluator4 extends ChapterPyodideEvaluator {
  * rather than a chapter's subset. */
 export class PyodideEvaluatorFull extends PyodideEvaluatorBase {
   constructor(conductor: IRunnerPlugin) {
-    super(conductor, "*", 4);
+    super(conductor, "*", FULL_PYTHON_VARIANT);
   }
 
   protected validateChunk(): void {

--- a/src/conductor/plugins/autocomplete/keywords.ts
+++ b/src/conductor/plugins/autocomplete/keywords.ts
@@ -1,6 +1,34 @@
+/** Sentinel variant for unrestricted "Python Full" (see PyodideEvaluatorFull)
+ * — not a real chapter number, but a superset of every chapter, so every
+ * `variant >= n` chapter-gate check in this file, resolver.ts, and
+ * highlight-rules.ts naturally treats it as at least as capable as any
+ * chapter. */
+export const FULL_PYTHON_VARIANT = Infinity;
+
+/** Keywords only meaningful once every chapter gate is off — real Python
+ * keywords that no Source §x chapter grammar accepts (see the `forbidden_*`
+ * tokens in lexer.ts), so they only belong in getKeywords/getIllegalKeywords
+ * output for FULL_PYTHON_VARIANT. */
+const fullOnlyKeywords = [
+  "assert",
+  "class",
+  "del",
+  "except",
+  "finally",
+  "match",
+  "case",
+  "raise",
+  "try",
+  "with",
+  "yield",
+  "async",
+  "await",
+];
+
 export const getKeywords = (variant: number): string[] => {
   let keywords = [
     "and",
+    "as",
     "def",
     "elif",
     "else",
@@ -26,26 +54,19 @@ export const getKeywords = (variant: number): string[] => {
       "pass",
     ]);
   }
+
+  if (variant === FULL_PYTHON_VARIANT) {
+    keywords = keywords.concat(fullOnlyKeywords);
+  }
   return keywords;
 };
 
 export const getIllegalKeywords = (variant: number): string[] => {
-  let illegalKeywords = [
-    "as",
-    "assert",
-    "class",
-    "del",
-    "except",
-    "finally",
-    "match",
-    "case",
-    "raise",
-    "try",
-    "with",
-    "yield",
-    "async",
-    "await",
-  ];
+  // Python Full has no chapter feature gate (see PyodideEvaluatorFull) —
+  // nothing is illegal.
+  if (variant === FULL_PYTHON_VARIANT) return [];
+
+  let illegalKeywords = [...fullOnlyKeywords];
 
   if (variant < 3) {
     illegalKeywords = illegalKeywords.concat([

--- a/src/conductor/plugins/autocomplete/mode.ts
+++ b/src/conductor/plugins/autocomplete/mode.ts
@@ -1,5 +1,6 @@
 import type { SyntaxHighlightData } from "@sourceacademy/common-autocomplete";
 import PythonHighlightRules from "./highlight-rules";
+import { FULL_PYTHON_VARIANT } from "./keywords";
 export default (variant: number): SyntaxHighlightData => ({
   highlightRules: PythonHighlightRules(variant),
   foldingRules: {
@@ -20,6 +21,6 @@ export default (variant: number): SyntaxHighlightData => ({
   autoOutdent: {
     hookFrom: "ace/mode/python",
   },
-  id: `ace/mode/python${variant}`,
+  id: `ace/mode/python${variant === FULL_PYTHON_VARIANT ? "full" : variant}`,
   snippetFileId: "ace/snippets/python",
 });

--- a/src/tests/autocomplete-plugin.test.ts
+++ b/src/tests/autocomplete-plugin.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@sourceacademy/common-autocomplete";
 import type { IChannel, IConduit } from "@sourceacademy/conductor/conduit";
 import AutoCompletePlugin from "../conductor/plugins/autocomplete";
+import { FULL_PYTHON_VARIANT } from "../conductor/plugins/autocomplete/keywords";
 
 class TestChannel<T> implements IChannel<T> {
   readonly name = "test";
@@ -184,5 +185,26 @@ describe("AutoCompletePlugin Conductor channels", () => {
         }),
       }),
     );
+  });
+
+  test("'as' is a legal keyword, not highlighted as invalid, in every chapter", () => {
+    const chapter1 = makePlugin(1);
+    const chapter1Mode = requestMode(chapter1.webSyntax);
+    const chapter1Mapper = chapter1Mode?.highlightRules.constants.find(isKeywordMapperRule);
+
+    expect(chapter1Mapper?.token.map.keyword.split("|")).toContain("as");
+    expect(chapter1Mapper?.token.map["invalid.illegal"].split("|")).not.toContain("as");
+  });
+
+  test("Python Full highlights every Python keyword as legal, none as invalid", () => {
+    const full = makePlugin(FULL_PYTHON_VARIANT);
+    const fullMode = requestMode(full.webSyntax);
+    const fullMapper = fullMode?.highlightRules.constants.find(isKeywordMapperRule);
+
+    const legalKeywords = fullMapper?.token.map.keyword.split("|");
+    for (const keyword of ["yield", "class", "try", "with", "except", "as"]) {
+      expect(legalKeywords).toContain(keyword);
+    }
+    expect(fullMapper?.token.map["invalid.illegal"]).toBe("");
   });
 });

--- a/src/tests/autocomplete.test.ts
+++ b/src/tests/autocomplete.test.ts
@@ -36,6 +36,7 @@ import {
   PyodideEvaluatorFull,
 } from "../../src/conductor/PyodideEvaluator";
 import AutoCompletePlugin from "../../src/conductor/plugins/autocomplete";
+import { FULL_PYTHON_VARIANT } from "../../src/conductor/plugins/autocomplete/keywords";
 import pythonMode from "../../src/conductor/plugins/autocomplete/mode";
 import { getNames } from "../../src/conductor/plugins/autocomplete/resolver";
 
@@ -67,7 +68,7 @@ describe("Python autocomplete plugin registration", () => {
     [PyodideEvaluator2, 2],
     [PyodideEvaluator3, 3],
     [PyodideEvaluator4, 4],
-    [PyodideEvaluatorFull, 4],
+    [PyodideEvaluatorFull, FULL_PYTHON_VARIANT],
     [PyStepperEvaluator1, 1],
     [PyStepperEvaluator2, 2],
   ] as const)("%p registers variant %i and requests its web counterpart", (Evaluator, variant) => {


### PR DESCRIPTION
## Summary
- `as` was flagged as an illegal keyword in every chapter, even though it's valid Source Python syntax
- `PyodideEvaluatorFull` reused chapter 4's autocomplete variant, so real Python keywords chapter 4 doesn't have (`yield`, `class`, `try`, `with`, `except`, etc.) were still highlighted as invalid in Python Full
- Introduces a `FULL_PYTHON_VARIANT` sentinel (`Infinity`) so Full Python's keyword gate is genuinely unrestricted rather than pinned to chapter 4's gate

Fixes #380

## Test plan
- [x] Added tests: `as` is legal in every chapter; Python Full highlights `yield`/`class`/`try`/`with`/`except`/`as` as legal with no illegal keywords
- [x] `npx jest` — full suite passes (19521 passed, 0 failed)
- [x] `npx tsc --noEmit` and `npx eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013reeqq7jG66DR1vnwby5T3