### PR TITLE
Wire gutter-click breakpoints to their closest enclosing statement

### DIFF
--- a/src/breakpoints.ts
+++ b/src/breakpoints.ts
@@ -1,0 +1,84 @@
+/**
+ * Resolves gutter-clicked line numbers to AST nodes, for issue #383: "Proper breakpoints with
+ * gutter clicks". A gutter click only carries a line number, not an AST node, so this walks the
+ * parsed tree once per run and flags the statement each requested line resolves to. The stepper
+ * (`conductor/stepper`) and CSE machine (`engines/cse`) each separately check the resulting flag
+ * and treat it exactly like an explicit `breakpoint()` call.
+ */
+
+import { StmtNS } from "./ast-types";
+
+/** Bolted onto statement instances, mirroring `engines/cse/types.ts`'s `isEnvDependent` — not
+ * part of the generated `ast-types.ts`, since it's per-run state, not part of the grammar. */
+type BreakpointFlag = { hasBreakpoint?: boolean };
+
+/** Every statement in `stmt`'s subtree (including `stmt` itself), depth-first. Only the five
+ * statement kinds that own a nested statement list (`ast-types.ts`) are recursed into. */
+function collectStatements(stmt: StmtNS.Stmt, out: StmtNS.Stmt[]): void {
+  out.push(stmt);
+  switch (stmt.kind) {
+    case "If": {
+      const s = stmt as StmtNS.If;
+      s.body.forEach(child => collectStatements(child, out));
+      s.elseBlock?.forEach(child => collectStatements(child, out));
+      break;
+    }
+    case "While":
+      (stmt as StmtNS.While).body.forEach(child => collectStatements(child, out));
+      break;
+    case "For":
+      (stmt as StmtNS.For).body.forEach(child => collectStatements(child, out));
+      break;
+    case "FunctionDef":
+      (stmt as StmtNS.FunctionDef).body.forEach(child => collectStatements(child, out));
+      break;
+    case "FileInput":
+      (stmt as StmtNS.FileInput).statements.forEach(child => collectStatements(child, out));
+      break;
+  }
+}
+
+/** For a single target line, the statement that best represents "the line the student clicked":
+ * the smallest statement whose own span covers it, or (for a blank/comment line, or a line
+ * between statements) the nearest statement that starts on or after it. `null` if `line` is past
+ * every statement in the file. */
+function closestStatementForLine(statements: StmtNS.Stmt[], line: number): StmtNS.Stmt | null {
+  let bestCovering: StmtNS.Stmt | null = null;
+  let bestCoveringSpan = Infinity;
+  let bestFollowing: StmtNS.Stmt | null = null;
+  let bestFollowingLine = Infinity;
+
+  for (const stmt of statements) {
+    const start = stmt.startToken.line;
+    const end = stmt.endToken.line;
+    if (start <= line && line <= end) {
+      const span = end - start;
+      if (span < bestCoveringSpan) {
+        bestCovering = stmt;
+        bestCoveringSpan = span;
+      }
+    } else if (start > line && start < bestFollowingLine) {
+      bestFollowing = stmt;
+      bestFollowingLine = start;
+    }
+  }
+
+  return bestCovering ?? bestFollowing;
+}
+
+/**
+ * Flags, for each line in `lines`, the closest enclosing statement in `ast` with
+ * `hasBreakpoint = true`. The stepper and CSE machine each check this flag where they already
+ * check for an explicit `breakpoint()` call, and record the same kind of step for it.
+ */
+export function markBreakpoints(ast: StmtNS.FileInput, lines: number[]): void {
+  if (lines.length === 0) return;
+
+  const statements: StmtNS.Stmt[] = [];
+  ast.statements.forEach(stmt => collectStatements(stmt, statements));
+
+  for (const line of lines) {
+    const match = closestStatementForLine(statements, line);
+    if (match) (match as StmtNS.Stmt & BreakpointFlag).hasBreakpoint = true;
+  }
+}

--- a/src/conductor/PyCseEvaluator.ts
+++ b/src/conductor/PyCseEvaluator.ts
@@ -14,6 +14,7 @@ import {
   destroyStreams,
   displayError,
 } from "../engines/cse/streams";
+import { markBreakpoints } from "../breakpoints";
 import { parse } from "../parser/parser-adapter";
 import { analyze } from "../resolver/analysis";
 import dataVisualizer from "../stdlib/dataVisualizer";
@@ -29,6 +30,7 @@ import { PythonDataVisualizerRunnerPlugin } from "./dataVisualizer/PyDataVisuali
 import { asInterfacableEvaluator, GenericDataHandler } from "./GenericDataHandler";
 import { registerAutoCompletePlugin } from "./plugins/autocomplete";
 import { collectSnapshots } from "./plugins/PyCseMachinePlugin";
+import { fetchRunConfig } from "./runConfig";
 
 function once<T>(fn: () => Promise<T>): () => Promise<T> {
   let promise: Promise<T> | undefined;
@@ -145,15 +147,9 @@ abstract class PyCseEvaluatorBase extends BasicEvaluator {
       // Chapters 1-2: run to completion via the generator (maxSnapshots=0 → no
       // snapshots collected, CSE tab never appears) so stdout/errors are emitted.
       if (this.variant >= 3) {
-        const configRaw = await this.conductor.requestFile("/__cse_config__");
-        let maxSnapshots = 1000;
-        if (configRaw) {
-          try {
-            maxSnapshots = (JSON.parse(configRaw) as { stepLimit?: number }).stepLimit ?? 1000;
-          } catch {
-            // malformed config — fall back to default step limit
-          }
-        }
+        const config = await fetchRunConfig(this.conductor);
+        const maxSnapshots = config.stepLimit ?? 1000;
+        markBreakpoints(ast, config.breakpointLines ?? []);
 
         const { snapshots, breakpointSteps } = await collectSnapshots(
           this.context,

--- a/src/conductor/PyStepperEvaluator.ts
+++ b/src/conductor/PyStepperEvaluator.ts
@@ -3,8 +3,10 @@ import { ConductorError, EvaluatorSyntaxError } from "@sourceacademy/conductor/c
 import { BasicEvaluator, type IRunnerPlugin } from "@sourceacademy/conductor/runner";
 import { RunnerStatus } from "@sourceacademy/conductor/types";
 
+import { markBreakpoints } from "../breakpoints";
 import { parse } from "../parser";
 import { registerAutoCompletePlugin } from "./plugins/autocomplete";
+import { fetchRunConfig } from "./runConfig";
 import { evaluatePython } from "./stepper/getSteps";
 import { preprocessPython } from "./stepper/preprocess";
 import { PythonStepperRunnerPlugin } from "./stepper/PyStepperRunnerPlugin";
@@ -59,6 +61,9 @@ abstract class PyStepperEvaluatorBase extends BasicEvaluator {
     try {
       const script = chunk + "\n";
       const ast = parse(script);
+
+      const config = await fetchRunConfig(this.conductor);
+      markBreakpoints(ast, config.breakpointLines ?? []);
 
       // Preprocessing: reject an undefined variable as a (preprocessing) error and do NOT run the
       // stepper — a free name has no meaning in the substitution model. Mirrors Source's

--- a/src/conductor/runConfig.ts
+++ b/src/conductor/runConfig.ts
@@ -1,0 +1,29 @@
+import type { IRunnerPlugin } from "@sourceacademy/conductor/runner";
+
+/**
+ * Per-run configuration the host serves via a virtual `/__cse_config__` file (fetched through
+ * {@link IRunnerPlugin.requestFile}, the only generic inbound channel Conductor offers — there is
+ * no dedicated message type for either of these in `@sourceacademy/conductor`).
+ */
+export interface RunConfig {
+  /** Snapshot cap for the CSE machine tab. Default: 1000 (see `PyCseEvaluator.ts`). */
+  stepLimit?: number;
+  /**
+   * Lines the host's gutter-click breakpoints (the ace editor's red dots) currently sit on, for
+   * issue #383. Resolved to their closest enclosing statement by `markBreakpoints`
+   * (`../breakpoints.ts`) before evaluation/stepping starts.
+   */
+  breakpointLines?: number[];
+}
+
+/** Fetches and parses `/__cse_config__`. Malformed JSON or a missing file both fall back to `{}`
+ * (every field optional, so callers apply their own defaults) rather than failing the run. */
+export async function fetchRunConfig(conductor: IRunnerPlugin): Promise<RunConfig> {
+  const raw = await conductor.requestFile("/__cse_config__");
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as RunConfig;
+  } catch {
+    return {};
+  }
+}

--- a/src/conductor/stepper/__tests__/getSteps.test.ts
+++ b/src/conductor/stepper/__tests__/getSteps.test.ts
@@ -7,6 +7,7 @@ import {
   type StepNode,
 } from "../ast";
 import { isBuiltinConstantName } from "../builtins";
+import { markBreakpoints } from "../../../breakpoints";
 import { parse } from "../../../parser";
 import { evaluatePython, getPythonSteps } from "../getSteps";
 import { formatPrintLlistOutput } from "../lists";
@@ -1664,6 +1665,66 @@ describe("Python stepper — breakpoint() marks a debugger breakpoint (#188)", (
       step => step.markers?.[0]?.redexNodeType === "DebuggerStatement",
     );
     expect(flagged).toHaveLength(1);
+  });
+});
+
+describe("Python stepper — gutter-click breakpoints (#383)", () => {
+  // A gutter click only carries a line number, not an AST node: `markBreakpoints` (../../../breakpoints)
+  // resolves it to the closest enclosing statement and flags it; `translate.ts` copies that flag onto
+  // the corresponding StepNode, and `reduce.ts` folds it into the same `isBreakpoint` field the
+  // breakpoint() detection above uses — so it surfaces identically, via `redexNodeType ===
+  // "DebuggerStatement"` on the *before* marker.
+
+  function stepsWithBreakpoints(src: string, lines: number[]) {
+    const ast = parse(src + "\n");
+    markBreakpoints(ast, lines);
+    return getPythonSteps(ast);
+  }
+
+  function flaggedExplanations(src: string, lines: number[]) {
+    return stepsWithBreakpoints(src, lines)
+      .filter(step => step.markers?.[0]?.redexNodeType === "DebuggerStatement")
+      .map(step => step.markers?.[0]?.explanation);
+  }
+
+  test("a click on a plain statement's line marks it as a breakpoint target", () => {
+    expect(flaggedExplanations("x = 1\ny = 2", [1])).toEqual([
+      "Declaring and substituting x into the rest of the block",
+    ]);
+  });
+
+  test("a click on a blank line snaps to the next statement", () => {
+    expect(flaggedExplanations("x = 1\n\ny = 2", [2])).toEqual([
+      "Declaring and substituting y into the rest of the block",
+    ]);
+  });
+
+  test("a click inside a function body marks that statement, not the def line", () => {
+    // Fires on the *first* step that reaches the `y = x + 1` line (`x` already substituted to `4`
+    // by the call, so the first step is reducing `4 + 1`) — not the later "declared and
+    // substituted" step, matching a debugger stopping the moment execution reaches the line.
+    const src = "def f(x):\n  y = x + 1\n  return y\nf(4)";
+    expect(flaggedExplanations(src, [2])).toEqual(["Evaluating binary expression 4 + 1"]);
+  });
+
+  test("a multi-step statement is only a breakpoint target once, not on every step it takes", () => {
+    // `y`'s initializer takes three expression steps (1 + 2, then + 3, then bind); a naive
+    // "the whole statement is flagged" check would mark all of them. Only the first should carry
+    // `redexNodeType === "DebuggerStatement"`.
+    const flagged = flaggedExplanations("y = 1 + 2 + 3", [1]);
+    expect(flagged).toHaveLength(1);
+  });
+
+  test("a click past the end of the program marks nothing", () => {
+    expect(flaggedExplanations("x = 1", [50])).toEqual([]);
+  });
+
+  test("composes with an explicit breakpoint() call elsewhere in the same program", () => {
+    const flagged = flaggedExplanations("breakpoint()\nx = 1\ny = 2", [3]);
+    expect(flagged).toEqual([
+      "Evaluating breakpoint statement",
+      "Declaring and substituting y into the rest of the block",
+    ]);
   });
 });
 

--- a/src/conductor/stepper/ast.ts
+++ b/src/conductor/stepper/ast.ts
@@ -15,6 +15,10 @@
 /** A single estree-shaped stepper node. Plain JSON: a `type` discriminator plus child fields. */
 export interface StepNode {
   type: string;
+  /** Set by `translate.ts` when the source statement was flagged by `markBreakpoints` (a gutter
+   * click resolved to its closest enclosing statement — see `../../breakpoints.ts`). Checked by
+   * `reduce.ts` alongside its existing `breakpoint()`-call detection. */
+  hasBreakpoint?: boolean;
   [key: string]: unknown;
 }
 

--- a/src/conductor/stepper/reduce.ts
+++ b/src/conductor/stepper/reduce.ts
@@ -846,13 +846,19 @@ function stepHead(head: StepNode, rest: StepNode[]): HeadOutcome {
       }
       const reduced = reduceExpr(expr);
       if (reduced) {
+        // `hasBreakpoint: false` on the carried-forward copy: `head` still has one more expression
+        // step to take, so it stays the head on the next call to this function with the *same*
+        // `hasBreakpoint` flag (plain object spread) — clearing it here is what makes a gutter
+        // breakpoint (see `headBreakpoint` in `reduceProgram`/`reduceBlock`) fire exactly once, on
+        // this first step reaching the statement, rather than on every subsequent expression step
+        // taken while still evaluating it.
         return {
           kind: "step",
-          newBody: [{ ...head, expression: reduced.node }, ...rest],
+          newBody: [{ ...head, expression: reduced.node, hasBreakpoint: false }, ...rest],
           preRedex: reduced.preRedex,
           postRedex: reduced.postRedex,
           postNewBody: reduced.postNode
-            ? [{ ...head, expression: reduced.postNode }, ...rest]
+            ? [{ ...head, expression: reduced.postNode, hasBreakpoint: false }, ...rest]
             : undefined,
           explanation: reduced.explanation,
           beforeExplanation: reduced.beforeExplanation,
@@ -870,17 +876,29 @@ function stepHead(head: StepNode, rest: StepNode[]): HeadOutcome {
       if (!isValue(init)) {
         const reduced = reduceExpr(init);
         if (reduced) {
+          // See the identical `hasBreakpoint: false` note in the `ExpressionStatement` case above.
           return {
             kind: "step",
-            newBody: [{ ...head, declarations: [{ ...decl, init: reduced.node }] }, ...rest],
+            newBody: [
+              { ...head, declarations: [{ ...decl, init: reduced.node }], hasBreakpoint: false },
+              ...rest,
+            ],
             preRedex: reduced.preRedex,
             postRedex: reduced.postRedex,
             postNewBody: reduced.postNode
-              ? [{ ...head, declarations: [{ ...decl, init: reduced.postNode }] }, ...rest]
+              ? [
+                  {
+                    ...head,
+                    declarations: [{ ...decl, init: reduced.postNode }],
+                    hasBreakpoint: false,
+                  },
+                  ...rest,
+                ]
               : undefined,
             explanation: reduced.explanation,
             beforeExplanation: reduced.beforeExplanation,
             output: reduced.output,
+            isBreakpoint: reduced.isBreakpoint,
           };
         }
         return { kind: "irreducible" };
@@ -940,13 +958,14 @@ function stepHead(head: StepNode, rest: StepNode[]): HeadOutcome {
     case "IfStatement": {
       const reduced = reduceExpr(head.test as StepNode);
       if (reduced) {
+        // See the identical `hasBreakpoint: false` note in the `ExpressionStatement` case above.
         return {
           kind: "step",
-          newBody: [{ ...head, test: reduced.node }, ...rest],
+          newBody: [{ ...head, test: reduced.node, hasBreakpoint: false }, ...rest],
           preRedex: reduced.preRedex,
           postRedex: reduced.postRedex,
           postNewBody: reduced.postNode
-            ? [{ ...head, test: reduced.postNode }, ...rest]
+            ? [{ ...head, test: reduced.postNode, hasBreakpoint: false }, ...rest]
             : undefined,
           explanation: reduced.explanation,
           beforeExplanation: reduced.beforeExplanation,
@@ -987,6 +1006,12 @@ export function reduceProgram(prog: StepNode): ReduceResult | null {
   const head = body[0];
   const rest = body.slice(1);
   const outcome = stepHead(head, rest);
+  // A statement flagged by `markBreakpoints` (a gutter click resolved to its closest enclosing
+  // statement — see `../../breakpoints.ts`, propagated onto the `StepNode` by `translate.ts`) is
+  // treated exactly like an explicit `breakpoint()` call: computed once here, where `head` is in
+  // scope, and OR'd into every `ReduceResult` this function can return for it, rather than
+  // threading it through every `stepHead` arm individually.
+  const headBreakpoint = !!head.hasBreakpoint;
 
   switch (outcome.kind) {
     case "step":
@@ -998,7 +1023,7 @@ export function reduceProgram(prog: StepNode): ReduceResult | null {
         explanation: outcome.explanation,
         beforeExplanation: outcome.beforeExplanation,
         output: outcome.output,
-        isBreakpoint: outcome.isBreakpoint,
+        isBreakpoint: outcome.isBreakpoint || headBreakpoint,
       };
     case "finished-expression": {
       // A fully-evaluated top-level expression statement is a value to discard — a Python statement
@@ -1017,6 +1042,7 @@ export function reduceProgram(prog: StepNode): ReduceResult | null {
         postNode: prog,
         explanation: `Evaluated ${text}`,
         beforeExplanation: `Evaluating ${text}`,
+        isBreakpoint: headBreakpoint,
       };
     }
     case "return": // A `return` at the top level is not valid Python; treat the program as done.
@@ -1034,7 +1060,7 @@ export function reduceProgram(prog: StepNode): ReduceResult | null {
  */
 function reduceBlock(node: StepNode): ReduceResult | null {
   const none = (): StepNode => literal(null, "None");
-  const fallOff = (preRedex: StepNode): ReduceResult => {
+  const fallOff = (preRedex: StepNode, isBreakpoint = false): ReduceResult => {
     const result = none();
     return {
       node: result,
@@ -1042,6 +1068,7 @@ function reduceBlock(node: StepNode): ReduceResult | null {
       postRedex: result,
       explanation: "Function returned None",
       beforeExplanation: "Function returning None",
+      isBreakpoint,
     };
   };
 
@@ -1051,6 +1078,8 @@ function reduceBlock(node: StepNode): ReduceResult | null {
   const head = body[0];
   const rest = body.slice(1);
   const outcome = stepHead(head, rest);
+  // See the identical `headBreakpoint` note in `reduceProgram`.
+  const headBreakpoint = !!head.hasBreakpoint;
 
   switch (outcome.kind) {
     case "step":
@@ -1062,7 +1091,7 @@ function reduceBlock(node: StepNode): ReduceResult | null {
         explanation: outcome.explanation,
         beforeExplanation: outcome.beforeExplanation,
         output: outcome.output,
-        isBreakpoint: outcome.isBreakpoint,
+        isBreakpoint: outcome.isBreakpoint || headBreakpoint,
       };
     case "return": {
       // `return` exits the function: the block contracts to the return's argument (or `None` for a
@@ -1074,6 +1103,7 @@ function reduceBlock(node: StepNode): ReduceResult | null {
         postRedex: arg,
         explanation: `Returned ${unparse(arg)}`,
         beforeExplanation: `Returning ${unparse(arg)}`,
+        isBreakpoint: headBreakpoint,
       };
     }
     case "finished-expression": {
@@ -1081,7 +1111,7 @@ function reduceBlock(node: StepNode): ReduceResult | null {
       // was the last statement, the function fell off the end → None. As in `reduceProgram`'s
       // "finished-expression" case, the after step shows the value green once more (`postNode`) before
       // it disappears on the next contraction.
-      if (rest.length === 0) return fallOff(head);
+      if (rest.length === 0) return fallOff(head, headBreakpoint);
       const text = unparse(head.expression as StepNode);
       return {
         node: { ...node, body: rest },
@@ -1090,6 +1120,7 @@ function reduceBlock(node: StepNode): ReduceResult | null {
         postNode: node,
         explanation: `Evaluated ${text}`,
         beforeExplanation: `Evaluating ${text}`,
+        isBreakpoint: headBreakpoint,
       };
     }
     case "irreducible":

--- a/src/conductor/stepper/translate.ts
+++ b/src/conductor/stepper/translate.ts
@@ -131,6 +131,16 @@ function block(statements: StmtNS.Stmt[]): StepNode {
 }
 
 function translateStmt(stmt: StmtNS.Stmt): StepNode {
+  const node = translateStmtInner(stmt);
+  // `hasBreakpoint` is bolted onto the source statement by `markBreakpoints` (see
+  // `../../breakpoints.ts`); copy it across so `reduce.ts` can still see it once the statement
+  // has become an (estree-shaped, location-free) `StepNode` — mirrors how `breakpoint()` itself
+  // is detected structurally at reduction time rather than here at translation time (see below).
+  if ((stmt as StmtNS.Stmt & { hasBreakpoint?: boolean }).hasBreakpoint) node.hasBreakpoint = true;
+  return node;
+}
+
+function translateStmtInner(stmt: StmtNS.Stmt): StepNode {
   switch (stmt.kind) {
     case "SimpleExpr": {
       const expr = (stmt as StmtNS.SimpleExpr).expression;

--- a/src/engines/cse/interpreter.ts
+++ b/src/engines/cse/interpreter.ts
@@ -354,6 +354,15 @@ export async function* generateCSEMachineStateStream(
       }
     }
 
+    // A node flagged by `markBreakpoints` (a gutter click resolved to its closest enclosing
+    // statement — see `breakpoints.ts`) is treated exactly like an explicit `breakpoint()` call:
+    // recorded the moment it's about to be evaluated, using the same `steps - 1` step-index
+    // convention as the block above.
+    if (!isPrelude && isNode(command) && command.hasBreakpoint) {
+      context.runtime.breakpointSteps.push(steps - 1);
+      context.runtime.break = true;
+    }
+
     control.pop();
 
     if (isNode(command)) {

--- a/src/engines/cse/types.ts
+++ b/src/engines/cse/types.ts
@@ -5,7 +5,11 @@ import { Context } from "./context";
 import { Environment } from "./environment";
 import { Value } from "./stash";
 
-export type Node = { isEnvDependent?: boolean } & (StmtNS.Stmt | ExprNS.Expr | StatementSequence);
+export type Node = { isEnvDependent?: boolean; hasBreakpoint?: boolean } & (
+  | StmtNS.Stmt
+  | ExprNS.Expr
+  | StatementSequence
+);
 
 export interface StatementSequence {
   kind: "StatementSequence";

--- a/src/tests/PyCseEvaluator.test.ts
+++ b/src/tests/PyCseEvaluator.test.ts
@@ -157,23 +157,27 @@ describe("PyCseEvaluator3/4 (CSE snapshots)", () => {
   });
 
   test("gutter-click breakpoint lines don't leak into a chunk that didn't request them", async () => {
-    const { conductor, errors, sendSnapshots } = makeMockConductor({
+    // Same evaluator and conductor across both calls, mutating the mocked /__cse_config__ file in
+    // between - unlike a fresh evaluator (which would trivially start with no breakpointSteps
+    // regardless of any reset logic), this actually exercises evaluateChunk's per-run reset
+    // (this.context.runtime.breakpointSteps = []; see PyCseEvaluator.ts), the same reset the
+    // breakpoint()-leak test above exercises for an explicit breakpoint() call.
+    const files: Record<string, string> = {
       "/__cse_config__": JSON.stringify({ breakpointLines: [1] }),
-    });
+    };
+    const { conductor, errors, sendSnapshots } = makeMockConductor(files);
     const evaluator = new PyCseEvaluator3(conductor);
 
     await evaluator.evaluateChunk("x = 1");
-
     expect(errors).toEqual([]);
     const [, firstBreakpointSteps] = sendSnapshots.mock.calls[0];
     expect(firstBreakpointSteps.length).toBeGreaterThan(0);
 
-    // A fresh evaluator with no configured breakpoint lines: no breakpointSteps at all.
-    const { conductor: plainConductor, sendSnapshots: plainSendSnapshots } = makeMockConductor();
-    const plainEvaluator = new PyCseEvaluator3(plainConductor);
-    await plainEvaluator.evaluateChunk("x = 1");
-    const [, plainBreakpointSteps] = plainSendSnapshots.mock.calls[0];
-    expect(plainBreakpointSteps).toEqual([]);
+    delete files["/__cse_config__"];
+    await evaluator.evaluateChunk("x = 1");
+    expect(errors).toEqual([]);
+    const [, secondBreakpointSteps] = sendSnapshots.mock.calls[1];
+    expect(secondBreakpointSteps).toEqual([]);
   });
 });
 

--- a/src/tests/PyCseEvaluator.test.ts
+++ b/src/tests/PyCseEvaluator.test.ts
@@ -26,14 +26,14 @@ import {
  * PythonDataVisualizerRunnerPlugin (used via `this.dataVisualizerPlugin?.resetRun()`). One
  * generic stub covers every registerPlugin call: only the methods each plugin path actually
  * invokes need to exist. */
-function makeMockConductor() {
+function makeMockConductor(files: Record<string, string> = {}) {
   const results: unknown[] = [];
   const errors: unknown[] = [];
   const outputs: string[] = [];
   const sendSnapshots = jest.fn();
   const resetRun = jest.fn().mockResolvedValue(undefined);
   const conductor = {
-    requestFile: () => Promise.resolve(undefined),
+    requestFile: (name: string) => Promise.resolve(files[name]),
     sendResult: (r: unknown) => results.push(r),
     sendError: (e: unknown) => errors.push(e),
     sendOutput: (m: string) => outputs.push(m),
@@ -138,6 +138,42 @@ describe("PyCseEvaluator3/4 (CSE snapshots)", () => {
     const [, secondBreakpointSteps] = sendSnapshots.mock.calls[1];
     expect(firstBreakpointSteps.length).toBeGreaterThan(0);
     expect(secondBreakpointSteps).toEqual([]);
+  });
+
+  test("gutter-click breakpoint lines from /__cse_config__ (#383) surface in sendSnapshots", async () => {
+    // The host has no dedicated message for gutter clicks; it serves them through the same
+    // /__cse_config__ virtual file evaluateChunk already fetches stepLimit from (see runConfig.ts).
+    const { conductor, errors, sendSnapshots } = makeMockConductor({
+      "/__cse_config__": JSON.stringify({ breakpointLines: [2] }),
+    });
+    const evaluator = new PyCseEvaluator3(conductor);
+
+    await evaluator.evaluateChunk("x = 1\ny = 2");
+
+    expect(errors).toEqual([]);
+    expect(sendSnapshots).toHaveBeenCalledTimes(1);
+    const [, breakpointSteps] = sendSnapshots.mock.calls[0];
+    expect(breakpointSteps.length).toBeGreaterThan(0);
+  });
+
+  test("gutter-click breakpoint lines don't leak into a chunk that didn't request them", async () => {
+    const { conductor, errors, sendSnapshots } = makeMockConductor({
+      "/__cse_config__": JSON.stringify({ breakpointLines: [1] }),
+    });
+    const evaluator = new PyCseEvaluator3(conductor);
+
+    await evaluator.evaluateChunk("x = 1");
+
+    expect(errors).toEqual([]);
+    const [, firstBreakpointSteps] = sendSnapshots.mock.calls[0];
+    expect(firstBreakpointSteps.length).toBeGreaterThan(0);
+
+    // A fresh evaluator with no configured breakpoint lines: no breakpointSteps at all.
+    const { conductor: plainConductor, sendSnapshots: plainSendSnapshots } = makeMockConductor();
+    const plainEvaluator = new PyCseEvaluator3(plainConductor);
+    await plainEvaluator.evaluateChunk("x = 1");
+    const [, plainBreakpointSteps] = plainSendSnapshots.mock.calls[0];
+    expect(plainBreakpointSteps).toEqual([]);
   });
 });
 

--- a/src/tests/PyCseMachinePlugin.test.ts
+++ b/src/tests/PyCseMachinePlugin.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { markBreakpoints } from "../breakpoints";
 import {
   collectSnapshots,
   formatValue,
@@ -762,5 +763,80 @@ f()`,
     const last = snapshots[snapshots.length - 1];
     const xBinding = last.environments.flatMap(e => e.bindings).find(b => b.name === "x");
     expect(xBinding?.value.displayValue).toBe("None");
+  });
+});
+
+describe("gutter-click breakpoints (#383)", () => {
+  // A gutter click only carries a line number; `markBreakpoints` (../breakpoints) resolves it to
+  // the closest enclosing statement and flags it, and the interpreter checks that flag right next
+  // to its existing breakpoint() check (interpreter.ts) — so a gutter click should produce the
+  // same kind of `breakpointSteps` entry an equivalent breakpoint() call would.
+
+  /** Like `runAndCollectWithBreakpoints`, but marks `lines` via `markBreakpoints` instead of
+   * relying on an explicit `breakpoint()` call in the source. */
+  async function runWithGutterBreakpoints(code: string, lines: number[], variant = 3) {
+    const ctx = new Context();
+    for (const [name, val] of [...math.builtins, ...misc.builtins]) {
+      ctx.nativeStorage.builtins.set(name, val);
+    }
+    const script = code + "\n";
+    const ast = parse(script);
+    markBreakpoints(ast, lines);
+    return collectSnapshots(ctx, new Control(ast), new Stash(), -1, variant, script);
+  }
+
+  it("records a breakpointSteps entry for a plain statement's line", async () => {
+    const { breakpointSteps } = await runWithGutterBreakpoints("x = 1\ny = 2", [1]);
+    expect(breakpointSteps.length).toBeGreaterThan(0);
+  });
+
+  it("resolves a click on a blank line to the next statement", async () => {
+    const { breakpointSteps } = await runWithGutterBreakpoints("x = 1\n\ny = 2", [2]);
+    expect(breakpointSteps.length).toBeGreaterThan(0);
+  });
+
+  it("is recorded inside a function body", async () => {
+    const { breakpointSteps } = await runWithGutterBreakpoints(
+      `def f():
+    y = 1
+    return y
+
+f()`,
+      [2],
+    );
+    expect(breakpointSteps.length).toBeGreaterThan(0);
+  });
+
+  it("is recorded on every iteration inside a loop, in ascending order", async () => {
+    const { breakpointSteps } = await runWithGutterBreakpoints(
+      `for x in range(3):
+    y = x`,
+      [2],
+    );
+    expect(breakpointSteps.length).toBe(3);
+    expect([...breakpointSteps].sort((a, b) => a - b)).toEqual(breakpointSteps);
+  });
+
+  it("resolves a click on an if statement's header to the if statement itself", async () => {
+    const { breakpointSteps } = await runWithGutterBreakpoints(
+      `x = 1
+if x > 0:
+    y = 1
+else:
+    y = 2`,
+      [2],
+    );
+    expect(breakpointSteps.length).toBeGreaterThan(0);
+  });
+
+  it("ignores a line past the end of the program", async () => {
+    const { breakpointSteps } = await runWithGutterBreakpoints("x = 1", [50]);
+    expect(breakpointSteps).toHaveLength(0);
+  });
+
+  it("composes with an explicit breakpoint() call elsewhere in the same program", async () => {
+    const { breakpointSteps } = await runWithGutterBreakpoints("breakpoint()\nx = 1\ny = 2", [3]);
+    // One from the explicit breakpoint() call, one from the gutter click on `y = 2`.
+    expect(breakpointSteps.length).toBe(2);
   });
 });

--- a/src/tests/PyCseMachinePlugin.test.ts
+++ b/src/tests/PyCseMachinePlugin.test.ts
@@ -785,18 +785,33 @@ describe("gutter-click breakpoints (#383)", () => {
     return collectSnapshots(ctx, new Control(ast), new Stash(), -1, variant, script);
   }
 
+  /** The source line of the statement on top of control at `stepIndex` — i.e. the statement a
+   * breakpoint step is about to evaluate. `metadata.startLine` comes straight from the node's own
+   * `startToken.line` (`serializeControlItem`), so this pins down exactly which statement
+   * `markBreakpoints` resolved to, unlike a snapshot's own `currentLine` (the *previously*
+   * evaluated node - off by one from what's on top of control at a breakpoint step). */
+  function breakpointLine(
+    snapshots: Awaited<ReturnType<typeof runWithGutterBreakpoints>>["snapshots"],
+    stepIndex: number,
+  ): number | undefined {
+    const step = snapshots.find(s => s.stepIndex === stepIndex);
+    return (step?.control[0]?.metadata as { startLine?: number } | undefined)?.startLine;
+  }
+
   it("records a breakpointSteps entry for a plain statement's line", async () => {
-    const { breakpointSteps } = await runWithGutterBreakpoints("x = 1\ny = 2", [1]);
-    expect(breakpointSteps.length).toBeGreaterThan(0);
+    const { snapshots, breakpointSteps } = await runWithGutterBreakpoints("x = 1\ny = 2", [1]);
+    expect(breakpointSteps).toHaveLength(1);
+    expect(breakpointLine(snapshots, breakpointSteps[0])).toBe(1);
   });
 
   it("resolves a click on a blank line to the next statement", async () => {
-    const { breakpointSteps } = await runWithGutterBreakpoints("x = 1\n\ny = 2", [2]);
-    expect(breakpointSteps.length).toBeGreaterThan(0);
+    const { snapshots, breakpointSteps } = await runWithGutterBreakpoints("x = 1\n\ny = 2", [2]);
+    expect(breakpointSteps).toHaveLength(1);
+    expect(breakpointLine(snapshots, breakpointSteps[0])).toBe(3);
   });
 
   it("is recorded inside a function body", async () => {
-    const { breakpointSteps } = await runWithGutterBreakpoints(
+    const { snapshots, breakpointSteps } = await runWithGutterBreakpoints(
       `def f():
     y = 1
     return y
@@ -804,21 +819,25 @@ describe("gutter-click breakpoints (#383)", () => {
 f()`,
       [2],
     );
-    expect(breakpointSteps.length).toBeGreaterThan(0);
+    expect(breakpointSteps).toHaveLength(1);
+    expect(breakpointLine(snapshots, breakpointSteps[0])).toBe(2);
   });
 
   it("is recorded on every iteration inside a loop, in ascending order", async () => {
-    const { breakpointSteps } = await runWithGutterBreakpoints(
+    const { snapshots, breakpointSteps } = await runWithGutterBreakpoints(
       `for x in range(3):
     y = x`,
       [2],
     );
     expect(breakpointSteps.length).toBe(3);
     expect([...breakpointSteps].sort((a, b) => a - b)).toEqual(breakpointSteps);
+    for (const step of breakpointSteps) {
+      expect(breakpointLine(snapshots, step)).toBe(2);
+    }
   });
 
   it("resolves a click on an if statement's header to the if statement itself", async () => {
-    const { breakpointSteps } = await runWithGutterBreakpoints(
+    const { snapshots, breakpointSteps } = await runWithGutterBreakpoints(
       `x = 1
 if x > 0:
     y = 1
@@ -826,7 +845,8 @@ else:
     y = 2`,
       [2],
     );
-    expect(breakpointSteps.length).toBeGreaterThan(0);
+    expect(breakpointSteps).toHaveLength(1);
+    expect(breakpointLine(snapshots, breakpointSteps[0])).toBe(2);
   });
 
   it("ignores a line past the end of the program", async () => {
@@ -835,8 +855,17 @@ else:
   });
 
   it("composes with an explicit breakpoint() call elsewhere in the same program", async () => {
-    const { breakpointSteps } = await runWithGutterBreakpoints("breakpoint()\nx = 1\ny = 2", [3]);
-    // One from the explicit breakpoint() call, one from the gutter click on `y = 2`.
-    expect(breakpointSteps.length).toBe(2);
+    const { snapshots, breakpointSteps } = await runWithGutterBreakpoints(
+      "breakpoint()\nx = 1\ny = 2",
+      [3],
+    );
+    // One from the explicit breakpoint() call (line 1's APPLICATION instruction is on top, not a
+    // node, so it carries no startLine - checked via displayText instead), one from the gutter
+    // click on `y = 2` (line 3).
+    expect(breakpointSteps).toHaveLength(2);
+    expect(
+      snapshots.find(s => s.stepIndex === breakpointSteps[0])?.control[0]?.displayText,
+    ).toContain("call");
+    expect(breakpointLine(snapshots, breakpointSteps[1])).toBe(3);
   });
 });

--- a/src/tests/breakpoints.test.ts
+++ b/src/tests/breakpoints.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for `markBreakpoints` (../breakpoints), the "closest enclosing statement for a
+ * gutter-clicked line" resolution used by issue #383. The stepper/CSE-machine-facing behaviour
+ * (the flag actually surfacing as a breakpoint step) is covered separately by
+ * `conductor/stepper/__tests__/getSteps.test.ts` and `PyCseMachinePlugin.test.ts`; this file
+ * exercises the marking pass itself, in isolation.
+ */
+
+import { StmtNS } from "../ast-types";
+import { markBreakpoints } from "../breakpoints";
+import { parse } from "../parser/parser-adapter";
+
+type Flagged = StmtNS.Stmt & { hasBreakpoint?: boolean };
+
+/** `"<kind>@<line>"` for every flagged statement in `ast`, depth-first. */
+function flagged(ast: StmtNS.FileInput): string[] {
+  const out: string[] = [];
+  function walk(stmt: StmtNS.Stmt): void {
+    if ((stmt as Flagged).hasBreakpoint) out.push(`${stmt.kind}@${stmt.startToken.line}`);
+    switch (stmt.kind) {
+      case "If": {
+        const s = stmt as StmtNS.If;
+        s.body.forEach(walk);
+        s.elseBlock?.forEach(walk);
+        break;
+      }
+      case "While":
+        (stmt as StmtNS.While).body.forEach(walk);
+        break;
+      case "For":
+        (stmt as StmtNS.For).body.forEach(walk);
+        break;
+      case "FunctionDef":
+        (stmt as StmtNS.FunctionDef).body.forEach(walk);
+        break;
+    }
+  }
+  ast.statements.forEach(walk);
+  return out;
+}
+
+describe("markBreakpoints", () => {
+  it("flags the statement on the clicked line", () => {
+    const ast = parse("x = 1\ny = 2\n");
+    markBreakpoints(ast, [2]);
+    expect(flagged(ast)).toEqual(["Assign@2"]);
+  });
+
+  it("flags the innermost statement, not an enclosing block", () => {
+    const ast = parse(`if True:
+    x = 1
+    y = 2
+`);
+    markBreakpoints(ast, [3]);
+    expect(flagged(ast)).toEqual(["Assign@3"]);
+  });
+
+  it("flags the if statement itself when the click is on its header line", () => {
+    const ast = parse(`if True:
+    x = 1
+`);
+    markBreakpoints(ast, [1]);
+    expect(flagged(ast)).toEqual(["If@1"]);
+  });
+
+  it("flags a loop body statement inside a for loop", () => {
+    const ast = parse(`for i in range(3):
+    x = i
+`);
+    markBreakpoints(ast, [2]);
+    expect(flagged(ast)).toEqual(["Assign@2"]);
+  });
+
+  it("flags a statement inside a function body", () => {
+    const ast = parse(`def f():
+    x = 1
+    return x
+`);
+    markBreakpoints(ast, [3]);
+    expect(flagged(ast)).toEqual(["Return@3"]);
+  });
+
+  it("snaps a blank-line click to the next statement", () => {
+    const ast = parse(`x = 1
+
+y = 2
+`);
+    markBreakpoints(ast, [2]);
+    expect(flagged(ast)).toEqual(["Assign@3"]);
+  });
+
+  it("ignores a line past the last statement", () => {
+    const ast = parse("x = 1\n");
+    markBreakpoints(ast, [10]);
+    expect(flagged(ast)).toEqual([]);
+  });
+
+  it("is a no-op when no lines are requested", () => {
+    const ast = parse("x = 1\n");
+    markBreakpoints(ast, []);
+    expect(flagged(ast)).toEqual([]);
+  });
+
+  it("flags multiple requested lines independently", () => {
+    const ast = parse("x = 1\ny = 2\nz = 3\n");
+    markBreakpoints(ast, [1, 3]);
+    expect(flagged(ast).sort()).toEqual(["Assign@1", "Assign@3"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #383. A gutter click only carries a line number; `markBreakpoints` (`src/breakpoints.ts`) resolves it to the closest enclosing statement (innermost covering statement, or the nearest following one for a blank/comment line) and flags it with a bolted-on `hasBreakpoint` property, mirroring `engines/cse/types.ts`'s existing `isEnvDependent`.
- The CSE machine (`engines/cse/interpreter.ts`) and the stepper (`conductor/stepper/reduce.ts`) each check that flag right next to their existing `breakpoint()` detection and record the same kind of step — so a gutter click reuses the host's existing breakpoint-navigation controls (the "jump to next breakpoint" double-arrow) rather than needing a new wire message.
- The host serves the clicked line numbers through the existing `/__cse_config__` virtual file (extended with a new `breakpointLines` field), fetched via the shared `src/conductor/runConfig.ts` helper — the same channel `stepLimit` already used, so no changes are needed to `@sourceacademy/conductor` or the other vendored protocol packages. Both `PyCseEvaluator.ts` and `PyStepperEvaluator.ts` (which previously fetched no config at all) now read it.
- Along the way, fixed a real bug caught by the stepper's own tests: a naive implementation fired the breakpoint marker on *every* intermediate step of a multi-step statement (e.g. each reduction step of a multi-term RHS expression), not just the first time execution reaches that line. Fixed in `stepHead` (`reduce.ts`) by clearing the flag on the carried-forward copy once it's been reported once.

## Test plan

- [x] `npx jest` — full suite passes (74/74 suites, 19554 tests)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src` — no new errors/warnings
- New/extended coverage:
  - `src/tests/breakpoints.test.ts` — unit tests for the line-to-statement resolution algorithm
  - `src/tests/PyCseMachinePlugin.test.ts` — gutter breakpoints in loops, functions, if-headers, blank lines, past-end-of-file, composed with an explicit `breakpoint()` call
  - `src/conductor/stepper/__tests__/getSteps.test.ts` — same coverage for the stepper, plus a regression test asserting a multi-step statement is only flagged once
  - `src/tests/PyCseEvaluator.test.ts` — end-to-end test mocking `requestFile("/__cse_config__")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvqZCkjN8CLSBWCoNSZbAG