### PR TITLE
Stepper: support a subset of module imports

### DIFF
--- a/src/conductor/PyStepperEvaluator.ts
+++ b/src/conductor/PyStepperEvaluator.ts
@@ -2,9 +2,11 @@ import { STEPPER_DIRECTORY_ID } from "@sourceacademy/common-stepper";
 import { ConductorError, EvaluatorSyntaxError } from "@sourceacademy/conductor/common";
 import { BasicEvaluator, type IRunnerPlugin } from "@sourceacademy/conductor/runner";
 import { RunnerStatus } from "@sourceacademy/conductor/types";
+import { ModuleLoaderRunnerPlugin } from "@sourceacademy/runner-module-loader";
 
 import { markBreakpoints } from "../breakpoints";
 import { parse } from "../parser";
+import { asInterfacableEvaluator, GenericDataHandler } from "./GenericDataHandler";
 import { registerAutoCompletePlugin } from "./plugins/autocomplete";
 import { fetchRunConfig } from "./runConfig";
 import { evaluatePython } from "./stepper/getSteps";
@@ -21,9 +23,17 @@ import { PythonStepperRunnerPlugin } from "./stepper/PyStepperRunnerPlugin";
  *
  * This mirrors js-slang's `SourceStepperEvaluator`; only parsing and step production are
  * Python-specific.
+ *
+ * Module loading (`from X import y`, py-slang#385): a `GenericDataHandler` — the same engine-agnostic
+ * `IDataHandler` implementation `PyCseEvaluatorBase`/`Py2JsEvaluatorBase` use — is registered with
+ * `ModuleLoaderRunnerPlugin` exactly as those evaluators do, so `ModuleLoaderRunnerPlugin.instance` is
+ * reachable from the stepper module for resolving a program's imports before stepping begins. Handed
+ * to `PythonStepperRunnerPlugin` at registration below, which threads it into `getPythonSteps` (see
+ * `moduleInterop.ts`'s `resolveImports`) for both the Stepper tab's steps and the REPL's final value.
  */
 abstract class PyStepperEvaluatorBase extends BasicEvaluator {
   private readonly stepper: PythonStepperRunnerPlugin;
+  private readonly dataHandler = new GenericDataHandler();
   /** The selected SICPy sublanguage (1–4). Gates which built-ins preprocessing accepts, so e.g. a
    * §1 program cannot use the §2 list library — see {@link preprocessPython}. */
   private readonly chapter: number;
@@ -33,8 +43,13 @@ abstract class PyStepperEvaluatorBase extends BasicEvaluator {
     registerAutoCompletePlugin(conductor, chapter);
     this.chapter = chapter;
     // Register the language-agnostic stepper runner (Python binding) and load its host (web) half.
-    this.stepper = conductor.registerPlugin(PythonStepperRunnerPlugin);
+    this.stepper = conductor.registerPlugin(PythonStepperRunnerPlugin, this.dataHandler);
     conductor.hostLoadPlugin(STEPPER_DIRECTORY_ID);
+    this.conductor.registerPlugin(
+      ModuleLoaderRunnerPlugin,
+      this.conductor,
+      asInterfacableEvaluator(this, this.dataHandler),
+    );
   }
 
   /**
@@ -79,7 +94,7 @@ abstract class PyStepperEvaluatorBase extends BasicEvaluator {
 
       // Reduce to the final value for the REPL. We send a string (never `undefined`) so the result
       // survives the channel and does not break the host's result saga.
-      this.conductor.sendResult(evaluatePython(ast));
+      this.conductor.sendResult(await evaluatePython(ast, this.dataHandler));
     } catch (error) {
       this.conductor.sendError(
         error instanceof SyntaxError

--- a/src/conductor/stepper/PyStepperRunnerPlugin.ts
+++ b/src/conductor/stepper/PyStepperRunnerPlugin.ts
@@ -4,6 +4,7 @@ import type {
   SyntaxProfile,
 } from "@sourceacademy/common-stepper";
 import type { IChannel, IConduit } from "@sourceacademy/conductor/conduit";
+import type { IDataHandler } from "@sourceacademy/conductor/types";
 import { BaseStepperRunnerPlugin } from "@sourceacademy/runner-stepper";
 
 import type { StmtNS } from "../../ast-types";
@@ -18,21 +19,28 @@ const DEFAULT_STEP_LIMIT = 1000;
  * It receives a parsed Python program (`StmtNS.FileInput`) and produces serialized evaluation steps
  * by driving the Python substitution stepper ({@link getPythonSteps}). All Python-specific knowledge
  * lives in the stepper module; the base class and host plugin stay language-agnostic.
+ *
+ * `evaluator` (a conductor `IDataHandler`, e.g. `PyStepperEvaluatorBase`'s own `GenericDataHandler`)
+ * is what `getPythonSteps` uses to resolve a program's `FromImport`s, if any — see
+ * `moduleInterop.ts`'s `resolveImports`. `undefined` when no module loader is wired up.
  */
 export class PythonStepperRunnerPlugin extends BaseStepperRunnerPlugin<StmtNS.FileInput> {
+  private readonly evaluator: IDataHandler | undefined;
   private readonly stepLimit: number;
 
   constructor(
     conduit: IConduit,
     channels: IChannel<StepperMessage>[],
+    evaluator?: IDataHandler,
     stepLimit: number = DEFAULT_STEP_LIMIT,
   ) {
     super(conduit, channels);
+    this.evaluator = evaluator;
     this.stepLimit = stepLimit;
   }
 
-  getSteps(ast: StmtNS.FileInput): SerializedStepperStep[] {
-    return getPythonSteps(ast, this.stepLimit);
+  getSteps(ast: StmtNS.FileInput): Promise<SerializedStepperStep[]> {
+    return getPythonSteps(ast, this.stepLimit, this.evaluator);
   }
 
   /** Ships Python's rendering rules so the host displays Python syntax with no per-language host code. */

--- a/src/conductor/stepper/__tests__/getSteps.test.ts
+++ b/src/conductor/stepper/__tests__/getSteps.test.ts
@@ -1927,6 +1927,79 @@ describe("Python stepper — real module resolution (py-slang#385)", () => {
     expect(opaqueNode.label).toBe("Thing");
   });
 
+  test("an opaque value round-trips: one module call's result passed into another", async () => {
+    // stepNodeToModule reads an Opaque node's `handle` back out (see its "Opaque" case) so a value
+    // created by one imported function can be forwarded, unchanged, as an argument to another —
+    // never converted to/from any stepper-representable form along the way.
+    const dh = new GenericDataHandler();
+    class Thing {}
+    const theThing = new Thing();
+    async function* makeThingFunc(): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+      await Promise.resolve();
+      return dh.opaque_make(theThing);
+    }
+    async function* isSameThingFunc(
+      x: TypedValue<DataType>,
+    ): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+      await Promise.resolve();
+      const payload = await dh.opaque_get(x as TypedValue<DataType.OPAQUE>);
+      return { type: DataType.BOOLEAN, value: payload === theThing };
+    }
+    const makeThing = await dh.closure_make(
+      { returnType: DataType.OPAQUE, args: [] },
+      makeThingFunc,
+    );
+    const isSameThing = await dh.closure_make(
+      { returnType: DataType.BOOLEAN, args: [DataType.OPAQUE] },
+      isSameThingFunc,
+    );
+    installFakeModule({
+      visualmod: [
+        { symbol: "make_thing", value: makeThing },
+        { symbol: "is_same_thing", value: isSameThing },
+      ],
+    });
+    const ast = parse(
+      "from visualmod import make_thing, is_same_thing\nis_same_thing(make_thing())\n",
+    );
+    expect(await evaluatePython(ast, dh)).toBe("True");
+  });
+
+  test("arity() reports an imported function's real parameter count", async () => {
+    const dh = new GenericDataHandler();
+    async function* addFunc(): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+      await Promise.resolve();
+      return { type: DataType.NUMBER, value: 0 };
+    }
+    const add = await dh.closure_make(
+      { returnType: DataType.NUMBER, args: [DataType.NUMBER, DataType.NUMBER] },
+      addFunc,
+    );
+    installFakeModule({ mathmod: [{ symbol: "add", value: add }] });
+    const ast = parse("from mathmod import add\narity(add)\n");
+    expect(await evaluatePython(ast, dh)).toBe("2");
+  });
+
+  test("calling an imported function with the wrong arity is a Python-style TypeError, not a native crash", async () => {
+    const dh = new GenericDataHandler();
+    async function* doubleFunc(): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+      await Promise.resolve();
+      throw new Error("should never be invoked — arity is checked before the call is placed");
+    }
+    const double = await dh.closure_make(
+      { returnType: DataType.NUMBER, args: [DataType.NUMBER] },
+      doubleFunc,
+    );
+    installFakeModule({ mathmod: [{ symbol: "double", value: double }] });
+    const ast = parse("from mathmod import double\ndouble(1, 2)\n");
+    const steps = await getPythonSteps(ast, undefined, dh);
+    const secondLast = steps.at(-2);
+    expect(secondLast?.markers?.[0]?.explanation).toBe(
+      "TypeError: double() takes 1 argument(s) but 2 were given",
+    );
+    expect(steps.at(-1)?.markers?.[0]?.explanation).toBe("Evaluation stuck");
+  });
+
   test("a Python closure argument is declined — the call stays stuck, not silently wrong", async () => {
     // See moduleInterop.ts's module doc comment: forwarding a Python-authored callable into a module
     // call would need the module to call back into Python, which this design explicitly doesn't
@@ -1951,6 +2024,19 @@ describe("Python stepper — real module resolution (py-slang#385)", () => {
     installFakeModule({});
     const ast = parse("from nosuchmodule import x\nx\n");
     await expect(getPythonSteps(ast, undefined, dh)).rejects.toThrow(/not found/i);
+
+    // The loader's own rejection reason survives as `cause`, not just the generic "not found" text —
+    // see moduleInterop.ts's resolveImports.
+    let caught: unknown;
+    try {
+      await getPythonSteps(parse("from nosuchmodule import x\nx\n"), undefined, dh);
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as { cause?: unknown }).cause).toBeInstanceOf(Error);
+    expect(((caught as { cause?: Error }).cause as Error).message).toBe(
+      "no such module: nosuchmodule",
+    );
   });
 
   test("a name a module doesn't export is a clear error", async () => {

--- a/src/conductor/stepper/__tests__/getSteps.test.ts
+++ b/src/conductor/stepper/__tests__/getSteps.test.ts
@@ -1,3 +1,6 @@
+import { DataType, type TypedValue } from "@sourceacademy/conductor/types";
+import { ModuleLoaderRunnerPlugin } from "@sourceacademy/runner-module-loader";
+
 import {
   emptyList,
   expressionStatement,
@@ -9,9 +12,13 @@ import {
 import { isBuiltinConstantName } from "../builtins";
 import { markBreakpoints } from "../../../breakpoints";
 import { parse } from "../../../parser";
+import { GenericDataHandler } from "../../GenericDataHandler";
 import { evaluatePython, getPythonSteps } from "../getSteps";
 import { formatPrintLlistOutput } from "../lists";
 import { preprocessPython } from "../preprocess";
+
+/** A fake `IModulePlugin` export — mirrors `src/tests/py2js-from-import.test.ts`'s identical type. */
+type FakeExport = { symbol: string; value: TypedValue<DataType> };
 
 // `chapter` defaults to 2 so the existing §2 (list-library) tests resolve those names; the
 // chapter-gating tests pass an explicit chapter (1 to forbid §2 names, 2 to allow them).
@@ -20,22 +27,22 @@ function preprocess(src: string, chapter = 2) {
   return preprocessPython(parse(script), script, chapter);
 }
 
-function steps(src: string) {
+async function steps(src: string) {
   return getPythonSteps(parse(src + "\n"));
 }
 
-function result(src: string) {
+async function result(src: string) {
   return evaluatePython(parse(src + "\n"));
 }
 
-function explanations(src: string) {
-  return steps(src).map(s => s.markers?.[0]?.explanation ?? "");
+async function explanations(src: string) {
+  return (await steps(src)).map(s => s.markers?.[0]?.explanation ?? "");
 }
 
 /** The program's cumulative output (everything print/print_llist has written) on its last step; see
  * the "cumulative print output per step" describe block below for the field's full behaviour. */
-function finalOutput(src: string): string | undefined {
-  const s = steps(src);
+async function finalOutput(src: string): Promise<string | undefined> {
+  const s = await steps(src);
   return (s[s.length - 1] as { output?: string }).output;
 }
 
@@ -66,67 +73,67 @@ function findNode(ast: unknown, pred: (node: any) => boolean): any {
 }
 
 describe("Python stepper — final values", () => {
-  test("arithmetic respects precedence", () => {
-    expect(result("1 + 2 * 3")).toBe("7");
+  test("arithmetic respects precedence", async () => {
+    expect(await result("1 + 2 * 3")).toBe("7");
   });
 
-  test("true division yields a float repr", () => {
-    expect(result("7 / 2")).toBe("3.5");
-    expect(result("4 / 2")).toBe("2.0");
+  test("true division yields a float repr", async () => {
+    expect(await result("7 / 2")).toBe("3.5");
+    expect(await result("4 / 2")).toBe("2.0");
   });
 
-  test("floor division and modulo", () => {
-    expect(result("7 // 2")).toBe("3");
-    expect(result("7 % 3")).toBe("1");
+  test("floor division and modulo", async () => {
+    expect(await result("7 // 2")).toBe("3");
+    expect(await result("7 % 3")).toBe("1");
   });
 
-  test("power", () => {
-    expect(result("2 ** 10")).toBe("1024");
+  test("power", async () => {
+    expect(await result("2 ** 10")).toBe("1024");
   });
 
-  test("comparisons produce Python booleans", () => {
-    expect(result("1 < 2")).toBe("True");
-    expect(result("2 == 3")).toBe("False");
+  test("comparisons produce Python booleans", async () => {
+    expect(await result("1 < 2")).toBe("True");
+    expect(await result("2 == 3")).toBe("False");
   });
 
-  test("assignment binds by substitution", () => {
-    expect(result("x = 5\nx + 1")).toBe("6");
+  test("assignment binds by substitution", async () => {
+    expect(await result("x = 5\nx + 1")).toBe("6");
   });
 
-  test("lambda application", () => {
-    expect(result("f = lambda x: x + 1\nf(10)")).toBe("11");
+  test("lambda application", async () => {
+    expect(await result("f = lambda x: x + 1\nf(10)")).toBe("11");
   });
 
-  test("function definition application", () => {
-    expect(result("def square(n):\n  return n * n\nsquare(4)")).toBe("16");
+  test("function definition application", async () => {
+    expect(await result("def square(n):\n  return n * n\nsquare(4)")).toBe("16");
   });
 
-  test("a multi-statement body with if/else reduces to the taken return", () => {
+  test("a multi-statement body with if/else reduces to the taken return", async () => {
     const f = "def f(x):\n  if x == 1:\n    return x + 1\n  else:\n    return x + 2\n";
-    expect(result(f + "f(2)")).toBe("4");
-    expect(result(f + "f(1)")).toBe("2");
+    expect(await result(f + "f(2)")).toBe("4");
+    expect(await result(f + "f(1)")).toBe("2");
   });
 
-  test("a body with a local binding before the return", () => {
-    expect(result("def g(x):\n  y = x + 1\n  return y * 2\ng(3)")).toBe("8");
+  test("a body with a local binding before the return", async () => {
+    expect(await result("def g(x):\n  y = x + 1\n  return y * 2\ng(3)")).toBe("8");
   });
 
-  test("a function that falls off the end evaluates to None", () => {
-    expect(result("def noop(x):\n  pass\nnoop(5)")).toBe("None");
+  test("a function that falls off the end evaluates to None", async () => {
+    expect(await result("def noop(x):\n  pass\nnoop(5)")).toBe("None");
   });
 
-  test("a bare `return` yields None", () => {
-    expect(result("def early(x):\n  if x > 0:\n    return\n  else:\n    return x\nearly(3)")).toBe(
-      "None",
-    );
+  test("a bare `return` yields None", async () => {
+    expect(
+      await result("def early(x):\n  if x > 0:\n    return\n  else:\n    return x\nearly(3)"),
+    ).toBe("None");
   });
 
-  test("recursion (a function may call itself)", () => {
+  test("recursion (a function may call itself)", async () => {
     const fact = "def fact(n):\n  return 1 if n == 0 else n * fact(n - 1)\n";
-    expect(result(fact + "fact(0)")).toBe("1");
-    expect(result(fact + "fact(4)")).toBe("24");
+    expect(await result(fact + "fact(0)")).toBe("1");
+    expect(await result(fact + "fact(4)")).toBe("24");
     // A recursive call renders as a compact mu-term (carries the function name), not an inline body.
-    const recursiveCall = steps(fact + "fact(3)").some(s =>
+    const recursiveCall = (await steps(fact + "fact(3)")).some(s =>
       findNode(
         s.ast,
         n =>
@@ -138,81 +145,81 @@ describe("Python stepper — final values", () => {
     expect(recursiveCall).toBe(true);
   });
 
-  test("ternary selects a branch", () => {
-    expect(result("1 if 2 > 1 else 99")).toBe("1");
-    expect(result("1 if 2 < 1 else 99")).toBe("99");
+  test("ternary selects a branch", async () => {
+    expect(await result("1 if 2 > 1 else 99")).toBe("1");
+    expect(await result("1 if 2 < 1 else 99")).toBe("99");
   });
 
-  test("if-statement selects a branch and binds", () => {
-    expect(result("if 1 < 2:\n  x = 10\nelse:\n  x = 20\nx + 1")).toBe("11");
+  test("if-statement selects a branch and binds", async () => {
+    expect(await result("if 1 < 2:\n  x = 10\nelse:\n  x = 20\nx + 1")).toBe("11");
   });
 
-  test("unary negation and not", () => {
-    expect(result("-5 + 2")).toBe("-3");
-    expect(result("not (1 < 2)")).toBe("False");
+  test("unary negation and not", async () => {
+    expect(await result("-5 + 2")).toBe("-3");
+    expect(await result("not (1 < 2)")).toBe("False");
   });
 });
 
 describe("Python stepper — short-circuit", () => {
-  test("`and` returns the right operand when the left is truthy", () => {
-    expect(result("True and (1 < 2)")).toBe("True");
+  test("`and` returns the right operand when the left is truthy", async () => {
+    expect(await result("True and (1 < 2)")).toBe("True");
   });
 
-  test("`and` short-circuits on a falsy left without touching the right", () => {
+  test("`and` short-circuits on a falsy left without touching the right", async () => {
     // `undefined_name` is a free variable; it must never be reduced.
-    expect(result("False and undefined_name")).toBe("False");
+    expect(await result("False and undefined_name")).toBe("False");
   });
 
-  test("`or` short-circuits on a truthy left", () => {
-    expect(result("True or undefined_name")).toBe("True");
+  test("`or` short-circuits on a truthy left", async () => {
+    expect(await result("True or undefined_name")).toBe("True");
   });
 });
 
 describe("Python stepper — built-in functions and constants", () => {
-  test("math constants evaluate to their float value", () => {
-    expect(result("math_pi")).toBe(String(Math.PI));
-    expect(result("math_e")).toBe(String(Math.E));
-    expect(result("math_tau")).toBe(String(2 * Math.PI));
-    expect(result("math_inf")).toBe("inf");
-    expect(result("math_nan")).toBe("nan");
+  test("math constants evaluate to their float value", async () => {
+    expect(await result("math_pi")).toBe(String(Math.PI));
+    expect(await result("math_e")).toBe(String(Math.E));
+    expect(await result("math_tau")).toBe(String(2 * Math.PI));
+    expect(await result("math_inf")).toBe("inf");
+    expect(await result("math_nan")).toBe("nan");
   });
 
-  test("a constant is substituted in before stepping (renders as its value, not the name)", () => {
-    expect(result("math_pi * 0")).toBe("0.0");
+  test("a constant is substituted in before stepping (renders as its value, not the name)", async () => {
+    expect(await result("math_pi * 0")).toBe("0.0");
     // Mirrors js-slang's substitution stepper: the constant is replaced up front, so there is no
     // "math_pi is …" contraction step and the first rendered program already shows the value.
-    expect(explanations("math_pi").some(e => e.includes("math_pi is"))).toBe(false);
-    const firstAst = steps("math_pi")[0].ast as unknown;
+    expect((await explanations("math_pi")).some(e => e.includes("math_pi is"))).toBe(false);
+    const firstAst = (await steps("math_pi"))[0].ast as unknown;
     expect(
       findNode(firstAst, n => n.type === "Identifier" && n.name === "math_pi"),
     ).toBeUndefined();
     expect(findNode(firstAst, n => n.type === "Literal")).toBeDefined();
   });
 
-  test("math functions compute on value arguments", () => {
-    expect(result("math_sqrt(16)")).toBe("4.0");
-    expect(result("math_floor(3.7)")).toBe("3");
-    expect(result("math_ceil(3.2)")).toBe("4");
-    expect(result("math_trunc(-3.7)")).toBe("-3");
-    expect(result("math_factorial(5)")).toBe("120");
-    expect(result("math_gcd(12, 18)")).toBe("6");
-    expect(result("math_log(1)")).toBe("0.0");
-    expect(result("math_isnan(math_nan)")).toBe("True");
+  test("math functions compute on value arguments", async () => {
+    expect(await result("math_sqrt(16)")).toBe("4.0");
+    expect(await result("math_floor(3.7)")).toBe("3");
+    expect(await result("math_ceil(3.2)")).toBe("4");
+    expect(await result("math_trunc(-3.7)")).toBe("-3");
+    expect(await result("math_factorial(5)")).toBe("120");
+    expect(await result("math_gcd(12, 18)")).toBe("6");
+    expect(await result("math_log(1)")).toBe("0.0");
+    expect(await result("math_isnan(math_nan)")).toBe("True");
   });
 
-  test('math function call explanation is "<name> runs"', () => {
-    expect(explanations("math_sqrt(9)")).toContain("Running math_sqrt");
+  test('math function call explanation is "<name> runs"', async () => {
+    expect(await explanations("math_sqrt(9)")).toContain("Running math_sqrt");
   });
 
-  test("numeric MISC builtins", () => {
-    expect(result("abs(-5)")).toBe("5");
-    expect(result("abs(-2.5)")).toBe("2.5");
-    expect(result("round(2.5)")).toBe("2"); // banker's rounding
-    expect(result("round(3.5)")).toBe("4");
-    expect(result("round(3.14159, 2)")).toBe("3.14");
-    expect(result("max(1, 7, 3)")).toBe("7");
-    expect(result("min(4, 2, 9)")).toBe("2");
-    expect(result('len("hello")')).toBe("5");
+  test("numeric MISC builtins", async () => {
+    expect(await result("abs(-5)")).toBe("5");
+    expect(await result("abs(-2.5)")).toBe("2.5");
+    expect(await result("round(2.5)")).toBe("2"); // banker's rounding
+    expect(await result("round(3.5)")).toBe("4");
+    expect(await result("round(3.14159, 2)")).toBe("3.14");
+    expect(await result("max(1, 7, 3)")).toBe("7");
+    expect(await result("min(4, 2, 9)")).toBe("2");
+    expect(await result('len("hello")')).toBe("5");
   });
 
   // Unlike CPython's max()/min(), which accept a single iterable argument
@@ -221,67 +228,69 @@ describe("Python stepper — built-in functions and constants", () => {
   // Python list under the hood, so max(pair(1, 5)) is the borderline case:
   // it *looks* like the single-iterable form CPython supports, but is
   // rejected the same way max(5) is, since it's still just one argument.
-  test("max/min require at least 2 direct arguments — no single-iterable form", () => {
-    expect(explanations("max(5)").pop()).toBe("Evaluation stuck");
-    expect(explanations("min(5)").pop()).toBe("Evaluation stuck");
-    expect(result("max(5)")).toContain("takes at least 2 argument(s) but 1 were given");
-    expect(explanations("max(pair(1, 5))").pop()).toBe("Evaluation stuck");
-    expect(result("max(pair(1, 5))")).toContain("takes at least 2 argument(s) but 1 were given");
-    expect(result("arity(max)")).toBe("2");
-    expect(result("arity(min)")).toBe("2");
+  test("max/min require at least 2 direct arguments — no single-iterable form", async () => {
+    expect((await explanations("max(5)")).pop()).toBe("Evaluation stuck");
+    expect((await explanations("min(5)")).pop()).toBe("Evaluation stuck");
+    expect(await result("max(5)")).toContain("takes at least 2 argument(s) but 1 were given");
+    expect((await explanations("max(pair(1, 5))")).pop()).toBe("Evaluation stuck");
+    expect(await result("max(pair(1, 5))")).toContain(
+      "takes at least 2 argument(s) but 1 were given",
+    );
+    expect(await result("arity(max)")).toBe("2");
+    expect(await result("arity(min)")).toBe("2");
   });
 
-  test("type conversions", () => {
-    expect(result("str(42)")).toBe("'42'");
-    expect(result('repr("hi")')).toBe("\"'hi'\"");
+  test("type conversions", async () => {
+    expect(await result("str(42)")).toBe("'42'");
+    expect(await result('repr("hi")')).toBe("\"'hi'\"");
   });
 
-  test("type predicates", () => {
-    expect(result("is_integer(5)")).toBe("True");
-    expect(result("is_float(5)")).toBe("False");
-    expect(result("is_float(5.0)")).toBe("True");
-    expect(result('is_string("a")')).toBe("True");
-    expect(result("is_boolean(True)")).toBe("True");
-    expect(result("is_none(None)")).toBe("True");
-    expect(result("is_function(abs)")).toBe("True");
-    expect(result("is_function(math_sqrt)")).toBe("True");
-    expect(result("is_complex(3)")).toBe("False");
-    expect(result("is_number(5)")).toBe("True");
-    expect(result("is_number(5.0)")).toBe("True");
-    expect(result("is_number(1+2j)")).toBe("True");
-    expect(result("is_number(True)")).toBe("False");
-    expect(result('is_number("a")')).toBe("False");
+  test("type predicates", async () => {
+    expect(await result("is_integer(5)")).toBe("True");
+    expect(await result("is_float(5)")).toBe("False");
+    expect(await result("is_float(5.0)")).toBe("True");
+    expect(await result('is_string("a")')).toBe("True");
+    expect(await result("is_boolean(True)")).toBe("True");
+    expect(await result("is_none(None)")).toBe("True");
+    expect(await result("is_function(abs)")).toBe("True");
+    expect(await result("is_function(math_sqrt)")).toBe("True");
+    expect(await result("is_complex(3)")).toBe("False");
+    expect(await result("is_number(5)")).toBe("True");
+    expect(await result("is_number(5.0)")).toBe("True");
+    expect(await result("is_number(1+2j)")).toBe("True");
+    expect(await result("is_number(True)")).toBe("False");
+    expect(await result('is_number("a")')).toBe("False");
   });
 
-  test("arity reports parameter counts", () => {
-    expect(result("arity(lambda x, y: x + y)")).toBe("2");
-    expect(result("def f(a, b, c):\n  return a\narity(f)")).toBe("3");
+  test("arity reports parameter counts", async () => {
+    expect(await result("arity(lambda x, y: x + y)")).toBe("2");
+    expect(await result("def f(a, b, c):\n  return a\narity(f)")).toBe("3");
   });
 
-  test("builtins compose with user code and arithmetic", () => {
-    expect(result("abs(-3) + math_floor(2.9)")).toBe("5");
-    expect(result('len("ab") * 3')).toBe("6");
-    expect(result("f = lambda x: abs(x)\nf(-8)")).toBe("8");
+  test("builtins compose with user code and arithmetic", async () => {
+    expect(await result("abs(-3) + math_floor(2.9)")).toBe("5");
+    expect(await result('len("ab") * 3')).toBe("6");
+    expect(await result("f = lambda x: abs(x)\nf(-8)")).toBe("8");
   });
 
-  test("print returns None", () => {
-    expect(result('print("hi")')).toBe("None");
+  test("print returns None", async () => {
+    expect(await result('print("hi")')).toBe("None");
   });
 
-  test("error() and misuse make evaluation stuck", () => {
-    expect(explanations('error("boom")').pop()).toBe("Evaluation stuck");
-    expect(explanations('abs("text")').pop()).toBe("Evaluation stuck"); // TypeError
-    expect(explanations("math_sqrt(1, 2)").pop()).toBe("Evaluation stuck"); // wrong arity
+  test("error() and misuse make evaluation stuck", async () => {
+    expect((await explanations('error("boom")')).pop()).toBe("Evaluation stuck");
+    expect((await explanations('abs("text")')).pop()).toBe("Evaluation stuck"); // TypeError
+    expect((await explanations("math_sqrt(1, 2)")).pop()).toBe("Evaluation stuck"); // wrong arity
   });
 
-  test("a bare built-in function name is a value (complete, not stuck)", () => {
-    expect(explanations("abs").pop()).toBe("Evaluation complete");
-    expect(explanations("math_sqrt").pop()).toBe("Evaluation complete");
+  test("a bare built-in function name is a value (complete, not stuck)", async () => {
+    expect((await explanations("abs")).pop()).toBe("Evaluation complete");
+    expect((await explanations("math_sqrt")).pop()).toBe("Evaluation complete");
   });
 
-  test("unsupported/interactive builtins stay stuck", () => {
+  test("unsupported/interactive builtins stay stuck", async () => {
     // random_random / time_time / input are intentionally not modelled by the stepper.
-    expect(explanations("random_random()").pop()).toBe("Evaluation stuck");
+    expect((await explanations("random_random()")).pop()).toBe("Evaluation stuck");
   });
 });
 
@@ -459,21 +468,22 @@ describe("Python stepper — unsupported operators are a preprocessing error", (
 });
 
 describe("Python stepper — step structure", () => {
-  test('begins with a "Start of evaluation" step and alternates before/after', () => {
-    const e = explanations("1 + 2 * 3");
+  test('begins with a "Start of evaluation" step and alternates before/after', async () => {
+    const e = await explanations("1 + 2 * 3");
     expect(e[0]).toBe("Start of evaluation");
-    expect(steps("1 + 2 * 3")[1].markers?.[0]?.redexType).toBe("beforeMarker");
-    expect(steps("1 + 2 * 3")[2].markers?.[0]?.redexType).toBe("afterMarker");
+    const s = await steps("1 + 2 * 3");
+    expect(s[1].markers?.[0]?.redexType).toBe("beforeMarker");
+    expect(s[2].markers?.[0]?.redexType).toBe("afterMarker");
   });
 
-  test("innermost redex reduces first (2 * 3 before 1 + 6)", () => {
-    const e = explanations("1 + 2 * 3");
+  test("innermost redex reduces first (2 * 3 before 1 + 6)", async () => {
+    const e = await explanations("1 + 2 * 3");
     expect(e[1]).toContain("2 * 3");
     expect(e[3]).toContain("1 + 6");
   });
 
-  test("every before-marker redexId resolves to a node in that step AST", () => {
-    for (const step of steps("1 + 2 * 3\nx = 4\nx * x")) {
+  test("every before-marker redexId resolves to a node in that step AST", async () => {
+    for (const step of await steps("1 + 2 * 3\nx = 4\nx * x")) {
       const marker = step.markers?.[0];
       if (marker?.redexId != null) {
         expect(nodeIds(step.ast).has(marker.redexId)).toBe(true);
@@ -481,34 +491,35 @@ describe("Python stepper — step structure", () => {
     }
   });
 
-  test("serialized steps are structured-clone safe (survive the channel)", () => {
-    expect(() => structuredClone(steps("f = lambda x: x + 1\nf(10)"))).not.toThrow();
+  test("serialized steps are structured-clone safe (survive the channel)", async () => {
+    const s = await steps("f = lambda x: x + 1\nf(10)");
+    expect(() => structuredClone(s)).not.toThrow();
   });
 
-  test("the serialized AST is estree-shaped for the host renderer", () => {
-    const ast = steps("1 + 2")[0].ast as any;
+  test("the serialized AST is estree-shaped for the host renderer", async () => {
+    const ast = (await steps("1 + 2"))[0].ast as any;
     expect(ast.type).toBe("Program");
     expect(ast.body[0].type).toBe("ExpressionStatement");
     expect(ast.body[0].expression.type).toBe("BinaryExpression");
     expect(ast.body[0].expression).toMatchObject({ operator: "+" });
   });
 
-  test('closes with a terminal "Evaluation complete" step, like Source', () => {
-    const e = explanations("1 + 2");
+  test('closes with a terminal "Evaluation complete" step, like Source', async () => {
+    const e = await explanations("1 + 2");
     expect(e[e.length - 1]).toBe("Evaluation complete");
   });
 
-  test("the final line's value disappears before completion (a program yields no value)", () => {
+  test("the final line's value disappears before completion (a program yields no value)", async () => {
     // Unlike Source/js-slang, a Python program has no value: the last line's value is discarded just
     // like every other line's, so the run ends on an *empty* program rather than lingering on it. It is
     // shown highlighted green (still present) one last time — the discard step's *after* step — before
     // that happens; see "green flash before discard" below for the fully worked-out step sequence.
-    const e = explanations("1 + 1");
+    const e = await explanations("1 + 1");
     expect(e[e.length - 1]).toBe("Evaluation complete");
     expect(e[e.length - 2]).toBe("Evaluated 2"); // the discard step's after (green) step, as for any statement
     expect(e[e.length - 3]).toBe("Evaluating 2"); // ...and its before (red) step
 
-    const s = steps("1 + 1");
+    const s = await steps("1 + 1");
     const lastVisible = s[s.length - 2].ast as any; // the green "2" step, one before the terminal step
     expect(lastVisible.body).toHaveLength(1); // "2" is still there, not yet discarded
     const terminal = s[s.length - 1].ast as any;
@@ -516,21 +527,21 @@ describe("Python stepper — step structure", () => {
     expect(terminal.body).toHaveLength(0); // nothing rendered at completion
 
     // A program ending in an assignment already completed empty; the two now behave identically.
-    const assign = steps("x = 1");
+    const assign = await steps("x = 1");
     expect((assign[assign.length - 1].ast as any).body).toHaveLength(0);
 
     // The REPL still echoes the final value, even though the stepper no longer lingers on it.
-    expect(result("1 + 1")).toBe("2");
+    expect(await result("1 + 1")).toBe("2");
   });
 
-  test("green flash before discard: a finished value is shown green once before it disappears", () => {
+  test("green flash before discard: a finished value is shown green once before it disappears", async () => {
     // The user-facing spec this implements: every contraction's before-step reads "… evaluating"
     // (about to happen) and its after-step reads "… evaluated" (just happened, dropping the old
     // "finished evaluating" wording) — and a contraction that discards a whole finished statement
     // (an evaluated expression, a name binding, `pass`, an inlined `if` branch) shows it highlighted
     // green, still present in the tree, on its after-step; only the *next* contraction's before-step
     // shows it actually gone. Worked out fully for "1 + 1\n1 + 2\n" (ten steps total).
-    const e = explanations("1 + 1\n1 + 2");
+    const e = await explanations("1 + 1\n1 + 2");
     expect(e).toEqual([
       "Start of evaluation",
       "Evaluating binary expression 1 + 1",
@@ -544,7 +555,7 @@ describe("Python stepper — step structure", () => {
       "Evaluation complete",
     ]);
 
-    const s = steps("1 + 1\n1 + 2");
+    const s = await steps("1 + 1\n1 + 2");
     const bodyLengths = s.map(step => (step.ast as any).body.length);
     // Step 5 (index 4, the "Evaluated 2" green step) still has both statements — "2" has not yet been
     // discarded — and step 9 (index 8, "Evaluated 3") still has its one statement, for the same reason.
@@ -553,37 +564,40 @@ describe("Python stepper — step structure", () => {
 });
 
 describe('Python stepper — runtime errors end with "Evaluation stuck"', () => {
-  test("a thrown runtime error (division by zero) ends stuck and shows the message", () => {
-    const e = explanations("7 // 0");
+  test("a thrown runtime error (division by zero) ends stuck and shows the message", async () => {
+    const e = await explanations("7 // 0");
     expect(e[e.length - 1]).toBe("Evaluation stuck");
     // The penultimate step explains why it is stuck.
     expect(e[e.length - 2]).toContain("ZeroDivisionError");
   });
 
-  test("a runtime error inside a function body ends stuck", () => {
-    expect(explanations("def f(x):\n  return x // 0\nf(5)").pop()).toBe("Evaluation stuck");
+  test("a runtime error inside a function body ends stuck", async () => {
+    expect((await explanations("def f(x):\n  return x // 0\nf(5)")).pop()).toBe("Evaluation stuck");
   });
 
-  test("calling a non-function is stuck, not complete", () => {
-    expect(explanations("5(3)").pop()).toBe("Evaluation stuck");
+  test("calling a non-function is stuck, not complete", async () => {
+    expect((await explanations("5(3)")).pop()).toBe("Evaluation stuck");
   });
 
-  test("an unbound name left over is stuck, not a value", () => {
-    expect(explanations("undefined_name + 1").pop()).toBe("Evaluation stuck");
+  test("an unbound name left over is stuck, not a value", async () => {
+    expect((await explanations("undefined_name + 1")).pop()).toBe("Evaluation stuck");
   });
 
-  test('a successful run still ends "Evaluation complete"', () => {
-    expect(explanations("def f(x):\n  return x + 1\nf(4)").pop()).toBe("Evaluation complete");
-    expect(explanations("7 // 2").pop()).toBe("Evaluation complete");
+  test('a successful run still ends "Evaluation complete"', async () => {
+    expect((await explanations("def f(x):\n  return x + 1\nf(4)")).pop()).toBe(
+      "Evaluation complete",
+    );
+    expect((await explanations("7 // 2")).pop()).toBe("Evaluation complete");
   });
 
-  test("evaluatePython surfaces a runtime error as its message (never throws)", () => {
-    expect(result("7 // 0")).toContain("ZeroDivisionError");
-    expect(() => result("7 // 0")).not.toThrow();
+  test("evaluatePython surfaces a runtime error as its message (never throws)", async () => {
+    // A runtime fault (as opposed to a preprocessing/import error — see getSteps.ts's own doc comment
+    // on `evaluatePython`) resolves to a message string; it must never reject.
+    await expect(result("7 // 0")).resolves.toContain("ZeroDivisionError");
   });
 
-  test("short-circuit still completes (the dead operand is never reached)", () => {
-    expect(explanations("False and undefined_name").pop()).toBe("Evaluation complete");
+  test("short-circuit still completes (the dead operand is never reached)", async () => {
+    expect((await explanations("False and undefined_name")).pop()).toBe("Evaluation complete");
   });
 });
 
@@ -591,83 +605,84 @@ describe("Python stepper — a runtime error is named in the step before the stu
   // Like ZeroDivisionError, the specific error appears as the step immediately before the terminal
   // "Evaluation stuck" (the driver turns a thrown error into a beforeMarker step then the stuck step).
   // This covers the errors the reducer used to swallow into a bare, message-less "Evaluation stuck".
-  const errorStep = (src: string): string | undefined => {
-    const e = explanations(src);
+  const errorStep = async (src: string): Promise<string | undefined> => {
+    const e = await explanations(src);
     expect(e[e.length - 1]).toBe("Evaluation stuck");
     return e[e.length - 2];
   };
 
-  test("calling a non-callable value reports a TypeError", () => {
-    expect(errorStep("5(3)")).toBe("TypeError: 'int' object is not callable");
-    expect(errorStep("(3.5)(1)")).toBe("TypeError: 'float' object is not callable");
-    expect(errorStep("None()")).toBe("TypeError: 'NoneType' object is not callable");
-    expect(errorStep('"hi"()')).toBe("TypeError: 'str' object is not callable");
+  test("calling a non-callable value reports a TypeError", async () => {
+    expect(await errorStep("5(3)")).toBe("TypeError: 'int' object is not callable");
+    expect(await errorStep("(3.5)(1)")).toBe("TypeError: 'float' object is not callable");
+    expect(await errorStep("None()")).toBe("TypeError: 'NoneType' object is not callable");
+    expect(await errorStep('"hi"()')).toBe("TypeError: 'str' object is not callable");
   });
 
-  test("wrong number of arguments to a user function reports a TypeError", () => {
-    expect(errorStep("f = lambda x: x\nf(1, 2)")).toBe(
+  test("wrong number of arguments to a user function reports a TypeError", async () => {
+    expect(await errorStep("f = lambda x: x\nf(1, 2)")).toBe(
       "TypeError: f() takes 1 argument(s) but 2 were given",
     );
-    expect(errorStep("def g(a, b):\n  return a + b\ng(1)")).toBe(
+    expect(await errorStep("def g(a, b):\n  return a + b\ng(1)")).toBe(
       "TypeError: g() takes 2 argument(s) but 1 were given",
     );
-    expect(errorStep("(lambda a: a)(1, 2, 3)")).toBe(
+    expect(await errorStep("(lambda a: a)(1, 2, 3)")).toBe(
       "TypeError: <lambda>() takes 1 argument(s) but 3 were given",
     );
   });
 
-  test("unsupported binary operand types report a TypeError", () => {
-    expect(errorStep('1 + "a"')).toBe(
+  test("unsupported binary operand types report a TypeError", async () => {
+    expect(await errorStep('1 + "a"')).toBe(
       "TypeError: unsupported operand type(s) for +: 'int' and 'str'",
     );
-    expect(errorStep('"a" - "b"')).toBe(
+    expect(await errorStep('"a" - "b"')).toBe(
       "TypeError: unsupported operand type(s) for -: 'str' and 'str'",
     );
-    expect(errorStep("None + 1")).toBe(
+    expect(await errorStep("None + 1")).toBe(
       "TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'",
     );
-    expect(errorStep("x = lambda a: a\nx - 1")).toBe(
+    expect(await errorStep("x = lambda a: a\nx - 1")).toBe(
       "TypeError: unsupported operand type(s) for -: 'function' and 'int'",
     );
   });
 
-  test("unsupported ordering comparisons report a TypeError", () => {
-    expect(errorStep("None < 1")).toBe(
+  test("unsupported ordering comparisons report a TypeError", async () => {
+    expect(await errorStep("None < 1")).toBe(
       "TypeError: '<' not supported between instances of 'NoneType' and 'int'",
     );
-    expect(errorStep('1 < "a"')).toBe(
+    expect(await errorStep('1 < "a"')).toBe(
       "TypeError: '<' not supported between instances of 'int' and 'str'",
     );
   });
 
-  test("unary minus/plus on a non-numeric reports a TypeError", () => {
-    expect(errorStep('-"a"')).toBe("TypeError: bad operand type for unary -: 'str'");
-    expect(errorStep("-None")).toBe("TypeError: bad operand type for unary -: 'NoneType'");
+  test("unary minus/plus on a non-numeric reports a TypeError", async () => {
+    expect(await errorStep('-"a"')).toBe("TypeError: bad operand type for unary -: 'str'");
+    expect(await errorStep("-None")).toBe("TypeError: bad operand type for unary -: 'NoneType'");
   });
 
-  test("legal-but-unmodelled operations stay a silent stuck (never a false error)", () => {
+  test("legal-but-unmodelled operations stay a silent stuck (never a false error)", async () => {
     // These are valid Python the teaching stepper just does not evaluate (string repetition,
     // %-formatting); they must remain a plain "Evaluation stuck" with no TypeError step. (String
     // ordering, unlike these, *is* modelled — see "string ordering (< > <= >=)" below.)
     for (const src of ['"ab" * 2', '2 * "ab"', '"a" % "b"']) {
-      const e = explanations(src);
+      const e = await explanations(src);
       expect(e[e.length - 1]).toBe("Evaluation stuck");
       expect(e.some(x => x.includes("TypeError"))).toBe(false);
     }
   });
 
-  test("the REPL value surfaces the same error message", () => {
-    expect(result("5(3)")).toBe("TypeError: 'int' object is not callable");
-    expect(result('1 + "a"')).toBe("TypeError: unsupported operand type(s) for +: 'int' and 'str'");
-    expect(() => result("5(3)")).not.toThrow();
+  test("the REPL value surfaces the same error message", async () => {
+    expect(await result("5(3)")).toBe("TypeError: 'int' object is not callable");
+    expect(await result('1 + "a"')).toBe(
+      "TypeError: unsupported operand type(s) for +: 'int' and 'str'",
+    );
   });
 });
 
 describe("Python stepper — function values render as mu-terms (not inline bodies)", () => {
   // A substituted `def` must NOT expand its whole body at every use: it is substituted as a *named*
   // value (the `name` marker) so the host collapses it to a hoverable mu-term, exactly like Source.
-  test("a def is substituted as a named function value, not expanded inline", () => {
-    const s = steps("def square(n):\n  return n * n\nsquare(4)");
+  test("a def is substituted as a named function value, not expanded inline", async () => {
+    const s = await steps("def square(n):\n  return n * n\nsquare(4)");
 
     // Some step shows the call with `square` substituted in as a named FunctionDeclaration value.
     const collapsed = s.some(step => {
@@ -681,8 +696,8 @@ describe("Python stepper — function values render as mu-terms (not inline bodi
     expect(declSite.name).toBeUndefined();
   });
 
-  test("a lambda bound to a name is substituted as a named function value", () => {
-    const s = steps("f = lambda x: x + 1\nf(10)");
+  test("a lambda bound to a name is substituted as a named function value", async () => {
+    const s = await steps("f = lambda x: x + 1\nf(10)");
 
     const collapsed = s.some(step => {
       const call = findNode(step.ast, n => n.type === "CallExpression");
@@ -696,9 +711,9 @@ describe("Python stepper — function values render as mu-terms (not inline bodi
     expect(declInit.name).toBeUndefined();
   });
 
-  test("an anonymous lambda argument stays anonymous (rendered inline)", () => {
+  test("an anonymous lambda argument stays anonymous (rendered inline)", async () => {
     const lambda = findNode(
-      steps("(lambda x: x + 1)(5)")[0].ast,
+      (await steps("(lambda x: x + 1)(5)"))[0].ast,
       n => n.type === "ArrowFunctionExpression",
     );
     expect(lambda.name).toBeUndefined();
@@ -713,8 +728,8 @@ describe("Python stepper — a binding's substitution is visible on its own step
   // more step, highlighted green, before actually disappearing — the same "green flash before discard"
   // `pass` gets — but that lingering must not delay the substitution's effect on the rest of the tree.
 
-  test("a variable's bound value already appears in the rest on its own 'Declared and substituted' step", () => {
-    const s = steps("x = 5\nx + 1");
+  test("a variable's bound value already appears in the rest on its own 'Declared and substituted' step", async () => {
+    const s = await steps("x = 5\nx + 1");
     const i = s.findIndex(
       step =>
         step.markers?.[0]?.explanation === "Declared and substituted x into the rest of the block",
@@ -731,8 +746,8 @@ describe("Python stepper — a binding's substitution is visible on its own step
     expect(findNode(s[i + 1].ast, n => n.type === "VariableDeclaration")).toBeUndefined();
   });
 
-  test("a def's mu-term already appears in the rest on its own 'Declared and substituted' step", () => {
-    const s = steps("def square(n):\n  return n * n\nsquare(4)");
+  test("a def's mu-term already appears in the rest on its own 'Declared and substituted' step", async () => {
+    const s = await steps("def square(n):\n  return n * n\nsquare(4)");
     const i = s.findIndex(
       step =>
         step.markers?.[0]?.explanation ===
@@ -754,12 +769,12 @@ describe("Python stepper — a binding's substitution is visible on its own step
     ).toBeUndefined();
   });
 
-  test("a local binding inside a function body substitutes into the rest on the same step", () => {
+  test("a local binding inside a function body substitutes into the rest on the same step", async () => {
     // def f(x):
     //   y = x + 1
     //   return y
     // f(1)
-    const s = steps("def f(x):\n  y = x + 1\n  return y\nf(1)");
+    const s = await steps("def f(x):\n  y = x + 1\n  return y\nf(1)");
     const i = s.findIndex(
       step =>
         step.markers?.[0]?.explanation === "Declared and substituted y into the rest of the block",
@@ -778,33 +793,33 @@ describe("Python stepper — a binding's substitution is visible on its own step
 });
 
 describe("Python stepper — explanations mirror Source phrasing", () => {
-  test("binary expression", () => {
-    expect(explanations("1 + 2")).toContain("Evaluated binary expression 1 + 2");
+  test("binary expression", async () => {
+    expect(await explanations("1 + 2")).toContain("Evaluated binary expression 1 + 2");
   });
 
-  test("function declaration and application", () => {
-    const e = explanations("def square(n):\n  return n * n\nsquare(4)");
+  test("function declaration and application", async () => {
+    const e = await explanations("def square(n):\n  return n * n\nsquare(4)");
     expect(e).toContain("Declaring and substituting square into the rest of the block");
     expect(e).toContain("Substituted 4 into n of square");
   });
 
-  test("name binding", () => {
-    expect(explanations("x = 5\nx")).toContain(
+  test("name binding", async () => {
+    expect(await explanations("x = 5\nx")).toContain(
       "Declared and substituted x into the rest of the block",
     );
   });
 
-  test("if statement", () => {
-    expect(explanations("if 1 < 2:\n  x = 1\nelse:\n  x = 2\nx")).toContain(
+  test("if statement", async () => {
+    expect(await explanations("if 1 < 2:\n  x = 1\nelse:\n  x = 2\nx")).toContain(
       "Evaluated if statement, condition true, will proceed to if block",
     );
   });
 
-  test("short-circuit and conditional", () => {
-    expect(explanations("True and False")).toContain(
+  test("short-circuit and conditional", async () => {
+    expect(await explanations("True and False")).toContain(
       "Evaluated AND expression, left of operator is truthy, will evaluate right of operator",
     );
-    expect(explanations("1 if 2 > 1 else 9")).toContain(
+    expect(await explanations("1 if 2 > 1 else 9")).toContain(
       "Evaluated conditional expression, condition is true, will evaluate consequent",
     );
   });
@@ -812,85 +827,85 @@ describe("Python stepper — explanations mirror Source phrasing", () => {
 
 describe("Python stepper — pairs and linked lists (Python §2)", () => {
   // A pair renders in box-and-pointer notation `[head, tail]`, like Source; the empty list is `None`.
-  test("pair construction and accessors", () => {
-    expect(result("pair(1, 2)")).toBe("[1, 2]");
-    expect(result("head(pair(1, 2))")).toBe("1");
-    expect(result("tail(pair(1, 2))")).toBe("2");
-    expect(result("head(tail(pair(1, pair(2, 3))))")).toBe("2");
+  test("pair construction and accessors", async () => {
+    expect(await result("pair(1, 2)")).toBe("[1, 2]");
+    expect(await result("head(pair(1, 2))")).toBe("1");
+    expect(await result("tail(pair(1, 2))")).toBe("2");
+    expect(await result("head(tail(pair(1, pair(2, 3))))")).toBe("2");
   });
 
-  test("pair predicates", () => {
-    expect(result("is_pair(pair(1, 2))")).toBe("True");
-    expect(result("is_pair(5)")).toBe("False");
-    expect(result("is_pair(None)")).toBe("False");
-    expect(result("is_none(None)")).toBe("True");
-    expect(result("is_none(pair(1, 2))")).toBe("False");
+  test("pair predicates", async () => {
+    expect(await result("is_pair(pair(1, 2))")).toBe("True");
+    expect(await result("is_pair(5)")).toBe("False");
+    expect(await result("is_pair(None)")).toBe("False");
+    expect(await result("is_none(None)")).toBe("True");
+    expect(await result("is_none(pair(1, 2))")).toBe("False");
   });
 
-  test("llist builds nested pairs ending in None", () => {
-    expect(result("llist(1, 2, 3)")).toBe("[1, [2, [3, None]]]");
-    expect(result("llist()")).toBe("None");
-    expect(result("llist(42)")).toBe("[42, None]");
+  test("llist builds nested pairs ending in None", async () => {
+    expect(await result("llist(1, 2, 3)")).toBe("[1, [2, [3, None]]]");
+    expect(await result("llist()")).toBe("None");
+    expect(await result("llist(42)")).toBe("[42, None]");
   });
 
-  test("is_llist distinguishes proper lists from improper pairs", () => {
-    expect(result("is_llist(llist(1, 2, 3))")).toBe("True");
-    expect(result("is_llist(None)")).toBe("True");
-    expect(result("is_llist(pair(1, 2))")).toBe("False");
-    expect(result("is_llist(5)")).toBe("False");
+  test("is_llist distinguishes proper lists from improper pairs", async () => {
+    expect(await result("is_llist(llist(1, 2, 3))")).toBe("True");
+    expect(await result("is_llist(None)")).toBe("True");
+    expect(await result("is_llist(pair(1, 2))")).toBe("False");
+    expect(await result("is_llist(5)")).toBe("False");
   });
 
-  test("length, ref and member", () => {
-    expect(result("length(llist(1, 2, 3, 4))")).toBe("4");
-    expect(result("length(None)")).toBe("0");
-    expect(result("llist_ref(llist(10, 20, 30), 1)")).toBe("20");
-    expect(result("member(2, llist(1, 2, 3))")).toBe("[2, [3, None]]");
-    expect(result("member(9, llist(1, 2))")).toBe("None");
+  test("length, ref and member", async () => {
+    expect(await result("length(llist(1, 2, 3, 4))")).toBe("4");
+    expect(await result("length(None)")).toBe("0");
+    expect(await result("llist_ref(llist(10, 20, 30), 1)")).toBe("20");
+    expect(await result("member(2, llist(1, 2, 3))")).toBe("[2, [3, None]]");
+    expect(await result("member(9, llist(1, 2))")).toBe("None");
   });
 
-  test("map, filter and reduce", () => {
-    expect(result("map(lambda x: x * x, llist(1, 2, 3))")).toBe("[1, [4, [9, None]]]");
-    expect(result("filter(lambda x: x > 1, llist(1, 2, 3))")).toBe("[2, [3, None]]");
-    expect(result("reduce(lambda x, y: x + y, 0, llist(1, 2, 3))")).toBe("6");
+  test("map, filter and reduce", async () => {
+    expect(await result("map(lambda x: x * x, llist(1, 2, 3))")).toBe("[1, [4, [9, None]]]");
+    expect(await result("filter(lambda x: x > 1, llist(1, 2, 3))")).toBe("[2, [3, None]]");
+    expect(await result("reduce(lambda x, y: x + y, 0, llist(1, 2, 3))")).toBe("6");
   });
 
-  test("reverse, append, enum and build", () => {
-    expect(result("reverse(llist(1, 2, 3))")).toBe("[3, [2, [1, None]]]");
-    expect(result("append(llist(1, 2), llist(3, 4))")).toBe("[1, [2, [3, [4, None]]]]");
-    expect(result("enum_llist(1, 4)")).toBe("[1, [2, [3, [4, None]]]]");
-    expect(result("build_llist(lambda i: i * 2, 3)")).toBe("[0, [2, [4, None]]]");
+  test("reverse, append, enum and build", async () => {
+    expect(await result("reverse(llist(1, 2, 3))")).toBe("[3, [2, [1, None]]]");
+    expect(await result("append(llist(1, 2), llist(3, 4))")).toBe("[1, [2, [3, [4, None]]]]");
+    expect(await result("enum_llist(1, 4)")).toBe("[1, [2, [3, [4, None]]]]");
+    expect(await result("build_llist(lambda i: i * 2, 3)")).toBe("[0, [2, [4, None]]]");
   });
 
-  test("remove and remove_all", () => {
-    expect(result("remove(2, llist(1, 2, 3, 2))")).toBe("[1, [3, [2, None]]]");
-    expect(result("remove_all(2, llist(2, 1, 2, 3))")).toBe("[1, [3, None]]");
+  test("remove and remove_all", async () => {
+    expect(await result("remove(2, llist(1, 2, 3, 2))")).toBe("[1, [3, [2, None]]]");
+    expect(await result("remove_all(2, llist(2, 1, 2, 3))")).toBe("[1, [3, None]]");
   });
 
-  test("== compares structure and leaf values", () => {
-    expect(result("llist(1, 2, 3) == llist(1, 2, 3)")).toBe("True");
-    expect(result("llist(1, 2) == llist(1, 3)")).toBe("False");
-    expect(result("pair(1, pair(2, None)) == llist(1, 2)")).toBe("True");
-    expect(result("None == None")).toBe("True");
+  test("== compares structure and leaf values", async () => {
+    expect(await result("llist(1, 2, 3) == llist(1, 2, 3)")).toBe("True");
+    expect(await result("llist(1, 2) == llist(1, 3)")).toBe("False");
+    expect(await result("pair(1, pair(2, None)) == llist(1, 2)")).toBe("True");
+    expect(await result("None == None")).toBe("True");
   });
 
-  test("llist_to_string and for_each", () => {
-    expect(result("llist_to_string(llist(1, 2))")).toBe("'[1, [2, None]]'");
-    expect(result("for_each(lambda x: x, llist(1, 2, 3))")).toBe("True");
+  test("llist_to_string and for_each", async () => {
+    expect(await result("llist_to_string(llist(1, 2))")).toBe("'[1, [2, None]]'");
+    expect(await result("for_each(lambda x: x, llist(1, 2, 3))")).toBe("True");
   });
 
   // print_llist renders box-and-pointer notation as text ("llist(...)" for a proper list, "[head,
   // tail]" for an improper pair), like the CSE machine's and PVML's print_llist — unlike
   // llist_to_string above, which always uses bracket notation.
-  test("print_llist renders llist(...) for a proper list and [head, tail] otherwise", () => {
-    expect(finalOutput("print_llist(llist(1, 2, 3))")).toBe("llist(1, 2, 3)\n");
-    expect(finalOutput("print_llist(None)")).toBe("llist()\n");
-    expect(finalOutput("print_llist(pair(1, 2))")).toBe("[1, 2]\n");
-    expect(finalOutput("print_llist(llist('a', 'b'))")).toBe("llist('a', 'b')\n");
-    expect(result("print_llist(llist(1, 2, 3))")).toBe("None"); // print_llist's own return value
+  test("print_llist renders llist(...) for a proper list and [head, tail] otherwise", async () => {
+    expect(await finalOutput("print_llist(llist(1, 2, 3))")).toBe("llist(1, 2, 3)\n");
+    expect(await finalOutput("print_llist(None)")).toBe("llist()\n");
+    expect(await finalOutput("print_llist(pair(1, 2))")).toBe("[1, 2]\n");
+    expect(await finalOutput("print_llist(llist('a', 'b'))")).toBe("llist('a', 'b')\n");
+    expect(await result("print_llist(llist(1, 2, 3))")).toBe("None"); // print_llist's own return value
   });
 
-  test("print_llist: a proper-list element nested in an improper pair still renders as llist(...)", () => {
-    expect(finalOutput("print_llist(pair(llist(1, 2, 3), llist(4, 5, 6)))")).toBe(
+  test("print_llist: a proper-list element nested in an improper pair still renders as llist(...)", async () => {
+    expect(await finalOutput("print_llist(pair(llist(1, 2, 3), llist(4, 5, 6)))")).toBe(
       "llist(llist(1, 2, 3), 4, 5, 6)\n",
     );
   });
@@ -900,10 +915,10 @@ describe("Python stepper — pairs and linked lists (Python §2)", () => {
   // plain recursion with no identity-keyed memoization, so it can't reproduce that bug: the same
   // pair object is re-derived fresh from its own structure every time it's visited, regardless of
   // which parent reached it.
-  test("print_llist does not misrender a shared sub-list (js-slang#1124)", () => {
-    expect(finalOutput("x1 = llist(2, 3)\nx2 = llist(x1, pair(1, x1))\nprint_llist(x2)")).toBe(
-      "llist(llist(2, 3), llist(1, 2, 3))\n",
-    );
+  test("print_llist does not misrender a shared sub-list (js-slang#1124)", async () => {
+    expect(
+      await finalOutput("x1 = llist(2, 3)\nx2 = llist(x1, pair(1, x1))\nprint_llist(x2)"),
+    ).toBe("llist(llist(2, 3), llist(1, 2, 3))\n");
   });
 
   // Regression test for the O(N^2)/stack-overflow bug caught in review on #250: printLlistText used
@@ -933,38 +948,40 @@ describe("Python stepper — pairs and linked lists (Python §2)", () => {
     expect(properOutput.endsWith(`${properN - 1}, ${properN})\n`)).toBe(true);
   });
 
-  test("print_llist requires exactly 1 argument", () => {
-    expect(explanations("print_llist()").pop()).toBe("Evaluation stuck");
-    expect(explanations("print_llist(1, 2)").pop()).toBe("Evaluation stuck");
+  test("print_llist requires exactly 1 argument", async () => {
+    expect((await explanations("print_llist()")).pop()).toBe("Evaluation stuck");
+    expect((await explanations("print_llist(1, 2)")).pop()).toBe("Evaluation stuck");
   });
 
-  test("list functions are first-class values", () => {
-    expect(result("is_function(pair)")).toBe("True");
-    expect(result("is_function(map)")).toBe("True");
-    expect(result("arity(pair)")).toBe("2");
-    expect(result("arity(reduce)")).toBe("3");
+  test("list functions are first-class values", async () => {
+    expect(await result("is_function(pair)")).toBe("True");
+    expect(await result("is_function(map)")).toBe("True");
+    expect(await result("arity(pair)")).toBe("2");
+    expect(await result("arity(reduce)")).toBe("3");
     // A bare list-function name is a complete value, not stuck.
-    expect(explanations("head").pop()).toBe("Evaluation complete");
+    expect((await explanations("head")).pop()).toBe("Evaluation complete");
   });
 
-  test("a fully-evaluated list is a complete result", () => {
-    expect(explanations("llist(1, 2, 3)").pop()).toBe("Evaluation complete");
-    expect(explanations("map(lambda x: x + 1, llist(1, 2))").pop()).toBe("Evaluation complete");
+  test("a fully-evaluated list is a complete result", async () => {
+    expect((await explanations("llist(1, 2, 3)")).pop()).toBe("Evaluation complete");
+    expect((await explanations("map(lambda x: x + 1, llist(1, 2))")).pop()).toBe(
+      "Evaluation complete",
+    );
   });
 
-  test("misusing a list primitive is stuck, not a wrong answer", () => {
-    expect(explanations("head(5)").pop()).toBe("Evaluation stuck"); // not a pair
-    expect(explanations("tail(None)").pop()).toBe("Evaluation stuck"); // empty list has no tail
-    expect(explanations("pair(1)").pop()).toBe("Evaluation stuck"); // wrong arity
+  test("misusing a list primitive is stuck, not a wrong answer", async () => {
+    expect((await explanations("head(5)")).pop()).toBe("Evaluation stuck"); // not a pair
+    expect((await explanations("tail(None)")).pop()).toBe("Evaluation stuck"); // empty list has no tail
+    expect((await explanations("pair(1)")).pop()).toBe("Evaluation stuck"); // wrong arity
   });
 
-  test("the list reduction shows pairs/lists, not the helper implementation noise", () => {
+  test("the list reduction shows pairs/lists, not the helper implementation noise", async () => {
     // `pair` contracts in one labelled step, like Source's primitives.
-    expect(explanations("pair(1, 2)")).toContain("Running pair");
+    expect(await explanations("pair(1, 2)")).toContain("Running pair");
     // A pair value serialises as an estree `ArrayExpression` for the host's `[...]` template. It shows
     // as the contraction result and is then discarded before the terminal (empty) "Evaluation
     // complete" step — a Python statement yields no program value — so search across the steps for it.
-    const value = steps("pair(1, 2)")
+    const value = (await steps("pair(1, 2)"))
       .map(s => findNode(s.ast, (n: any) => n.type === "ArrayExpression"))
       .find(Boolean);
     expect(value).toBeDefined();
@@ -977,17 +994,18 @@ describe("Python stepper — pairs and linked lists (Python §2)", () => {
     expect(preprocess("reduce(lambda a, b: a + b, 0, None)")).toBeNull();
   });
 
-  test("user code composes with the list library", () => {
+  test("user code composes with the list library", async () => {
     const program =
       "def sum_list(xs):\n" +
       "  return 0 if is_none(xs) else head(xs) + sum_list(tail(xs))\n" +
       "sum_list(llist(1, 2, 3, 4))";
-    expect(result(program)).toBe("10");
+    expect(await result(program)).toBe("10");
   });
 
-  test("structured-clone safe with pairs (survives the channel)", () => {
-    expect(() => structuredClone(steps("map(lambda x: x * 2, llist(1, 2, 3))"))).not.toThrow();
-    for (const step of steps("reverse(llist(1, 2))")) {
+  test("structured-clone safe with pairs (survives the channel)", async () => {
+    const s = await steps("map(lambda x: x * 2, llist(1, 2, 3))");
+    expect(() => structuredClone(s)).not.toThrow();
+    for (const step of await steps("reverse(llist(1, 2))")) {
       const marker = step.markers?.[0];
       if (marker?.redexId != null) expect(nodeIds(step.ast).has(marker.redexId)).toBe(true);
     }
@@ -996,58 +1014,58 @@ describe("Python stepper — pairs and linked lists (Python §2)", () => {
 
 describe("Python stepper — floating-point arithmetic (float operands)", () => {
   // Any float operand promotes the operation to float (Python semantics), so a `.0` repr is kept.
-  test("float add, subtract and multiply", () => {
-    expect(result("1.5 + 2.5")).toBe("4.0");
-    expect(result("5.5 - 2.0")).toBe("3.5");
-    expect(result("2.5 * 2.0")).toBe("5.0");
+  test("float add, subtract and multiply", async () => {
+    expect(await result("1.5 + 2.5")).toBe("4.0");
+    expect(await result("5.5 - 2.0")).toBe("3.5");
+    expect(await result("2.5 * 2.0")).toBe("5.0");
   });
 
-  test("float true division, floor division and modulo", () => {
-    expect(result("7.0 / 2")).toBe("3.5");
-    expect(result("7.5 // 2")).toBe("3.0"); // floored, but stays a float
-    expect(result("7.5 % 2")).toBe("1.5");
+  test("float true division, floor division and modulo", async () => {
+    expect(await result("7.0 / 2")).toBe("3.5");
+    expect(await result("7.5 // 2")).toBe("3.0"); // floored, but stays a float
+    expect(await result("7.5 % 2")).toBe("1.5");
   });
 
-  test("float power", () => {
-    expect(result("2.0 ** 3")).toBe("8.0");
+  test("float power", async () => {
+    expect(await result("2.0 ** 3")).toBe("8.0");
   });
 
-  test("float comparisons produce Python booleans", () => {
-    expect(result("1.5 < 2.0")).toBe("True");
-    expect(result("2.5 > 1.0")).toBe("True");
-    expect(result("1.5 <= 1.5")).toBe("True");
-    expect(result("2.5 >= 3.0")).toBe("False");
-    expect(result("1.5 == 1.5")).toBe("True");
-    expect(result("1.5 != 2.0")).toBe("True");
+  test("float comparisons produce Python booleans", async () => {
+    expect(await result("1.5 < 2.0")).toBe("True");
+    expect(await result("2.5 > 1.0")).toBe("True");
+    expect(await result("1.5 <= 1.5")).toBe("True");
+    expect(await result("2.5 >= 3.0")).toBe("False");
+    expect(await result("1.5 == 1.5")).toBe("True");
+    expect(await result("1.5 != 2.0")).toBe("True");
   });
 });
 
 describe("Python stepper — integer comparisons and edge arithmetic", () => {
-  test("the remaining ordering/inequality operators on ints", () => {
-    expect(result("1 <= 2")).toBe("True");
-    expect(result("2 <= 2")).toBe("True");
-    expect(result("2 >= 1")).toBe("True");
-    expect(result("1 != 2")).toBe("True");
-    expect(result("1 != 1")).toBe("False");
+  test("the remaining ordering/inequality operators on ints", async () => {
+    expect(await result("1 <= 2")).toBe("True");
+    expect(await result("2 <= 2")).toBe("True");
+    expect(await result("2 >= 1")).toBe("True");
+    expect(await result("1 != 2")).toBe("True");
+    expect(await result("1 != 1")).toBe("False");
   });
 
-  test("zero raised to a negative power is a ZeroDivisionError (int and float paths)", () => {
-    expect(result("0 ** -1")).toContain("ZeroDivisionError");
-    expect(result("0.0 ** -1")).toContain("ZeroDivisionError");
-    expect(explanations("0 ** -1").pop()).toBe("Evaluation stuck");
+  test("zero raised to a negative power is a ZeroDivisionError (int and float paths)", async () => {
+    expect(await result("0 ** -1")).toContain("ZeroDivisionError");
+    expect(await result("0.0 ** -1")).toContain("ZeroDivisionError");
+    expect((await explanations("0 ** -1")).pop()).toBe("Evaluation stuck");
   });
 
-  test("string ordering (< > <= >=) compares lexicographically", () => {
-    expect(result('"a" < "b"')).toBe("True");
-    expect(result('"b" < "a"')).toBe("False");
-    expect(result('"apple" < "banana"')).toBe("True");
-    expect(result('"a" > "b"')).toBe("False");
-    expect(result('"abc" <= "abc"')).toBe("True");
-    expect(result('"abd" >= "abc"')).toBe("True");
-    expect(explanations('"a" < "b"').pop()).toBe("Evaluation complete"); // modelled, not stuck
+  test("string ordering (< > <= >=) compares lexicographically", async () => {
+    expect(await result('"a" < "b"')).toBe("True");
+    expect(await result('"b" < "a"')).toBe("False");
+    expect(await result('"apple" < "banana"')).toBe("True");
+    expect(await result('"a" > "b"')).toBe("False");
+    expect(await result('"abc" <= "abc"')).toBe("True");
+    expect(await result('"abd" >= "abc"')).toBe("True");
+    expect((await explanations('"a" < "b"')).pop()).toBe("Evaluation complete"); // modelled, not stuck
   });
 
-  test("== / != are structural over any x any at §1/§2, except bool and function operands", () => {
+  test("== / != are structural over any x any at §1/§2, except bool and function operands", async () => {
     // `==`/`!=` take any x any at Python §1/§2 (see docs/specs/python_typing_middle_12.tex): None,
     // pairs and mismatched types all compare structurally rather than erroring.
     const cases: [string, string][] = [
@@ -1059,12 +1077,12 @@ describe("Python stepper — integer comparisons and edge arithmetic", () => {
       ["1 != '1'", "True"],
     ];
     for (const [src, expected] of cases) {
-      expect(result(src)).toBe(expected);
-      expect(explanations(src).pop()).toBe("Evaluation complete");
+      expect(await result(src)).toBe(expected);
+      expect((await explanations(src)).pop()).toBe("Evaluation complete");
     }
   });
 
-  test("bool and function operands are still excluded from == / != at §1/§2", () => {
+  test("bool and function operands are still excluded from == / != at §1/§2", async () => {
     for (const src of [
       "True == 1",
       "True == True",
@@ -1075,12 +1093,12 @@ describe("Python stepper — integer comparisons and edge arithmetic", () => {
       "pair(1, True) == pair(1, True)",
       "pair(1, 2) == pair(1, (lambda x: x))",
     ]) {
-      expect(explanations(src).pop()).toBe("Evaluation stuck");
-      expect(result(src)).toContain("TypeError");
+      expect((await explanations(src)).pop()).toBe("Evaluation stuck");
+      expect(await result(src)).toContain("TypeError");
     }
   });
 
-  test("pairs compare structurally, recursively, under == at §2", () => {
+  test("pairs compare structurally, recursively, under == at §2", async () => {
     const cases: [string, string][] = [
       ["pair(1, 2) == pair(1, 2)", "True"],
       ["pair(1, 2) == pair(1.0, 2)", "True"],
@@ -1094,7 +1112,7 @@ describe("Python stepper — integer comparisons and edge arithmetic", () => {
       ["pair(100000000000000000001, 1) == pair(100000000000000000001, 1)", "True"],
     ];
     for (const [src, expected] of cases) {
-      expect(result(src)).toBe(expected);
+      expect(await result(src)).toBe(expected);
     }
   });
 });
@@ -1103,55 +1121,55 @@ describe("Python stepper — and/or/not require a strict bool operand", () => {
   // Unlike native Python's truthiness, this dialect's `and`/`or`/`not` require a genuine `bool`
   // operand (matching the real, non-stepper evaluator's BOOL_OP/NOT instructions): `1 and 1`, `not 5`,
   // `None and 1` are all TypeErrors here, not truthy-evaluated.
-  test("and/or short-circuit on a bool left operand; the right operand's type is unrestricted", () => {
-    expect(result("True and 1")).toBe("1"); // left truthy → right returned, any type
-    expect(result("False and 1")).toBe("False"); // left falsy → short-circuits, right never touched
-    expect(result("True or 1")).toBe("True"); // left truthy → short-circuits
-    expect(result("False or 1")).toBe("1"); // left falsy → right returned, any type
+  test("and/or short-circuit on a bool left operand; the right operand's type is unrestricted", async () => {
+    expect(await result("True and 1")).toBe("1"); // left truthy → right returned, any type
+    expect(await result("False and 1")).toBe("False"); // left falsy → short-circuits, right never touched
+    expect(await result("True or 1")).toBe("True"); // left truthy → short-circuits
+    expect(await result("False or 1")).toBe("1"); // left falsy → right returned, any type
   });
 
-  test("a non-bool left operand to and/or is a TypeError (stuck), not truthy-evaluated", () => {
+  test("a non-bool left operand to and/or is a TypeError (stuck), not truthy-evaluated", async () => {
     for (const src of ['"abc" and 1', "1 and 1", "None and 1", "(lambda x: x) and 1", "0 or 1"]) {
-      expect(explanations(src).pop()).toBe("Evaluation stuck");
+      expect((await explanations(src)).pop()).toBe("Evaluation stuck");
     }
-    expect(result("1 and 1")).toContain("TypeError");
+    expect(await result("1 and 1")).toContain("TypeError");
   });
 
-  test("not requires a bool argument; a non-bool value is a TypeError (stuck)", () => {
+  test("not requires a bool argument; a non-bool value is a TypeError (stuck)", async () => {
     for (const src of ["not 1", "not 1.0", "not None", "not ''", "not (lambda x: x)"]) {
-      expect(explanations(src).pop()).toBe("Evaluation stuck");
+      expect((await explanations(src)).pop()).toBe("Evaluation stuck");
     }
-    expect(result("not 1")).toContain("TypeError");
+    expect(await result("not 1")).toContain("TypeError");
   });
 });
 
 describe("Python stepper — the rest of the math library", () => {
-  test("binary math functions compute on two arguments", () => {
-    expect(result("math_pow(2, 10)")).toBe("1024.0");
-    expect(result("math_atan2(0, 1)")).toBe("0.0");
-    expect(result("math_hypot(3, 4)")).toBe("5.0");
-    expect(result("math_fmod(7, 3)")).toBe("1.0");
-    expect(result("math_copysign(3, -1)")).toBe("-3.0");
-    expect(result("math_remainder(7, 3)")).toBe("1.0");
+  test("binary math functions compute on two arguments", async () => {
+    expect(await result("math_pow(2, 10)")).toBe("1024.0");
+    expect(await result("math_atan2(0, 1)")).toBe("0.0");
+    expect(await result("math_hypot(3, 4)")).toBe("5.0");
+    expect(await result("math_fmod(7, 3)")).toBe("1.0");
+    expect(await result("math_copysign(3, -1)")).toBe("-3.0");
+    expect(await result("math_remainder(7, 3)")).toBe("1.0");
   });
 
-  test("angle conversion (degrees/radians)", () => {
-    expect(result("math_degrees(0)")).toBe("0.0");
-    expect(result("math_radians(0)")).toBe("0.0");
-    expect(parseFloat(result("math_degrees(math_pi)"))).toBeCloseTo(180);
-    expect(parseFloat(result("math_radians(180)"))).toBeCloseTo(Math.PI);
+  test("angle conversion (degrees/radians)", async () => {
+    expect(await result("math_degrees(0)")).toBe("0.0");
+    expect(await result("math_radians(0)")).toBe("0.0");
+    expect(parseFloat(await result("math_degrees(math_pi)"))).toBeCloseTo(180);
+    expect(parseFloat(await result("math_radians(180)"))).toBeCloseTo(Math.PI);
   });
 
-  test("infinity / finiteness predicates", () => {
-    expect(result("math_isinf(math_inf)")).toBe("True");
-    expect(result("math_isinf(1.0)")).toBe("False");
-    expect(result("math_isfinite(1.0)")).toBe("True");
-    expect(result("math_isfinite(math_inf)")).toBe("False");
+  test("infinity / finiteness predicates", async () => {
+    expect(await result("math_isinf(math_inf)")).toBe("True");
+    expect(await result("math_isinf(1.0)")).toBe("False");
+    expect(await result("math_isfinite(1.0)")).toBe("True");
+    expect(await result("math_isfinite(math_inf)")).toBe("False");
   });
 
-  test("a math function on a non-number is a TypeError (stuck)", () => {
-    expect(result("math_floor(None)")).toContain("TypeError");
-    expect(explanations("math_floor(None)").pop()).toBe("Evaluation stuck");
+  test("a math function on a non-number is a TypeError (stuck)", async () => {
+    expect(await result("math_floor(None)")).toContain("TypeError");
+    expect((await explanations("math_floor(None)")).pop()).toBe("Evaluation stuck");
   });
 });
 
@@ -1160,52 +1178,52 @@ describe("Python stepper — bool is not an int subtype in this dialect", () => 
   // no numeric builtin, here — it is only valid to `and`/`or`/`not` and to explicit conversions like
   // `int()`/`float()`/`str()`. This matches the real, non-stepper evaluator (e.g. `True == True`,
   // `True + 1` and `abs(True)` are all TypeErrors there too), even though native Python allows them.
-  test("bool is rejected by every binary arithmetic/comparison/equality operator", () => {
+  test("bool is rejected by every binary arithmetic/comparison/equality operator", async () => {
     for (const src of ["True + 1", "1 + True", "True * True", "True / 1", "True - True"]) {
-      expect(explanations(src).pop()).toBe("Evaluation stuck");
-      expect(result(src)).toContain("TypeError");
+      expect((await explanations(src)).pop()).toBe("Evaluation stuck");
+      expect(await result(src)).toContain("TypeError");
     }
     for (const src of ["True == True", "True == 1", "True > 1", "1 > True", "True <= True"]) {
-      expect(explanations(src).pop()).toBe("Evaluation stuck");
-      expect(result(src)).toContain("TypeError");
+      expect((await explanations(src)).pop()).toBe("Evaluation stuck");
+      expect(await result(src)).toContain("TypeError");
     }
   });
 
-  test("unary minus/plus on a bool is a TypeError (stuck)", () => {
-    expect(explanations("-True").pop()).toBe("Evaluation stuck");
-    expect(result("-True")).toContain("TypeError");
+  test("unary minus/plus on a bool is a TypeError (stuck)", async () => {
+    expect((await explanations("-True")).pop()).toBe("Evaluation stuck");
+    expect(await result("-True")).toContain("TypeError");
   });
 
-  test("abs/round/math functions reject a bool argument", () => {
+  test("abs/round/math functions reject a bool argument", async () => {
     for (const src of ["abs(True)", "round(True)", "math_sqrt(True)", "math_floor(False)"]) {
-      expect(explanations(src).pop()).toBe("Evaluation stuck");
-      expect(result(src)).toContain("TypeError");
+      expect((await explanations(src)).pop()).toBe("Evaluation stuck");
+      expect(await result(src)).toContain("TypeError");
     }
   });
 
-  test("min/max reject a bool argument", () => {
-    expect(explanations("min(True, 1)").pop()).toBe("Evaluation stuck");
-    expect(explanations("max(1, False)").pop()).toBe("Evaluation stuck");
+  test("min/max reject a bool argument", async () => {
+    expect((await explanations("min(True, 1)")).pop()).toBe("Evaluation stuck");
+    expect((await explanations("max(1, False)")).pop()).toBe("Evaluation stuck");
   });
 
-  test("str and is_boolean still accept a bool", () => {
+  test("str and is_boolean still accept a bool", async () => {
     // Conversions/predicates are where `bool` is still accepted — they use its representation rather
     // than treating it as a numeric operand.
-    expect(result("str(True)")).toBe("'True'");
-    expect(result("is_boolean(True)")).toBe("True");
+    expect(await result("str(True)")).toBe("'True'");
+    expect(await result("is_boolean(True)")).toBe("True");
   });
 });
 
 describe("Python stepper — str/repr and bool of compound values", () => {
-  test("str of a pair renders box-and-pointer with repr'd elements", () => {
-    expect(result("str(pair(1, 2))")).toBe("'[1, 2]'");
-    expect(result('str(pair("a", None))')).toBe("\"['a', None]\""); // string element shows quoted
+  test("str of a pair renders box-and-pointer with repr'd elements", async () => {
+    expect(await result("str(pair(1, 2))")).toBe("'[1, 2]'");
+    expect(await result('str(pair("a", None))')).toBe("\"['a', None]\""); // string element shows quoted
   });
 
-  test("str/repr of function values", () => {
-    expect(result("str(lambda x: x)")).toBe("'<function <lambda>>'");
-    expect(result("str(abs)")).toBe("'<built-in function abs>'");
-    expect(result("repr(math_sqrt)")).toBe("'<built-in function math_sqrt>'");
+  test("str/repr of function values", async () => {
+    expect(await result("str(lambda x: x)")).toBe("'<function <lambda>>'");
+    expect(await result("str(abs)")).toBe("'<built-in function abs>'");
+    expect(await result("repr(math_sqrt)")).toBe("'<built-in function math_sqrt>'");
   });
 });
 
@@ -1215,53 +1233,53 @@ describe("Python stepper — constructs outside the reducible subset degrade gra
   // that simply gets stuck, instead of failing the whole run. (The preprocessing gate would reject most
   // of these in production; the stepper's `getPythonSteps` translates them regardless.) Complex numbers
   // are *not* in this category — they are a fully-modelled value type; see "complex numbers" below.
-  test("a list literal reduces to an array value", () => {
-    expect(result("[1, 2, 3]")).toBe("[1, 2, 3]");
-    expect(result("[]")).toBe("[]");
-    expect(result('["a", 1]')).toBe("['a', 1]"); // elements use repr, so a string shows quoted
+  test("a list literal reduces to an array value", async () => {
+    expect(await result("[1, 2, 3]")).toBe("[1, 2, 3]");
+    expect(await result("[]")).toBe("[]");
+    expect(await result('["a", 1]')).toBe("['a', 1]"); // elements use repr, so a string shows quoted
   });
 
-  test("an unsupported expression becomes an inert placeholder (stuck)", () => {
-    expect(explanations("x[0]").pop()).toBe("Evaluation stuck"); // subscript is not modelled
+  test("an unsupported expression becomes an inert placeholder (stuck)", async () => {
+    expect((await explanations("x[0]")).pop()).toBe("Evaluation stuck"); // subscript is not modelled
   });
 
-  test("an assignment to a non-variable target is an inert placeholder (stuck)", () => {
-    expect(explanations("x[0] = 5").pop()).toBe("Evaluation stuck");
+  test("an assignment to a non-variable target is an inert placeholder (stuck)", async () => {
+    expect((await explanations("x[0] = 5")).pop()).toBe("Evaluation stuck");
   });
 
-  test("an unsupported statement becomes an inert placeholder (stuck)", () => {
+  test("an unsupported statement becomes an inert placeholder (stuck)", async () => {
     for (const src of ["assert True", "while False:\n  pass", "for i in x:\n  pass"]) {
-      expect(explanations(src).pop()).toBe("Evaluation stuck");
+      expect((await explanations(src)).pop()).toBe("Evaluation stuck");
     }
   });
 
-  test("a program left stuck at a leading non-value statement is 'stuck', not 'complete'", () => {
+  test("a program left stuck at a leading non-value statement is 'stuck', not 'complete'", async () => {
     // Two statements where the first cannot reduce and is not a value: the whole run is stuck.
-    expect(explanations("x[0]\n1").pop()).toBe("Evaluation stuck");
+    expect((await explanations("x[0]\n1")).pop()).toBe("Evaluation stuck");
   });
 });
 
 describe("Python stepper — list library edge built-ins", () => {
-  test("draw_data returns its first argument (there is no drawing canvas)", () => {
-    expect(result("draw_data(5)")).toBe("5");
-    expect(result("draw_data(pair(1, 2))")).toBe("[1, 2]");
+  test("draw_data returns its first argument (there is no drawing canvas)", async () => {
+    expect(await result("draw_data(5)")).toBe("5");
+    expect(await result("draw_data(pair(1, 2))")).toBe("[1, 2]");
   });
 
-  test("draw_data with no arguments is stuck (it needs at least one)", () => {
-    expect(explanations("draw_data()").pop()).toBe("Evaluation stuck");
-    expect(result("draw_data()")).toContain("at least 1 argument");
+  test("draw_data with no arguments is stuck (it needs at least one)", async () => {
+    expect((await explanations("draw_data()")).pop()).toBe("Evaluation stuck");
+    expect(await result("draw_data()")).toContain("at least 1 argument");
   });
 
-  test("a library function called with the wrong argument count is stuck", () => {
-    expect(explanations("map(lambda x: x)").pop()).toBe("Evaluation stuck");
-    expect(result("append(None)")).toContain("takes 2 argument(s) but 1 were given");
+  test("a library function called with the wrong argument count is stuck", async () => {
+    expect((await explanations("map(lambda x: x)")).pop()).toBe("Evaluation stuck");
+    expect(await result("append(None)")).toContain("takes 2 argument(s) but 1 were given");
   });
 });
 
 describe("Python stepper — step limit", () => {
-  test("stops with 'Maximum number of steps exceeded' when the step limit is reached", () => {
+  test("stops with 'Maximum number of steps exceeded' when the step limit is reached", async () => {
     // stepLimit 2 → one contraction allowed; a longer program is cut off with the limit marker.
-    const limited = getPythonSteps(parse("1 + 2 + 3 + 4\n"), 2);
+    const limited = await getPythonSteps(parse("1 + 2 + 3 + 4\n"), 2);
     expect(limited[limited.length - 1].markers?.[0]?.explanation).toBe(
       "Maximum number of steps exceeded",
     );
@@ -1284,25 +1302,25 @@ describe("Python stepper — module helpers", () => {
 });
 
 describe("Python stepper — MISC conversions and their error paths", () => {
-  test("float division by zero is a ZeroDivisionError (stuck)", () => {
-    expect(result("1.5 / 0")).toContain("ZeroDivisionError");
-    expect(explanations("1.5 % 0").pop()).toBe("Evaluation stuck");
+  test("float division by zero is a ZeroDivisionError (stuck)", async () => {
+    expect(await result("1.5 / 0")).toContain("ZeroDivisionError");
+    expect((await explanations("1.5 % 0")).pop()).toBe("Evaluation stuck");
   });
 
-  test("unary plus on a number is the number itself", () => {
-    expect(result("+5")).toBe("5"); // int
-    expect(result("+5.0")).toBe("5.0"); // float
+  test("unary plus on a number is the number itself", async () => {
+    expect(await result("+5")).toBe("5"); // int
+    expect(await result("+5.0")).toBe("5.0"); // float
   });
 
-  test("factorial of a negative is a ValueError (stuck)", () => {
-    expect(result("math_factorial(-1)")).toContain("ValueError");
-    expect(explanations("math_factorial(-1)").pop()).toBe("Evaluation stuck");
+  test("factorial of a negative is a ValueError (stuck)", async () => {
+    expect(await result("math_factorial(-1)")).toContain("ValueError");
+    expect((await explanations("math_factorial(-1)")).pop()).toBe("Evaluation stuck");
   });
 
-  test("len / arity misuse is a TypeError (stuck)", () => {
-    expect(result("len(5)")).toContain("TypeError");
-    expect(result("arity(5)")).toContain("TypeError");
-    expect(explanations("len(5)").pop()).toBe("Evaluation stuck");
+  test("len / arity misuse is a TypeError (stuck)", async () => {
+    expect(await result("len(5)")).toContain("TypeError");
+    expect(await result("arity(5)")).toContain("TypeError");
+    expect((await explanations("len(5)")).pop()).toBe("Evaluation stuck");
   });
 });
 
@@ -1310,163 +1328,163 @@ describe("Python stepper — complex numbers", () => {
   // A `<real>±<imag>j` literal is one token (parsed straight into real/imag by py-slang's parser), but
   // `2 + 3j` (with an operator) is an ordinary int-plus-complex expression — both must produce the same
   // value, so both forms are exercised throughout.
-  test("a bare complex literal displays like Python's repr (no parens when the real part is zero)", () => {
-    expect(result("1j")).toBe("1j");
-    expect(result("3j")).toBe("3j");
-    expect(result("-3j")).toBe("-3j");
-    expect(result("0j")).toBe("0j");
-    expect(result("-4.5j")).toBe("-4.5j");
-    expect(explanations("3j").pop()).toBe("Evaluation complete");
+  test("a bare complex literal displays like Python's repr (no parens when the real part is zero)", async () => {
+    expect(await result("1j")).toBe("1j");
+    expect(await result("3j")).toBe("3j");
+    expect(await result("-3j")).toBe("-3j");
+    expect(await result("0j")).toBe("0j");
+    expect(await result("-4.5j")).toBe("-4.5j");
+    expect((await explanations("3j")).pop()).toBe("Evaluation complete");
   });
 
-  test("a real+imaginary literal displays parenthesised, with an explicit sign", () => {
-    expect(result("2+3j")).toBe("(2+3j)");
-    expect(result("2-3j")).toBe("(2-3j)");
+  test("a real+imaginary literal displays parenthesised, with an explicit sign", async () => {
+    expect(await result("2+3j")).toBe("(2+3j)");
+    expect(await result("2-3j")).toBe("(2-3j)");
   });
 
-  test("int/float promote to complex when combined with one via an operator", () => {
-    expect(result("2 + 3j")).toBe("(2+3j)"); // int + complex
-    expect(result("3j + 2")).toBe("(2+3j)"); // complex + int, same value
-    expect(result("1.5 + 2j")).toBe("(1.5+2j)"); // float + complex
+  test("int/float promote to complex when combined with one via an operator", async () => {
+    expect(await result("2 + 3j")).toBe("(2+3j)"); // int + complex
+    expect(await result("3j + 2")).toBe("(2+3j)"); // complex + int, same value
+    expect(await result("1.5 + 2j")).toBe("(1.5+2j)"); // float + complex
   });
 
-  test("complex arithmetic: +, -, *, /", () => {
-    expect(result("(1+2j) + (3+4j)")).toBe("(4+6j)");
-    expect(result("(1+2j) - (3+4j)")).toBe("(-2-2j)");
-    expect(result("(1+2j) * (3+4j)")).toBe("(-5+10j)");
-    expect(result("(1+2j) / (3+4j)")).toBe("(0.44+0.08j)");
+  test("complex arithmetic: +, -, *, /", async () => {
+    expect(await result("(1+2j) + (3+4j)")).toBe("(4+6j)");
+    expect(await result("(1+2j) - (3+4j)")).toBe("(-2-2j)");
+    expect(await result("(1+2j) * (3+4j)")).toBe("(-5+10j)");
+    expect(await result("(1+2j) / (3+4j)")).toBe("(0.44+0.08j)");
   });
 
-  test("complex power (via the polar-form algorithm, like the real evaluator)", () => {
+  test("complex power (via the polar-form algorithm, like the real evaluator)", async () => {
     // `(1+2j) ** 2` is not exactly `-3+4j` here because the general complex power path always goes
     // through log/exp/trig, picking up float noise even for an integer exponent — this exactly mirrors
     // `PyComplexNumber.pow` in the real, non-stepper evaluator (same formula, same imprecision).
-    const s = result("(1+2j) ** 2");
+    const s = await result("(1+2j) ** 2");
     expect(s.startsWith("(-3+4.0")).toBe(true);
     expect(s.endsWith("j)")).toBe(true);
-    expect(result("0j ** 2")).toBe("0j");
+    expect(await result("0j ** 2")).toBe("0j");
   });
 
-  test("0 to a negative or non-real power is a ZeroDivisionError (stuck)", () => {
+  test("0 to a negative or non-real power is a ZeroDivisionError (stuck)", async () => {
     for (const src of ["0j ** -1", "0j ** (1+1j)"]) {
-      expect(result(src)).toContain("ZeroDivisionError");
-      expect(explanations(src).pop()).toBe("Evaluation stuck");
+      expect(await result(src)).toContain("ZeroDivisionError");
+      expect((await explanations(src)).pop()).toBe("Evaluation stuck");
     }
   });
 
-  test("complex division by zero is a ZeroDivisionError (stuck), for a plain-int or complex zero", () => {
+  test("complex division by zero is a ZeroDivisionError (stuck), for a plain-int or complex zero", async () => {
     for (const src of ["1j / 0", "1j / 0j"]) {
-      expect(result(src)).toContain("ZeroDivisionError");
-      expect(explanations(src).pop()).toBe("Evaluation stuck");
+      expect(await result(src)).toContain("ZeroDivisionError");
+      expect((await explanations(src)).pop()).toBe("Evaluation stuck");
     }
   });
 
-  test("== / != hold between any mix of int, float and complex", () => {
-    expect(result("(1+2j) == (1+2j)")).toBe("True");
-    expect(result("(1+2j) == (1+3j)")).toBe("False");
-    expect(result("(1+2j) != (1+3j)")).toBe("True");
-    expect(result("1 == 1+0j")).toBe("True");
-    expect(result("1.0 == 1+0j")).toBe("True");
-    expect(result("1+0j == 1")).toBe("True");
+  test("== / != hold between any mix of int, float and complex", async () => {
+    expect(await result("(1+2j) == (1+2j)")).toBe("True");
+    expect(await result("(1+2j) == (1+3j)")).toBe("False");
+    expect(await result("(1+2j) != (1+3j)")).toBe("True");
+    expect(await result("1 == 1+0j")).toBe("True");
+    expect(await result("1.0 == 1+0j")).toBe("True");
+    expect(await result("1+0j == 1")).toBe("True");
   });
 
-  test("ordering (<, <=, >, >=), // and % are not defined for complex — a TypeError (stuck)", () => {
+  test("ordering (<, <=, >, >=), // and % are not defined for complex — a TypeError (stuck)", async () => {
     for (const src of ["(1+2j) < (3+4j)", "(1+2j) // 2", "(1+2j) % 2"]) {
-      expect(explanations(src).pop()).toBe("Evaluation stuck");
-      expect(result(src)).toContain("TypeError");
+      expect((await explanations(src)).pop()).toBe("Evaluation stuck");
+      expect(await result(src)).toContain("TypeError");
     }
   });
 
-  test("unary minus/plus on complex", () => {
-    expect(result("-(1+2j)")).toBe("(-1-2j)");
-    expect(result("+(1+2j)")).toBe("(1+2j)");
+  test("unary minus/plus on complex", async () => {
+    expect(await result("-(1+2j)")).toBe("(-1-2j)");
+    expect(await result("+(1+2j)")).toBe("(1+2j)");
   });
 
-  test("abs() returns the modulus as a non-negative float", () => {
-    expect(result("abs(3+4j)")).toBe("5.0");
-    expect(result("abs(0j)")).toBe("0.0");
-    expect(result("abs(1j)")).toBe("1.0");
+  test("abs() returns the modulus as a non-negative float", async () => {
+    expect(await result("abs(3+4j)")).toBe("5.0");
+    expect(await result("abs(0j)")).toBe("0.0");
+    expect(await result("abs(1j)")).toBe("1.0");
   });
 
-  test("str/repr of a complex value (repr matches str, unlike a string's quoting)", () => {
-    expect(result("str(1+2j)")).toBe("'(1+2j)'");
-    expect(result("repr(1+2j)")).toBe("'(1+2j)'");
-    expect(result("str(2j)")).toBe("'2j'");
-    expect(result("str(-2j)")).toBe("'-2j'");
+  test("str/repr of a complex value (repr matches str, unlike a string's quoting)", async () => {
+    expect(await result("str(1+2j)")).toBe("'(1+2j)'");
+    expect(await result("repr(1+2j)")).toBe("'(1+2j)'");
+    expect(await result("str(2j)")).toBe("'2j'");
+    expect(await result("str(-2j)")).toBe("'-2j'");
   });
 
-  test("complex() constructs from a number, bool, string, or (real, imag) pair", () => {
-    expect(result("complex()")).toBe("0j");
-    expect(result("complex(5)")).toBe("(5+0j)");
-    expect(result("complex(5.5)")).toBe("(5.5+0j)");
-    expect(result("complex(True)")).toBe("(1+0j)"); // the one place bool is still accepted
-    expect(result("complex(1+2j)")).toBe("(1+2j)");
-    expect(result("complex(1, 2)")).toBe("(1+2j)");
-    expect(result("complex(1.5, 2.5)")).toBe("(1.5+2.5j)");
+  test("complex() constructs from a number, bool, string, or (real, imag) pair", async () => {
+    expect(await result("complex()")).toBe("0j");
+    expect(await result("complex(5)")).toBe("(5+0j)");
+    expect(await result("complex(5.5)")).toBe("(5.5+0j)");
+    expect(await result("complex(True)")).toBe("(1+0j)"); // the one place bool is still accepted
+    expect(await result("complex(1+2j)")).toBe("(1+2j)");
+    expect(await result("complex(1, 2)")).toBe("(1+2j)");
+    expect(await result("complex(1.5, 2.5)")).toBe("(1.5+2.5j)");
   });
 
-  test("complex(str) parses a Python complex-literal string", () => {
-    expect(result("complex('1+2j')")).toBe("(1+2j)");
-    expect(result("complex('-4.5j')")).toBe("-4.5j");
-    expect(result("complex('inf')")).toBe("(inf+0j)");
+  test("complex(str) parses a Python complex-literal string", async () => {
+    expect(await result("complex('1+2j')")).toBe("(1+2j)");
+    expect(await result("complex('-4.5j')")).toBe("-4.5j");
+    expect(await result("complex('inf')")).toBe("(inf+0j)");
   });
 
-  test("complex(str) rejects a malformed string with a ValueError (stuck)", () => {
-    expect(result("complex('not a number')")).toContain("ValueError");
-    expect(explanations("complex('not a number')").pop()).toBe("Evaluation stuck");
+  test("complex(str) rejects a malformed string with a ValueError (stuck)", async () => {
+    expect(await result("complex('not a number')")).toContain("ValueError");
+    expect((await explanations("complex('not a number')")).pop()).toBe("Evaluation stuck");
   });
 
-  test("complex(str) rejects prototype-chain property names as malformed, not as special values", () => {
+  test("complex(str) rejects prototype-chain property names as malformed, not as special values", async () => {
     // Regression: a bare `in` against the plain-object `specials` lookup used to match inherited
     // Object.prototype keys, so e.g. complex('constructorj') smuggled the Object constructor
     // function through as the imaginary part instead of being rejected.
-    expect(result("complex('constructorj')")).toContain("ValueError");
-    expect(result("complex('__proto__j')")).toContain("ValueError");
+    expect(await result("complex('constructorj')")).toContain("ValueError");
+    expect(await result("complex('__proto__j')")).toContain("ValueError");
   });
 
-  test("real()/imag() extract the components; they require an actual complex argument", () => {
-    expect(result("real(1+2j)")).toBe("1.0");
-    expect(result("imag(1+2j)")).toBe("2.0");
-    expect(explanations("real(5)").pop()).toBe("Evaluation stuck"); // int is not "complex" here
-    expect(result("real(5)")).toContain("TypeError");
+  test("real()/imag() extract the components; they require an actual complex argument", async () => {
+    expect(await result("real(1+2j)")).toBe("1.0");
+    expect(await result("imag(1+2j)")).toBe("2.0");
+    expect((await explanations("real(5)")).pop()).toBe("Evaluation stuck"); // int is not "complex" here
+    expect(await result("real(5)")).toContain("TypeError");
   });
 
-  test("is_complex distinguishes complex values from everything else", () => {
-    expect(result("is_complex(1+2j)")).toBe("True");
-    expect(result("is_complex(5)")).toBe("False");
-    expect(result("is_complex(5.0)")).toBe("False");
+  test("is_complex distinguishes complex values from everything else", async () => {
+    expect(await result("is_complex(1+2j)")).toBe("True");
+    expect(await result("is_complex(5)")).toBe("False");
+    expect(await result("is_complex(5.0)")).toBe("False");
   });
 
-  test("complex is a valid and/or *right* operand (its type is never checked there)", () => {
-    expect(result("True and (1+2j)")).toBe("(1+2j)");
+  test("complex is a valid and/or *right* operand (its type is never checked there)", async () => {
+    expect(await result("True and (1+2j)")).toBe("(1+2j)");
   });
 
-  test("complex is rejected as and/or's left operand, and by not — a TypeError (stuck)", () => {
-    expect(explanations("(1+2j) and True").pop()).toBe("Evaluation stuck");
-    expect(result("(1+2j) and True")).toContain("TypeError");
-    expect(explanations("not (1+2j)").pop()).toBe("Evaluation stuck");
-    expect(result("not (1+2j)")).toContain("TypeError");
+  test("complex is rejected as and/or's left operand, and by not — a TypeError (stuck)", async () => {
+    expect((await explanations("(1+2j) and True")).pop()).toBe("Evaluation stuck");
+    expect(await result("(1+2j) and True")).toContain("TypeError");
+    expect((await explanations("not (1+2j)")).pop()).toBe("Evaluation stuck");
+    expect(await result("not (1+2j)")).toContain("TypeError");
   });
 
-  test("min/max/round/math_* all reject complex — a TypeError (stuck), like bool", () => {
+  test("min/max/round/math_* all reject complex — a TypeError (stuck), like bool", async () => {
     for (const src of ["min(1+2j, 3)", "round(1+2j)", "math_sqrt(1+2j)"]) {
-      expect(explanations(src).pop()).toBe("Evaluation stuck");
-      expect(result(src)).toContain("TypeError");
+      expect((await explanations(src)).pop()).toBe("Evaluation stuck");
+      expect(await result(src)).toContain("TypeError");
     }
   });
 
-  test("mixing complex with an incompatible type (str) is a TypeError (stuck)", () => {
-    expect(explanations("'a' + (1+2j)").pop()).toBe("Evaluation stuck");
-    expect(result("'a' + (1+2j)")).toContain("TypeError");
+  test("mixing complex with an incompatible type (str) is a TypeError (stuck)", async () => {
+    expect((await explanations("'a' + (1+2j)")).pop()).toBe("Evaluation stuck");
+    expect(await result("'a' + (1+2j)")).toContain("TypeError");
   });
 
-  test("a pair may hold a complex element, formatted like any other pair element", () => {
-    expect(result("pair(1+2j, 2)")).toBe("[(1+2j), 2]");
-    expect(result("str(pair(1+2j, 2))")).toBe("'[(1+2j), 2]'");
+  test("a pair may hold a complex element, formatted like any other pair element", async () => {
+    expect(await result("pair(1+2j, 2)")).toBe("[(1+2j), 2]");
+    expect(await result("str(pair(1+2j, 2))")).toBe("'[(1+2j), 2]'");
   });
 
-  test("complex arithmetic composes with user code", () => {
-    expect(result("f = lambda z: z * z\nf(1+1j)")).toBe("2j");
+  test("complex arithmetic composes with user code", async () => {
+    expect(await result("f = lambda z: z * z\nf(1+1j)")).toBe("2j");
   });
 });
 
@@ -1487,15 +1505,15 @@ describe("Python stepper — breakpoint() marks a debugger breakpoint (#188)", (
     expect(preprocess("breakpoint()\nx = 1\nx + 1")).toBeNull();
   });
 
-  test("evaluates as a no-op, exactly like pass (never affects the result)", () => {
-    expect(result("breakpoint()\n1 + 1")).toBe("2");
-    expect(result("x = 5\nbreakpoint()\nx + 1")).toBe("6");
+  test("evaluates as a no-op, exactly like pass (never affects the result)", async () => {
+    expect(await result("breakpoint()\n1 + 1")).toBe("2");
+    expect(await result("x = 5\nbreakpoint()\nx + 1")).toBe("6");
     // Inside a function body too (a breakpoint before the return); the return value is unchanged.
-    expect(result("def f(x):\n  breakpoint()\n  return x + 1\nf(4)")).toBe("5");
+    expect(await result("def f(x):\n  breakpoint()\n  return x + 1\nf(4)")).toBe("5");
   });
 
-  test("produces a before/after pair reading 'Evaluating'/'Evaluated breakpoint statement'", () => {
-    expect(explanations("breakpoint()\n1 + 1")).toEqual([
+  test("produces a before/after pair reading 'Evaluating'/'Evaluated breakpoint statement'", async () => {
+    expect(await explanations("breakpoint()\n1 + 1")).toEqual([
       "Start of evaluation",
       "Evaluating breakpoint statement",
       "Evaluated breakpoint statement",
@@ -1507,13 +1525,13 @@ describe("Python stepper — breakpoint() marks a debugger breakpoint (#188)", (
     ]);
   });
 
-  test("only the 'Evaluating' step is a breakpoint target — never the 'Evaluated' one (#188)", () => {
+  test("only the 'Evaluating' step is a breakpoint target — never the 'Evaluated' one (#188)", async () => {
     // The double-arrow must land on "Evaluating breakpoint statement", not the following "Evaluated
     // breakpoint statement". The host picks a target by `redexNodeType === "DebuggerStatement"`, so the
     // *before* step must carry it and the *after* step must not — for every breakpoint, including when
     // there are several. (`stepNextBreakpoint` scans forward for the next such marker, so a flagged
     // after step would make it stop on the wrong, post-reduction step.)
-    const s = steps("breakpoint()\nx = 1\nbreakpoint()\nx");
+    const s = await steps("breakpoint()\nx = 1\nbreakpoint()\nx");
     const flagged = s
       .filter(step => step.markers?.[0]?.redexNodeType === "DebuggerStatement")
       .map(step => step.markers?.[0]?.explanation);
@@ -1533,11 +1551,11 @@ describe("Python stepper — breakpoint() marks a debugger breakpoint (#188)", (
     expect(after?.markers?.[0]?.redexNodeType).toBeUndefined();
   });
 
-  test("green flash before discard: the statement is shown highlighted green on the after step, like pass", () => {
+  test("green flash before discard: the statement is shown highlighted green on the after step, like pass", async () => {
     // Like `pass`, the after step ("Evaluated breakpoint statement") keeps the statement present and
     // highlights it green (an afterMarker whose redexId resolves to the call still in the tree); only
     // the *next* contraction's before step shows it actually gone.
-    const s = steps("breakpoint()\n1 + 1");
+    const s = await steps("breakpoint()\n1 + 1");
     const beforeIdx = s.findIndex(
       step => step.markers?.[0]?.explanation === "Evaluating breakpoint statement",
     );
@@ -1560,10 +1578,10 @@ describe("Python stepper — breakpoint() marks a debugger breakpoint (#188)", (
     expect((s[beforeIdx + 2].ast as any).body[0].type).toBe("ExpressionStatement");
   });
 
-  test("renders as the breakpoint() call the student typed (an ordinary CallExpression)", () => {
+  test("renders as the breakpoint() call the student typed (an ordinary CallExpression)", async () => {
     // No dedicated node type: `breakpoint()` translates to a plain CallExpression (see translate.ts)
     // and renders through the same Identifier/CallExpression templates as any other built-in call.
-    const stmt = (steps("breakpoint()\n1")[0].ast as any).body[0];
+    const stmt = ((await steps("breakpoint()\n1"))[0].ast as any).body[0];
     expect(stmt.type).toBe("ExpressionStatement");
     expect(stmt.expression.type).toBe("CallExpression");
     expect(stmt.expression.callee.type).toBe("Identifier");
@@ -1571,21 +1589,21 @@ describe("Python stepper — breakpoint() marks a debugger breakpoint (#188)", (
     expect(stmt.expression.arguments).toEqual([]);
   });
 
-  test("used as an expression it degrades to a no-op returning None (not the debugger form)", () => {
+  test("used as an expression it degrades to a no-op returning None (not the debugger form)", async () => {
     // Only the bare-statement form is the debugger; in expression position `breakpoint()` is an
     // ordinary built-in call that yields None, so the program still resolves rather than getting stuck.
-    expect(result("x = breakpoint()\nx")).toBe("None");
-    expect(explanations("x = breakpoint()\nx").pop()).toBe("Evaluation complete");
+    expect(await result("x = breakpoint()\nx")).toBe("None");
+    expect((await explanations("x = breakpoint()\nx")).pop()).toBe("Evaluation complete");
   });
 
-  test("aliased via a variable behaves exactly like breakpoint() itself, just as p = print; p(1) does", () => {
+  test("aliased via a variable behaves exactly like breakpoint() itself, just as p = print; p(1) does", async () => {
     // The bug this fixes: detection used to match the student's literal source text ("breakpoint()"),
     // so an alias silently lost the debugger behaviour. It is now resolved identity at reduction time
     // (stepHead in reduce.ts): `bp`, once substituted to the `breakpoint` builtin, is indistinguishable
     // from writing `breakpoint()` directly — same wording, same nav target, same no-op evaluation.
     const src = "bp = breakpoint\nbp()\n1 + 1";
-    expect(result(src)).toBe("2");
-    expect(explanations(src)).toEqual([
+    expect(await result(src)).toBe("2");
+    expect(await explanations(src)).toEqual([
       "Start of evaluation",
       "Declaring and substituting bp into the rest of the block",
       "Declared and substituted bp into the rest of the block",
@@ -1597,28 +1615,28 @@ describe("Python stepper — breakpoint() marks a debugger breakpoint (#188)", (
       "Evaluated 2",
       "Evaluation complete",
     ]);
-    const flagged = steps(src).filter(
+    const flagged = (await steps(src)).filter(
       step => step.markers?.[0]?.redexNodeType === "DebuggerStatement",
     );
     expect(flagged).toHaveLength(1);
     expect(flagged[0].markers?.[0]?.explanation).toBe("Evaluating breakpoint statement");
   });
 
-  test("aliasing also works inside a function body", () => {
+  test("aliasing also works inside a function body", async () => {
     const src = "def f(x):\n  bp = breakpoint\n  bp()\n  return x + 1\nf(4)";
-    expect(result(src)).toBe("5");
-    const flagged = steps(src).filter(
+    expect(await result(src)).toBe("5");
+    const flagged = (await steps(src)).filter(
       step => step.markers?.[0]?.redexNodeType === "DebuggerStatement",
     );
     expect(flagged).toHaveLength(1);
   });
 
-  test("aliased and used as an expression still degrades to a no-op (not a breakpoint target)", () => {
+  test("aliased and used as an expression still degrades to a no-op (not a breakpoint target)", async () => {
     // Aliasing must not *widen* what counts as the debugger form either: `bp()` in expression position
     // degrades exactly like `breakpoint()` does in the direct case above.
     const src = "bp = breakpoint\nx = bp()\nx";
-    expect(result(src)).toBe("None");
-    const flagged = steps(src).filter(
+    expect(await result(src)).toBe("None");
+    const flagged = (await steps(src)).filter(
       step => step.markers?.[0]?.redexNodeType === "DebuggerStatement",
     );
     expect(flagged).toHaveLength(0);
@@ -1631,21 +1649,24 @@ describe("Python stepper — breakpoint() marks a debugger breakpoint (#188)", (
   test.each([
     ["one literal argument", "breakpoint(5)"],
     ["several literal arguments", "breakpoint(1, 2, 3)"],
-  ])("%s: still evaluates as a no-op and is flagged as a breakpoint target", (_desc, call) => {
-    expect(result(`${call}\n1 + 1`)).toBe("2");
-    const flagged = steps(`${call}\n1 + 1`).filter(
-      step => step.markers?.[0]?.redexNodeType === "DebuggerStatement",
-    );
-    expect(flagged).toHaveLength(1);
-    expect(flagged[0].markers?.[0]?.explanation).toBe("Evaluating breakpoint statement");
-  });
+  ])(
+    "%s: still evaluates as a no-op and is flagged as a breakpoint target",
+    async (_desc, call) => {
+      expect(await result(`${call}\n1 + 1`)).toBe("2");
+      const flagged = (await steps(`${call}\n1 + 1`)).filter(
+        step => step.markers?.[0]?.redexNodeType === "DebuggerStatement",
+      );
+      expect(flagged).toHaveLength(1);
+      expect(flagged[0].markers?.[0]?.explanation).toBe("Evaluating breakpoint statement");
+    },
+  );
 
-  test("an argument that is itself reducible is stepped through first, then flagged once all arguments are values", () => {
+  test("an argument that is itself reducible is stepped through first, then flagged once all arguments are values", async () => {
     // breakpoint(1 + 2): the argument isn't a value yet, so the statement must not be flagged as the
     // debugger target on the very first encounter — only once `1 + 2` has itself reduced to `3` (the
     // point analogous to the CSE machine's APPLICATION instruction actually firing).
     const src = "breakpoint(1 + 2)\n1 + 1";
-    const flagged = steps(src).filter(
+    const flagged = (await steps(src)).filter(
       step => step.markers?.[0]?.redexNodeType === "DebuggerStatement",
     );
     expect(flagged).toHaveLength(1);
@@ -1658,10 +1679,10 @@ describe("Python stepper — breakpoint() marks a debugger breakpoint (#188)", (
     expect(args[0].value).toBe(3n);
   });
 
-  test("aliased and called with arguments is still flagged as a breakpoint target", () => {
+  test("aliased and called with arguments is still flagged as a breakpoint target", async () => {
     const src = "bp = breakpoint\nbp(1, 2)\n1 + 1";
-    expect(result(src)).toBe("2");
-    const flagged = steps(src).filter(
+    expect(await result(src)).toBe("2");
+    const flagged = (await steps(src)).filter(
       step => step.markers?.[0]?.redexNodeType === "DebuggerStatement",
     );
     expect(flagged).toHaveLength(1);
@@ -1675,52 +1696,52 @@ describe("Python stepper — gutter-click breakpoints (#383)", () => {
   // breakpoint() detection above uses — so it surfaces identically, via `redexNodeType ===
   // "DebuggerStatement"` on the *before* marker.
 
-  function stepsWithBreakpoints(src: string, lines: number[]) {
+  async function stepsWithBreakpoints(src: string, lines: number[]) {
     const ast = parse(src + "\n");
     markBreakpoints(ast, lines);
     return getPythonSteps(ast);
   }
 
-  function flaggedExplanations(src: string, lines: number[]) {
-    return stepsWithBreakpoints(src, lines)
+  async function flaggedExplanations(src: string, lines: number[]) {
+    return (await stepsWithBreakpoints(src, lines))
       .filter(step => step.markers?.[0]?.redexNodeType === "DebuggerStatement")
       .map(step => step.markers?.[0]?.explanation);
   }
 
-  test("a click on a plain statement's line marks it as a breakpoint target", () => {
-    expect(flaggedExplanations("x = 1\ny = 2", [1])).toEqual([
+  test("a click on a plain statement's line marks it as a breakpoint target", async () => {
+    expect(await flaggedExplanations("x = 1\ny = 2", [1])).toEqual([
       "Declaring and substituting x into the rest of the block",
     ]);
   });
 
-  test("a click on a blank line snaps to the next statement", () => {
-    expect(flaggedExplanations("x = 1\n\ny = 2", [2])).toEqual([
+  test("a click on a blank line snaps to the next statement", async () => {
+    expect(await flaggedExplanations("x = 1\n\ny = 2", [2])).toEqual([
       "Declaring and substituting y into the rest of the block",
     ]);
   });
 
-  test("a click inside a function body marks that statement, not the def line", () => {
+  test("a click inside a function body marks that statement, not the def line", async () => {
     // Fires on the *first* step that reaches the `y = x + 1` line (`x` already substituted to `4`
     // by the call, so the first step is reducing `4 + 1`) — not the later "declared and
     // substituted" step, matching a debugger stopping the moment execution reaches the line.
     const src = "def f(x):\n  y = x + 1\n  return y\nf(4)";
-    expect(flaggedExplanations(src, [2])).toEqual(["Evaluating binary expression 4 + 1"]);
+    expect(await flaggedExplanations(src, [2])).toEqual(["Evaluating binary expression 4 + 1"]);
   });
 
-  test("a multi-step statement is only a breakpoint target once, not on every step it takes", () => {
+  test("a multi-step statement is only a breakpoint target once, not on every step it takes", async () => {
     // `y`'s initializer takes three expression steps (1 + 2, then + 3, then bind); a naive
     // "the whole statement is flagged" check would mark all of them. Only the first should carry
     // `redexNodeType === "DebuggerStatement"`.
-    const flagged = flaggedExplanations("y = 1 + 2 + 3", [1]);
+    const flagged = await flaggedExplanations("y = 1 + 2 + 3", [1]);
     expect(flagged).toHaveLength(1);
   });
 
-  test("a click past the end of the program marks nothing", () => {
-    expect(flaggedExplanations("x = 1", [50])).toEqual([]);
+  test("a click past the end of the program marks nothing", async () => {
+    expect(await flaggedExplanations("x = 1", [50])).toEqual([]);
   });
 
-  test("composes with an explicit breakpoint() call elsewhere in the same program", () => {
-    const flagged = flaggedExplanations("breakpoint()\nx = 1\ny = 2", [3]);
+  test("composes with an explicit breakpoint() call elsewhere in the same program", async () => {
+    const flagged = await flaggedExplanations("breakpoint()\nx = 1\ny = 2", [3]);
     expect(flagged).toEqual([
       "Evaluating breakpoint statement",
       "Declaring and substituting y into the rest of the block",
@@ -1732,31 +1753,34 @@ describe("Python stepper — cumulative print output per step", () => {
   // Each serialized step carries the program's cumulative textual output (everything `print` has
   // written) up to that step, so the host can show a running output panel that grows with the slider.
   // The field is a runner addition to the serialized step (see getSteps.ts); read it via a cast.
-  const outputs = (src: string): (string | undefined)[] =>
-    steps(src).map(s => (s as { output?: string }).output);
+  const outputs = async (src: string): Promise<(string | undefined)[]> =>
+    (await steps(src)).map(s => (s as { output?: string }).output);
 
   // Each step's explanation paired with that step's cumulative output.
-  const rows = (src: string): [string, string | undefined][] =>
-    steps(src).map(s => [s.markers?.[0]?.explanation ?? "", (s as { output?: string }).output]);
+  const rows = async (src: string): Promise<[string, string | undefined][]> =>
+    (await steps(src)).map(s => [
+      s.markers?.[0]?.explanation ?? "",
+      (s as { output?: string }).output,
+    ]);
 
-  test("a print's text appears on its 'Ran print' step, not its 'Running print' step", () => {
-    const r = rows('print("hello")');
+  test("a print's text appears on its 'Ran print' step, not its 'Running print' step", async () => {
+    const r = await rows('print("hello")');
     const running = r.find(([e]) => e === "Running print");
     const ran = r.find(([e]) => e === "Ran print");
     expect(running?.[1]).toBeUndefined(); // before the print runs, no output yet
     expect(ran?.[1]).toBe("hello\n"); // the output appears exactly on the "Ran print" step
   });
 
-  test("output is cumulative: each print appends to everything printed before it", () => {
+  test("output is cumulative: each print appends to everything printed before it", async () => {
     // Two separate prints — the second's step output includes the first's, in order.
-    const ranOutputs = rows('print("a")\nprint(1, 2)')
+    const ranOutputs = (await rows('print("a")\nprint(1, 2)'))
       .filter(([e]) => e === "Ran print")
       .map(([, o]) => o);
     expect(ranOutputs).toEqual(["a\n", "a\n1 2\n"]);
   });
 
-  test("once printed, the output persists on every later step through 'Evaluation complete'", () => {
-    const o = outputs('print("x")\n1 + 1');
+  test("once printed, the output persists on every later step through 'Evaluation complete'", async () => {
+    const o = await outputs('print("x")\n1 + 1');
     expect(o[o.length - 1]).toBe("x\n"); // still present on the terminal step
     // Every step from the "Ran print" step onward carries it; none of them drops back to empty.
     const firstWithOutput = o.findIndex(x => x === "x\n");
@@ -1764,25 +1788,177 @@ describe("Python stepper — cumulative print output per step", () => {
     expect(o.slice(firstWithOutput).every(x => x === "x\n")).toBe(true);
   });
 
-  test("formatting mirrors CPython defaults: space-separated args, trailing newline, print() is blank", () => {
-    const ran = (src: string) =>
-      rows(src)
-        .filter(([e]) => e === "Ran print")
-        .map(([, o]) => o);
-    expect(ran('print("a", "b", "c")')).toEqual(["a b c\n"]); // sep=' '
-    expect(ran("print()")).toEqual(["\n"]); // just the end='\n'
-    expect(ran("print(3 * 4)")).toEqual(["12\n"]); // the argument is reduced to a value first
-    expect(ran("print(True)\nprint(None)")).toEqual(["True\n", "True\nNone\n"]); // Python reprs
+  test("formatting mirrors CPython defaults: space-separated args, trailing newline, print() is blank", async () => {
+    const ran = async (src: string) =>
+      (await rows(src)).filter(([e]) => e === "Ran print").map(([, o]) => o);
+    expect(await ran('print("a", "b", "c")')).toEqual(["a b c\n"]); // sep=' '
+    expect(await ran("print()")).toEqual(["\n"]); // just the end='\n'
+    expect(await ran("print(3 * 4)")).toEqual(["12\n"]); // the argument is reduced to a value first
+    expect(await ran("print(True)\nprint(None)")).toEqual(["True\n", "True\nNone\n"]); // Python reprs
   });
 
-  test("a program that never prints carries no output field on any step", () => {
-    expect(outputs("1 + 1\nx = 2\nx * x").every(o => o === undefined)).toBe(true);
+  test("a program that never prints carries no output field on any step", async () => {
+    expect((await outputs("1 + 1\nx = 2\nx * x")).every(o => o === undefined)).toBe(true);
   });
 
-  test("output accumulates across a print inside a function body and a later top-level print", () => {
-    const ran = rows('def f(x):\n  print(x)\n  return x + 1\nf(5)\nprint("done")')
+  test("output accumulates across a print inside a function body and a later top-level print", async () => {
+    const ran = (await rows('def f(x):\n  print(x)\n  return x + 1\nf(5)\nprint("done")'))
       .filter(([e]) => e === "Ran print")
       .map(([, o]) => o);
     expect(ran).toEqual(["5\n", "5\ndone\n"]);
+  });
+});
+
+describe("Python stepper — import statements", () => {
+  // See py-slang#385: a program with any `from X import Y` used to report "Evaluation stuck" the
+  // instant it reached the import line, regardless of whether the imported name was ever used.
+  test("an unused import is a no-op: the program still reaches Evaluation complete", async () => {
+    expect((await explanations("from rune import circle")).pop()).toBe("Evaluation complete");
+    expect((await explanations("from rune import circle\n1 + 1")).pop()).toBe(
+      "Evaluation complete",
+    );
+  });
+
+  test("the import line itself steps as a no-op, like `pass`", async () => {
+    const e = await explanations("from rune import circle\n1 + 1");
+    expect(e).toContain("Evaluating import statement");
+    expect(e).toContain("Evaluated import statement");
+  });
+
+  test("a used import gets stuck at the point of use, not at the import line", async () => {
+    // Preprocessing accepts it (the resolver binds imported names — see resolver.ts's
+    // visitFromImportStmt); real module resolution isn't wired up yet, so the name is simply unbound
+    // once stepping reaches it, same as any other undefined name at reduction time.
+    expect(preprocess("from rune import circle\ncircle", 1)).toBeNull();
+    const e = await explanations("from rune import circle\ncircle");
+    expect(e.pop()).toBe("Evaluation stuck");
+    expect(e).toContain("Evaluated import statement"); // it got past the import line first
+  });
+
+  test("an aliased import renders its original source text, not `pass`", async () => {
+    const withAlias = (await steps("from rune import circle as c\n1 + 1"))[0].ast as unknown as {
+      body: { raw?: string }[];
+    };
+    expect(withAlias.body[0].raw).toBe("from rune import circle as c");
+  });
+
+  test("a relative import is a student-actionable error, not a silent no-op", async () => {
+    // Mirrors the CSE machine's own RelativeImportNotSupportedError: local-file imports are a
+    // separate, unimplemented feature for the stepper (see py-slang#379's py2js support, which the
+    // stepper does not share), not something that should silently degrade to "stuck" once used.
+    // Determined from the AST alone, so this rejects even with no module loader wired up (see
+    // resolveImports's own doc comment).
+    await expect(steps("from .rune import circle\n1 + 1")).rejects.toThrow(/relative import/i);
+  });
+});
+
+describe("Python stepper — real module resolution (py-slang#385)", () => {
+  // Exercises moduleInterop.ts's resolveImports/moduleToStepNode/callModuleFunction end to end,
+  // against the same GenericDataHandler + ModuleLoaderRunnerPlugin.instance every other engine's own
+  // module-interop tests use (see src/tests/py2js-from-import.test.ts's identical setup) — not a
+  // stepper-specific mock, so a bug here would also mean the conductor plumbing itself is broken.
+  function installFakeModule(exportsByModule: Record<string, FakeExport[]>) {
+    ModuleLoaderRunnerPlugin.instance = {
+      requestModule: (name: string) => {
+        const exports = exportsByModule[name];
+        if (!exports) return Promise.reject(new Error(`no such module: ${name}`));
+        return Promise.resolve({ exports });
+      },
+    } as unknown as ModuleLoaderRunnerPlugin;
+  }
+
+  afterEach(() => {
+    ModuleLoaderRunnerPlugin.instance = null;
+  });
+
+  test("a constant export is substituted as a literal, like a built-in constant", async () => {
+    const dh = new GenericDataHandler();
+    installFakeModule({
+      physics: [{ symbol: "GRAVITY", value: { type: DataType.NUMBER, value: 9.8 } }],
+    });
+    const ast = parse("from physics import GRAVITY\nGRAVITY * 2\n");
+    expect(await evaluatePython(ast, dh)).toBe("19.6");
+  });
+
+  test("a function export is called through, sync-fast-path or not, and its result is usable", async () => {
+    const dh = new GenericDataHandler();
+    async function* doubleFunc(
+      a: TypedValue<DataType>,
+    ): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+      await Promise.resolve(); // conductor's ExternCallable contract requires an async generator
+      return { type: DataType.NUMBER, value: (a as TypedValue<DataType.NUMBER>).value * 2 };
+    }
+    const double = await dh.closure_make(
+      { returnType: DataType.NUMBER, args: [DataType.NUMBER] },
+      doubleFunc,
+    );
+    installFakeModule({ mathmod: [{ symbol: "double", value: double }] });
+    const ast = parse("from mathmod import double\ndouble(21) + 1\n");
+    expect(await evaluatePython(ast, dh)).toBe("43.0");
+  });
+
+  test("an opaque return value completes the program (renders as its label, never inspected)", async () => {
+    const dh = new GenericDataHandler();
+    class Thing {}
+    async function* makeThingFunc(): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+      await Promise.resolve();
+      return dh.opaque_make(new Thing());
+    }
+    const makeThing = await dh.closure_make(
+      { returnType: DataType.OPAQUE, args: [] },
+      makeThingFunc,
+    );
+    installFakeModule({ visualmod: [{ symbol: "make_thing", value: makeThing }] });
+    // `explanations`/`steps` (this file's own helpers) never pass an evaluator through — calling
+    // getPythonSteps directly here, as every test in this describe block does, is what actually wires
+    // `dh` in.
+    const ast = parse("from visualmod import make_thing\nmake_thing()\n");
+    const stepped = await getPythonSteps(ast, undefined, dh);
+    expect(stepped.at(-1)?.markers?.[0]?.explanation).toBe("Evaluation complete");
+    const last = stepped.at(-1)!.ast as unknown as { body: unknown[] };
+    expect(last.body).toEqual([]); // the opaque value was discarded like any other statement value
+
+    // A *used* opaque value (assigned, not just created-and-discarded) renders as its label.
+    const usedAst = parse("from visualmod import make_thing\nx = make_thing()\nx\n");
+    const usedSteps = await getPythonSteps(usedAst, undefined, dh);
+    const withOpaque = usedSteps.find(s => findNode(s.ast, (n: any) => n.type === "Opaque"));
+    expect(withOpaque).toBeDefined();
+    const opaqueNode = findNode(withOpaque!.ast, (n: any) => n.type === "Opaque");
+    expect(opaqueNode.label).toBe("Thing");
+  });
+
+  test("a Python closure argument is declined — the call stays stuck, not silently wrong", async () => {
+    // See moduleInterop.ts's module doc comment: forwarding a Python-authored callable into a module
+    // call would need the module to call back into Python, which this design explicitly doesn't
+    // support yet — an honest "Evaluation stuck", the same degrade `input()` already gets.
+    const dh = new GenericDataHandler();
+    async function* applyFunc(): AsyncGenerator<void, TypedValue<DataType>, undefined> {
+      await Promise.resolve();
+      throw new Error("should never be invoked — the call must stay stuck before reaching here");
+    }
+    const apply = await dh.closure_make(
+      { returnType: DataType.NUMBER, args: [DataType.VOID] },
+      applyFunc,
+    );
+    installFakeModule({ hofmod: [{ symbol: "apply", value: apply }] });
+    const ast = parse("from hofmod import apply\napply(lambda x: x)\n");
+    const steppedResult = await getPythonSteps(ast, undefined, dh);
+    expect(steppedResult.at(-1)?.markers?.[0]?.explanation).toBe("Evaluation stuck");
+  });
+
+  test("a missing module is a clear error, not a silent unbound name", async () => {
+    const dh = new GenericDataHandler();
+    installFakeModule({});
+    const ast = parse("from nosuchmodule import x\nx\n");
+    await expect(getPythonSteps(ast, undefined, dh)).rejects.toThrow(/not found/i);
+  });
+
+  test("a name a module doesn't export is a clear error", async () => {
+    const dh = new GenericDataHandler();
+    installFakeModule({
+      mathmod: [{ symbol: "double", value: { type: DataType.NUMBER, value: 1 } }],
+    });
+    const ast = parse("from mathmod import triple\ntriple\n");
+    await expect(getPythonSteps(ast, undefined, dh)).rejects.toThrow(/cannot import name 'triple'/);
   });
 });

--- a/src/conductor/stepper/ast.ts
+++ b/src/conductor/stepper/ast.ts
@@ -31,6 +31,50 @@ export function literal(value: unknown, raw: string, pyFloat = false): StepNode 
   return { type: "Literal", value, raw, pyFloat };
 }
 
+/**
+ * An opaque value from an imported module (e.g. a `rune` `Rune`) whose payload has no representation
+ * in the stepper's value model — unlike every other {@link StepNode} value it is never inspected or
+ * decomposed, only ever substituted around and passed to further calls (including back into another
+ * module call — see `moduleInterop.ts`'s `stepNodeToModule`, which reads `handle` back out for exactly
+ * that). `label` is a short display name (ideally the underlying payload's own constructor name, e.g.
+ * `"Rune"`; `"opaque"` if that isn't available) shown as `<label>` — see {@link unparse}'s `"Opaque"`
+ * case. `handle` is the underlying `TypedValue<DataType.OPAQUE>` (kept as `unknown` here so `ast.ts`
+ * stays free of any conductor-specific type — `moduleInterop.ts` does the casting). `dataUrl` is an
+ * optional rendered thumbnail a module may supply (see source-academy/modules#879); unset until a
+ * module opts into that convention, and not yet rendered by the host — reserved here so the field
+ * survives `substitute`/`clone` (both copy unknown fields structurally) once host rendering catches up.
+ */
+export function opaqueValue(label: string, handle: unknown, dataUrl?: string): StepNode {
+  const node: StepNode = { type: "Opaque", label, handle };
+  if (dataUrl !== undefined) node.dataUrl = dataUrl;
+  return node;
+}
+
+/**
+ * A callable exported by an imported module (e.g. `rune`'s `circle`) — the stepper's analogue of a
+ * `def`/`lambda` value, but with no Python body to substitute into: calling it (see `reduce.ts`'s
+ * `contractCall`) round-trips through the module via `closure` instead. `closure` is the underlying
+ * `TypedValue<DataType.CLOSURE>` handle (kept as `unknown` for the same reason as `opaqueValue`'s
+ * `handle`); `minArgs` backs the `arity()` built-in exactly like a `def`/`lambda`'s parameter count.
+ * Substituted into the program in place of the imported name before stepping begins (see
+ * `getSteps.ts`'s `resolveImports`), exactly like a built-in constant or a bound `def` — never looked
+ * up by name at call time, so nothing needs threading through the reducer beyond the one `evaluator`
+ * parameter `contractCall` needs to actually place the call.
+ */
+export function moduleFunction(name: string, closure: unknown, minArgs: number): StepNode {
+  return { type: "ModuleFunction", name, closure, minArgs };
+}
+
+/** Whether `node` is an opaque module value. See {@link opaqueValue}. */
+export function isOpaqueNode(node: StepNode): boolean {
+  return node.type === "Opaque";
+}
+
+/** Whether `node` is a callable imported from a module. See {@link moduleFunction}. */
+export function isModuleFunctionNode(node: StepNode): boolean {
+  return node.type === "ModuleFunction";
+}
+
 /** Python's textual form of a JS `number`: `inf`/`-inf`/`nan` for the specials, and a trailing `.0`
  * for an integer-valued float (so `4 / 2` reads `2.0`, like Python). Shared by the reducer and the
  * builtin library so all float results display consistently. */
@@ -153,6 +197,8 @@ export function isValue(node: StepNode): boolean {
     case "Identifier":
     case "ArrowFunctionExpression":
     case "FunctionDeclaration":
+    case "Opaque":
+    case "ModuleFunction":
       return true;
     case "ArrayExpression":
       return (node.elements as StepNode[]).every(isValue);
@@ -177,6 +223,8 @@ export function isResultValue(node: StepNode): boolean {
     case "Literal":
     case "ArrowFunctionExpression":
     case "FunctionDeclaration":
+    case "Opaque":
+    case "ModuleFunction":
       return true;
     case "ArrayExpression":
       return (node.elements as StepNode[]).every(isResultValue);
@@ -313,6 +361,10 @@ export function unparse(node: StepNode | null | undefined): string {
       return String((node.id as StepNode).name);
     case "ArrayExpression":
       return `[${(node.elements as StepNode[]).map(unparse).join(", ")}]`;
+    case "Opaque":
+      return `<${node.label}>`;
+    case "ModuleFunction":
+      return String(node.name);
     default:
       return `<${node.type}>`;
   }

--- a/src/conductor/stepper/ast.ts
+++ b/src/conductor/stepper/ast.ts
@@ -55,14 +55,22 @@ export function opaqueValue(label: string, handle: unknown, dataUrl?: string): S
  * `def`/`lambda` value, but with no Python body to substitute into: calling it (see `reduce.ts`'s
  * `contractCall`) round-trips through the module via `closure` instead. `closure` is the underlying
  * `TypedValue<DataType.CLOSURE>` handle (kept as `unknown` for the same reason as `opaqueValue`'s
- * `handle`); `minArgs` backs the `arity()` built-in exactly like a `def`/`lambda`'s parameter count.
- * Substituted into the program in place of the imported name before stepping begins (see
- * `getSteps.ts`'s `resolveImports`), exactly like a built-in constant or a bound `def` — never looked
- * up by name at call time, so nothing needs threading through the reducer beyond the one `evaluator`
- * parameter `contractCall` needs to actually place the call.
+ * `handle`); `minArgs` backs the `arity()` built-in exactly like a `def`/`lambda`'s parameter count,
+ * and (together with `isVararg`) the arity check `contractCall` runs before actually placing a call —
+ * `isVararg: false` means `minArgs` is an exact count (like a built-in's `min === max`), `true` means
+ * it's only a lower bound (extra arguments are collected by the module's own closure). Substituted
+ * into the program in place of the imported name before stepping begins (see `getSteps.ts`'s
+ * `resolveImports`), exactly like a built-in constant or a bound `def` — never looked up by name at
+ * call time, so nothing needs threading through the reducer beyond the one `evaluator` parameter
+ * `contractCall` needs to actually place the call.
  */
-export function moduleFunction(name: string, closure: unknown, minArgs: number): StepNode {
-  return { type: "ModuleFunction", name, closure, minArgs };
+export function moduleFunction(
+  name: string,
+  closure: unknown,
+  minArgs: number,
+  isVararg: boolean,
+): StepNode {
+  return { type: "ModuleFunction", name, closure, minArgs, isVararg };
 }
 
 /** Whether `node` is an opaque module value. See {@link opaqueValue}. */

--- a/src/conductor/stepper/builtins.ts
+++ b/src/conductor/stepper/builtins.ts
@@ -24,6 +24,8 @@ import {
   type StepNode,
   complexLiteral,
   isComplexValue,
+  isModuleFunctionNode,
+  isOpaqueNode,
   isPairNode,
   isResultValue,
   literal,
@@ -107,6 +109,7 @@ const isNumberNode = (n: StepNode): boolean => isIntNode(n) || isFloatNode(n) ||
 const isFunctionNode = (n: StepNode): boolean =>
   n.type === "ArrowFunctionExpression" ||
   n.type === "FunctionDeclaration" ||
+  n.type === "ModuleFunction" ||
   (n.type === "Identifier" && isBuiltinFunctionName(String(n.name)));
 
 /* node constructors */
@@ -417,6 +420,9 @@ Object.assign(BUILTIN_FUNCTIONS, {
     if (f.type === "Identifier" && isBuiltinFunctionName(String(f.name))) {
       return intLiteral(BigInt(BUILTIN_MIN_ARGS[String(f.name)] ?? 1));
     }
+    if (isModuleFunctionNode(f)) {
+      return intLiteral(BigInt(f.minArgs as number));
+    }
     return typeError("arity() argument must be a function");
   },
   print: (args: StepNode[]): StepNode => {
@@ -485,6 +491,7 @@ function pyTypeName(node: StepNode): string {
   if (isNoneNode(node)) return "NoneType";
   if (isPairNode(node)) return "pair";
   if (isFunctionNode(node)) return "function";
+  if (isOpaqueNode(node)) return String(node.label);
   return node.type;
 }
 

--- a/src/conductor/stepper/builtins.ts
+++ b/src/conductor/stepper/builtins.ts
@@ -149,7 +149,10 @@ export function formatPrintOutput(args: StepNode[]): string {
   return args.map(a => pyStr(a, false)).join(" ") + "\n";
 }
 
-function checkArity(name: string, args: StepNode[], min: number, max: number | null): void {
+/** Validates `args.length` against `[min, max]` (`max: null` means "at least `min`", i.e. variadic),
+ * throwing a Python-style `TypeError` shaped like a wrong-arity call to any callable — a static
+ * built-in here, or an imported `ModuleFunction` (see `reduce.ts`'s `contractCall`). */
+export function checkArity(name: string, args: StepNode[], min: number, max: number | null): void {
   if (args.length < min || (max !== null && args.length > max)) {
     const want = max === null ? `at least ${min}` : min === max ? `${min}` : `${min} to ${max}`;
     typeError(`${name}() takes ${want} argument(s) but ${args.length} were given`);

--- a/src/conductor/stepper/getSteps.ts
+++ b/src/conductor/stepper/getSteps.ts
@@ -13,10 +13,12 @@ import type {
   SerializedStepperNode,
   SerializedStepperStep,
 } from "@sourceacademy/common-stepper";
+import type { IDataHandler } from "@sourceacademy/conductor/types";
 
 import type { StmtNS } from "../../ast-types";
 import { type StepNode, unparse } from "./ast";
 import { isStepperValue, substituteBuiltinConstants } from "./builtins";
+import { resolveImports } from "./moduleInterop";
 import { reduceProgram } from "./reduce";
 import { translateProgram } from "./translate";
 
@@ -64,7 +66,11 @@ function isComplete(prog: StepNode): boolean {
   return false;
 }
 
-function drive(prog: StepNode, contractionLimit: number): Step[] {
+async function drive(
+  prog: StepNode,
+  contractionLimit: number,
+  evaluator: IDataHandler | undefined,
+): Promise<Step[]> {
   // The program's cumulative output so far. A `print(...)` contraction reports its text via
   // `result.output`; we append it *between* that contraction's before and after steps, so the text
   // first appears on the "Ran print" (after) step and persists on every step after it. Every step
@@ -82,9 +88,9 @@ function drive(prog: StepNode, contractionLimit: number): Step[] {
 
   let current = prog;
   for (let i = 0; i < contractionLimit; i++) {
-    let result: ReturnType<typeof reduceProgram>;
+    let result: Awaited<ReturnType<typeof reduceProgram>>;
     try {
-      result = reduceProgram(current);
+      result = await reduceProgram(current, evaluator);
     } catch (error) {
       // A runtime error during reduction (e.g. ZeroDivisionError): evaluation is stuck. Show the
       // error as the redex explanation on the current tree, then a terminal "Evaluation stuck" step,
@@ -233,16 +239,23 @@ function serializeStep(step: Step): SerializedStep {
  *
  * @param fileInput The parsed Python program.
  * @param stepLimit Maximum number of *steps* (two per contraction); defaults to 1000.
+ * @param evaluator The conductor module-interop handle (`IDataHandler`) used to resolve this
+ * program's `FromImport`s, if any — see `moduleInterop.ts`'s `resolveImports`. `undefined` when no
+ * module loader is wired up (e.g. a test calling this directly); every imported name is then simply
+ * left unbound, exactly as if this parameter didn't exist.
  */
-export function getPythonSteps(
+export async function getPythonSteps(
   fileInput: StmtNS.FileInput,
   stepLimit = 2 * DEFAULT_CONTRACTION_LIMIT,
-): SerializedStepperStep[] {
+  evaluator?: IDataHandler,
+): Promise<SerializedStepperStep[]> {
   const contractionLimit = Math.max(1, Math.floor(stepLimit / 2));
   // Built-in constants (math_pi, …) are substituted in up front so they render as their value from
-  // the first step, matching js-slang's stepper — see {@link substituteBuiltinConstants}.
-  const program = substituteBuiltinConstants(translateProgram(fileInput));
-  return drive(program, contractionLimit).map(serializeStep);
+  // the first step, matching js-slang's stepper — see {@link substituteBuiltinConstants}. Imported
+  // names are resolved and substituted the same way, immediately after — see `resolveImports`.
+  const translated = substituteBuiltinConstants(translateProgram(fileInput));
+  const program = await resolveImports(fileInput, evaluator, translated);
+  return (await drive(program, contractionLimit, evaluator)).map(serializeStep);
 }
 
 /**
@@ -252,9 +265,20 @@ export function getPythonSteps(
  * program value; see `reduceProgram`) — so we remember the last top-level expression's text as the
  * program reduces, just before it is discarded, and echo that. The stepper's reduction *is* the
  * program's value in the substitution model, so no separate interpreter is needed.
+ *
+ * @param evaluator See `getPythonSteps`'s identical parameter.
  */
-export function evaluatePython(fileInput: StmtNS.FileInput): string {
-  let current = substituteBuiltinConstants(translateProgram(fileInput));
+export async function evaluatePython(
+  fileInput: StmtNS.FileInput,
+  evaluator?: IDataHandler,
+): Promise<string> {
+  const translated = substituteBuiltinConstants(translateProgram(fileInput));
+  // Import resolution is deliberately outside the try/catch below: a `ModuleImportError` (module not
+  // found, a relative import, a name a module doesn't export) is a student-actionable, preprocessing-
+  // shaped error — it should propagate to the caller exactly like a `preprocessPython` error does, not
+  // be swallowed into the REPL's result text the way a mid-reduction runtime fault (e.g.
+  // ZeroDivisionError) is below.
+  let current = await resolveImports(fileInput, evaluator, translated);
   let resultRepr = "";
   try {
     for (let i = 0; i < DEFAULT_CONTRACTION_LIMIT; i++) {
@@ -267,7 +291,7 @@ export function evaluatePython(fileInput: StmtNS.FileInput): string {
         const expr = last.expression as StepNode;
         resultRepr = expr.type === "Literal" ? String(expr.raw ?? expr.value) : unparse(expr);
       }
-      const result = reduceProgram(current);
+      const result = await reduceProgram(current, evaluator);
       if (result === null) break;
       current = result.node;
     }

--- a/src/conductor/stepper/moduleInterop.ts
+++ b/src/conductor/stepper/moduleInterop.ts
@@ -44,8 +44,16 @@ import { isBuiltinFunctionName } from "./builtins";
 
 /** Thrown for a student-actionable import problem (module not found, name not exported, a relative
  * import) — surfaced by `getSteps.ts`'s callers the same way a preprocessing error is, rather than
- * left to manifest later as a confusing "Evaluation stuck" deep into a run. */
-export class ModuleImportError extends Error {}
+ * left to manifest later as a confusing "Evaluation stuck" deep into a run. `cause` (when the loader
+ * itself rejected, e.g. a module-not-found case) is set as a plain field rather than via `Error`'s
+ * two-argument constructor: this project's `lib` target predates `ErrorOptions`/`cause`. */
+export class ModuleImportError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.cause = options?.cause;
+  }
+  readonly cause?: unknown;
+}
 
 /** Thrown internally by `stepNodeToModule` for a value shape this interop layer cannot cross the
  * module boundary with. Turned into a graceful "Evaluation stuck" by `contractCall`, exactly like any
@@ -162,8 +170,11 @@ export async function moduleToStepNode(
       return opaqueValue(ctorName ?? "opaque", value);
     }
     case DataType.CLOSURE: {
-      const minArgs = await evaluator.closure_arity(value);
-      return moduleFunction(name, value, minArgs);
+      const [minArgs, isVararg] = await Promise.all([
+        evaluator.closure_arity(value),
+        evaluator.closure_is_vararg(value),
+      ]);
+      return moduleFunction(name, value, minArgs, isVararg);
     }
     case DataType.PAIR:
     case DataType.ARRAY: {
@@ -249,17 +260,20 @@ export async function resolveImports(
   const loader = ModuleLoaderRunnerPlugin.instance;
 
   const moduleNames = [...new Set(imports.map(s => s.module.lexeme))];
-  const plugins = new Map(
-    await Promise.all(
-      moduleNames.map(async moduleName => {
-        try {
-          return [moduleName, await loader.requestModule(moduleName)] as const;
-        } catch {
-          throw new ModuleImportError(`Module "${moduleName}" not found.`);
-        }
-      }),
-    ),
-  );
+  // `allSettled`, not `all`: every module is requested regardless of whether an earlier one
+  // rejects, so a second rejection is observed (and its promise handled) rather than becoming an
+  // unhandled rejection racing the first one's `throw` below. `cause` preserves the loader's own
+  // rejection reason (a genuine load failure, not just "not found") for diagnosis.
+  const settled = await Promise.allSettled(moduleNames.map(name => loader.requestModule(name)));
+  const plugins = new Map<string, Awaited<ReturnType<typeof loader.requestModule>>>();
+  for (let i = 0; i < settled.length; i++) {
+    const outcome = settled[i];
+    const moduleName = moduleNames[i];
+    if (outcome.status === "rejected") {
+      throw new ModuleImportError(`Module "${moduleName}" not found.`, { cause: outcome.reason });
+    }
+    plugins.set(moduleName, outcome.value);
+  }
 
   // Binding runs sequentially in source order (not concurrently) so two imports binding the same
   // name resolve deterministically — last one in source order wins, matching plain reassignment —

--- a/src/conductor/stepper/moduleInterop.ts
+++ b/src/conductor/stepper/moduleInterop.ts
@@ -1,0 +1,285 @@
+/**
+ * Module interop for the Python substitution stepper (`from X import Y`, py-slang#385).
+ *
+ * The stepper's own `StepNode`-flavoured sibling of `src/engines/cse/modules.ts`'s
+ * `moduleToPython`/`pythonToModule` — and, like `src/engines/py2js/moduleInterop.ts`, a second proof
+ * that conductor's module protocol doesn't require the CSE machine's own control/stash re-entrant
+ * instruction loop to consume: a plain recursive `async`/`await` conversion layer is enough, as long
+ * as the engine calling it has an `async` path of its own to await from (see `reduce.ts`'s
+ * `contractCall`, which is what this module is called from).
+ *
+ * Scope, deliberately narrower than the other two engines: a Python-authored callable (a `lambda`/
+ * `def`, or a bare reference to a static built-in) is never converted into a module argument — see
+ * `isPythonCallable`. Forwarding one would require the module to call back into Python mid-call,
+ * which (unlike CSE's `modules.ts`, whose `"closure"` case re-enters its own control/stash loop, or
+ * py2js's, which recurses into its own async interpreter entry point) the substitution reducer has no
+ * way to do without re-entering its own step machinery — out of scope for this pass. A call shaped
+ * that way simply doesn't reduce (irreducible → "Evaluation stuck"), the same honest degrade
+ * `builtins.ts` already documents for `input()`/`time_time()`. A `ModuleFunction` value (an *already*
+ * module-owned closure — see `ast.ts`) is fine to forward: passing it back never re-enters Python,
+ * only the module's own native call machinery.
+ *
+ * `callModuleFunction` tries `IDataHandler.closure_call_sync` first (a genuinely synchronous escape
+ * hatch a module's exported closure may opt into — see `GenericDataHandler.closure_call_sync`'s doc
+ * comment) before falling back to draining the mandatory `closure_call_unchecked` async generator.
+ * Per that same doc comment essentially no module (including presumably `rune`) opts in today, so
+ * this doesn't remove the need for the `async` path, but it costs nothing to prefer it when available.
+ */
+
+import { DataType, type IDataHandler, type TypedValue } from "@sourceacademy/conductor/types";
+import { ModuleLoaderRunnerPlugin } from "@sourceacademy/runner-module-loader";
+
+import type { StmtNS } from "../../ast-types";
+import { RELATIVE_IMPORT_NOT_SUPPORTED_MESSAGE } from "../../errors";
+import {
+  literal,
+  moduleFunction,
+  numberLiteral,
+  opaqueValue,
+  type StepNode,
+  stringLiteral,
+  substitute,
+} from "./ast";
+import { isBuiltinFunctionName } from "./builtins";
+
+/** Thrown for a student-actionable import problem (module not found, name not exported, a relative
+ * import) — surfaced by `getSteps.ts`'s callers the same way a preprocessing error is, rather than
+ * left to manifest later as a confusing "Evaluation stuck" deep into a run. */
+export class ModuleImportError extends Error {}
+
+/** Thrown internally by `stepNodeToModule` for a value shape this interop layer cannot cross the
+ * module boundary with. Turned into a graceful "Evaluation stuck" by `contractCall`, exactly like any
+ * other runtime fault the reducer raises — never allowed to escape as an unhandled rejection. */
+class ModuleInteropUnsupportedError extends Error {}
+
+/** A genuine Python-authored callable — the one value shape `stepNodeToModule` declines to forward
+ * into a module call. See the module doc comment. */
+function isPythonCallable(node: StepNode): boolean {
+  return (
+    node.type === "ArrowFunctionExpression" ||
+    node.type === "FunctionDeclaration" ||
+    (node.type === "Identifier" && isBuiltinFunctionName(String(node.name)))
+  );
+}
+
+/** Converts a stepper value into a conductor `TypedValue`, for passing into a module call as an
+ * argument. Mirrors `pythonToModule` in `src/engines/cse/modules.ts`, restricted per the module doc
+ * comment above. Throws `ModuleInteropUnsupportedError` for anything it cannot convert. */
+export async function stepNodeToModule(
+  evaluator: IDataHandler,
+  node: StepNode,
+): Promise<TypedValue<DataType>> {
+  if (isPythonCallable(node)) {
+    throw new ModuleInteropUnsupportedError(
+      "a Python function value cannot be passed to an imported module function here",
+    );
+  }
+  switch (node.type) {
+    case "Literal": {
+      const v = node.value;
+      if (v === null) return { type: DataType.EMPTY_LIST, value: null };
+      if (typeof v === "boolean") return { type: DataType.BOOLEAN, value: v };
+      if (typeof v === "bigint") return { type: DataType.NUMBER, value: Number(v) };
+      if (typeof v === "number") return { type: DataType.NUMBER, value: v };
+      if (typeof v === "string") return { type: DataType.CONST_STRING, value: v };
+      // A complex number: not supported crossing the module boundary, mirroring CSE's/py2js's
+      // identical restriction.
+      throw new ModuleInteropUnsupportedError("complex values are not supported in module interop");
+    }
+    case "ArrayExpression": {
+      const elements = await Promise.all(
+        (node.elements as StepNode[]).map(el => stepNodeToModule(evaluator, el)),
+      );
+      const array = await evaluator.array_make(DataType.ANY, elements.length, {
+        type: DataType.VOID,
+        value: undefined,
+      });
+      for (let i = 0; i < elements.length; i++) {
+        await evaluator.array_set(
+          array as unknown as TypedValue<DataType.ARRAY, DataType.VOID>,
+          i,
+          elements[i],
+        );
+      }
+      return array;
+    }
+    case "Opaque":
+      return node.handle as TypedValue<DataType.OPAQUE>;
+    case "ModuleFunction":
+      return node.closure as TypedValue<DataType.CLOSURE>;
+    default:
+      throw new ModuleInteropUnsupportedError(
+        `a ${node.type} value cannot be passed to an imported module function here`,
+      );
+  }
+}
+
+/** Reads a PAIR or ARRAY's elements uniformly — see the identical helper's doc comment in
+ * `src/engines/cse/modules.ts`. */
+async function readCompoundElements(
+  evaluator: IDataHandler,
+  value: TypedValue<DataType.ARRAY> | TypedValue<DataType.PAIR>,
+): Promise<TypedValue<DataType>[]> {
+  if (value.type === DataType.PAIR) {
+    return [await evaluator.pair_head(value), await evaluator.pair_tail(value)];
+  }
+  const length = await evaluator.array_length(value);
+  return Promise.all(Array.from({ length }, (_, i) => evaluator.array_get(value, i)));
+}
+
+/** Converts a conductor `TypedValue` into a stepper value — a module export flowing into a Python
+ * program, or a module function's return value. Mirrors `moduleToPython` in
+ * `src/engines/cse/modules.ts`. `name` labels a `DataType.CLOSURE` result (the display name calls to
+ * it render as); defaults to a generic label for one reached indirectly (e.g. a module function
+ * returning another as its result). */
+export async function moduleToStepNode(
+  evaluator: IDataHandler,
+  value: TypedValue<DataType>,
+  name = "<module function>",
+): Promise<StepNode> {
+  switch (value.type) {
+    case DataType.NUMBER:
+      // A module number is always a float — mirrors CSE's/py2js's identical stance (integers stay
+      // out of the module interface entirely).
+      return numberLiteral(value.value, true);
+    case DataType.INTEGER:
+      // py-slang never produces DataType.INTEGER itself; only here for switch exhaustiveness over
+      // conductor's DataType enum, mirroring the other two engines' identical case.
+      return numberLiteral(Number(value.value), true);
+    case DataType.BOOLEAN:
+      return literal(value.value, value.value ? "True" : "False");
+    case DataType.CONST_STRING:
+      return stringLiteral(value.value);
+    case DataType.VOID:
+    case DataType.EMPTY_LIST:
+      return literal(null, "None");
+    case DataType.OPAQUE: {
+      const payload = await evaluator.opaque_get(value);
+      const ctorName =
+        payload !== null && typeof payload === "object"
+          ? (payload as { constructor?: { name?: string } }).constructor?.name
+          : undefined;
+      return opaqueValue(ctorName ?? "opaque", value);
+    }
+    case DataType.CLOSURE: {
+      const minArgs = await evaluator.closure_arity(value);
+      return moduleFunction(name, value, minArgs);
+    }
+    case DataType.PAIR:
+    case DataType.ARRAY: {
+      // Untyped and recursive, uniformly for both — mirrors CSE's/py2js's identical non-distinction
+      // between a PAIR and an ARRAY (e.g. sound's Sound is a (wave, duration) dotted pair).
+      const elements = await readCompoundElements(evaluator, value);
+      const converted = await Promise.all(
+        elements.map(el => moduleToStepNode(evaluator, el, name)),
+      );
+      return { type: "ArrayExpression", elements: converted };
+    }
+  }
+}
+
+/**
+ * Calls an imported module function. Tries the synchronous fast path first (see the module doc
+ * comment), falling back to draining the mandatory async-generator call. Throws
+ * `ModuleInteropUnsupportedError` (caught by `contractCall`, same as any other runtime fault) if an
+ * argument can't cross the module boundary — see `stepNodeToModule`.
+ */
+export async function callModuleFunction(
+  evaluator: IDataHandler,
+  closure: TypedValue<DataType.CLOSURE>,
+  name: string,
+  args: StepNode[],
+): Promise<StepNode> {
+  const moduleArgs = await Promise.all(args.map(a => stepNodeToModule(evaluator, a)));
+  const syncCall = (
+    evaluator as IDataHandler & {
+      closure_call_sync?: (
+        c: TypedValue<DataType.CLOSURE>,
+        callArgs: TypedValue<DataType>[],
+      ) => TypedValue<DataType> | undefined;
+    }
+  ).closure_call_sync?.bind(evaluator);
+  const syncResult = syncCall?.(closure, moduleArgs);
+  if (syncResult !== undefined) {
+    return moduleToStepNode(evaluator, syncResult, name);
+  }
+  const gen = evaluator.closure_call_unchecked(closure, moduleArgs);
+  let step = await gen.next();
+  while (!step.done) step = await gen.next();
+  return moduleToStepNode(evaluator, step.value, name);
+}
+
+/**
+ * Resolves and binds every `FromImport` a program uses, before stepping begins — mirroring
+ * `src/engines/cse/modules.ts`'s `loadModules`/`evaluateImports` (module loading happens once, ahead
+ * of running/stepping the program itself, matching every other py-slang evaluator's two-phase model).
+ * Each imported name is substituted directly into `program` (exactly like `substituteBuiltinConstants`
+ * substitutes a built-in constant) rather than looked up by name at call time, so nothing needs
+ * threading through the reducer beyond the one `evaluator` parameter `contractCall` needs to actually
+ * place a call.
+ *
+ * `evaluator` is `undefined` when no module loader is wired up (e.g. a bare `getPythonSteps()` call in
+ * a test, or `PyStepperEvaluatorBase` in a host that hasn't registered `ModuleLoaderRunnerPlugin`) —
+ * every imported name is then simply left unbound, exactly matching this file's absence: a program
+ * that never uses the name still reaches "Evaluation complete" (`translate.ts`'s `FromImport` → a
+ * no-op statement), one that does gets stuck at the point of use, not here. A relative import, a
+ * missing module, or a name a module doesn't export are all *student-actionable* mistakes, though, so
+ * once an evaluator genuinely is available those throw `ModuleImportError` rather than degrading —
+ * mirrors how CSE (`RelativeImportNotSupportedError`/`ModuleNotFoundError`) and py2js
+ * (`loadChunkImports`) both treat the identical cases as hard errors, not silent no-ops.
+ */
+export async function resolveImports(
+  fileInput: StmtNS.FileInput,
+  evaluator: IDataHandler | undefined,
+  program: StepNode,
+): Promise<StepNode> {
+  const imports = fileInput.statements.filter(
+    (s): s is StmtNS.FromImport => s.kind === "FromImport",
+  );
+  if (imports.length === 0) return program;
+
+  const offending = imports.find(s => s.level > 0);
+  if (offending !== undefined) {
+    throw new ModuleImportError(RELATIVE_IMPORT_NOT_SUPPORTED_MESSAGE);
+  }
+
+  if (evaluator === undefined || ModuleLoaderRunnerPlugin.instance === null) {
+    return program;
+  }
+  const loader = ModuleLoaderRunnerPlugin.instance;
+
+  const moduleNames = [...new Set(imports.map(s => s.module.lexeme))];
+  const plugins = new Map(
+    await Promise.all(
+      moduleNames.map(async moduleName => {
+        try {
+          return [moduleName, await loader.requestModule(moduleName)] as const;
+        } catch {
+          throw new ModuleImportError(`Module "${moduleName}" not found.`);
+        }
+      }),
+    ),
+  );
+
+  // Binding runs sequentially in source order (not concurrently) so two imports binding the same
+  // name resolve deterministically — last one in source order wins, matching plain reassignment —
+  // rather than racing on whichever conversion happens to finish last; mirrors py2js's
+  // `loadChunkImports`' identical ordering rationale.
+  let result = program;
+  for (const stmt of imports) {
+    const moduleName = stmt.module.lexeme;
+    const exportsByName = new Map(plugins.get(moduleName)!.exports.map(e => [e.symbol, e.value]));
+    for (const spec of stmt.names) {
+      const exportValue = exportsByName.get(spec.name.lexeme);
+      if (exportValue === undefined) {
+        throw new ModuleImportError(
+          `cannot import name '${spec.name.lexeme}' from '${moduleName}'`,
+        );
+      }
+      const bound = (spec.alias ?? spec.name).lexeme;
+      const value = await moduleToStepNode(evaluator, exportValue, spec.name.lexeme);
+      result = substitute(result, bound, value);
+    }
+  }
+  return result;
+}

--- a/src/conductor/stepper/reduce.ts
+++ b/src/conductor/stepper/reduce.ts
@@ -45,7 +45,13 @@ import {
   substitute,
   unparse,
 } from "./ast";
-import { applyBuiltin, formatPrintOutput, isBuiltinFunctionName, isStepperValue } from "./builtins";
+import {
+  applyBuiltin,
+  checkArity,
+  formatPrintOutput,
+  isBuiltinFunctionName,
+  isStepperValue,
+} from "./builtins";
 import { formatPrintLlistOutput } from "./lists";
 import { callModuleFunction } from "./moduleInterop";
 
@@ -620,6 +626,11 @@ async function contractCall(
       throw new Error(`NameError: name '${String(callee.name)}' is not defined`);
     }
     const name = String(callee.name);
+    const minArgs = callee.minArgs as number;
+    // Checked up front, like a static built-in's own `checkArity` call inside `applyBuiltin` — a
+    // wrong-arity call gets a proper Python-style TypeError instead of whatever native error falls
+    // out of spreading a mismatched argument list into the module's own closure.
+    checkArity(name, args, minArgs, callee.isVararg ? null : minArgs);
     const result = await callModuleFunction(
       evaluator,
       callee.closure as TypedValue<DataType.CLOSURE>,

--- a/src/conductor/stepper/reduce.ts
+++ b/src/conductor/stepper/reduce.ts
@@ -23,6 +23,8 @@
  * bounded only by the step limit — a non-terminating recursion stops at "Maximum number of steps".
  */
 
+import type { DataType, IDataHandler, TypedValue } from "@sourceacademy/conductor/types";
+
 import {
   type ComplexValue,
   type StepNode,
@@ -31,6 +33,7 @@ import {
   isComplexValue,
   isEmptyList,
   isFunctionValue,
+  isModuleFunctionNode,
   isPairNode,
   isResultValue,
   isTruthy,
@@ -44,6 +47,7 @@ import {
 } from "./ast";
 import { applyBuiltin, formatPrintOutput, isBuiltinFunctionName, isStepperValue } from "./builtins";
 import { formatPrintLlistOutput } from "./lists";
+import { callModuleFunction } from "./moduleInterop";
 
 export interface ReduceResult {
   /** The program/expression after this single contraction — becomes `current` for the next step. */
@@ -571,7 +575,10 @@ function contractConditional(node: StepNode): ReduceResult {
   };
 }
 
-function contractCall(node: StepNode): ReduceResult | null {
+async function contractCall(
+  node: StepNode,
+  evaluator: IDataHandler | undefined,
+): Promise<ReduceResult | null> {
   const callee = node.callee as StepNode;
   const args = node.arguments as StepNode[];
 
@@ -597,6 +604,34 @@ function contractCall(node: StepNode): ReduceResult | null {
           : name === "print_llist"
             ? formatPrintLlistOutput(args)
             : undefined,
+    };
+  }
+
+  // A function imported from a module (`from rune import circle`, py-slang#385) — see
+  // `moduleInterop.ts`'s module doc comment for the scope this covers (no Python closure crossing
+  // into the call) and why it can't be represented as an ordinary `applyBuiltin` name lookup (the
+  // binding is per-program, substituted in by `getSteps.ts`'s `resolveImports`, not a fixed global
+  // table). `evaluator` is only absent when no module loader is wired up at all (see
+  // `resolveImports`'s doc comment), in which case no `ModuleFunction` node could exist in the tree
+  // in the first place — this branch is unreachable then, not a silent no-op.
+  if (isModuleFunctionNode(callee)) {
+    if (!args.every(isValue)) return null;
+    if (evaluator === undefined) {
+      throw new Error(`NameError: name '${String(callee.name)}' is not defined`);
+    }
+    const name = String(callee.name);
+    const result = await callModuleFunction(
+      evaluator,
+      callee.closure as TypedValue<DataType.CLOSURE>,
+      name,
+      args,
+    );
+    return {
+      node: result,
+      preRedex: node,
+      postRedex: result,
+      explanation: `Ran ${name}`,
+      beforeExplanation: `Running ${name}`,
     };
   }
 
@@ -707,7 +742,10 @@ function rebuildIndex(
 }
 
 /** Reduces `node` by a single step, or returns `null` if it is already a value / irreducible. */
-export function reduceExpr(node: StepNode): ReduceResult | null {
+export async function reduceExpr(
+  node: StepNode,
+  evaluator: IDataHandler | undefined,
+): Promise<ReduceResult | null> {
   switch (node.type) {
     case "Identifier":
       // A leftover name is an atom: a built-in function name, or an unbound name that does not reduce
@@ -716,48 +754,48 @@ export function reduceExpr(node: StepNode): ReduceResult | null {
       // from the first step rather than contracting mid-run.
       return null;
     case "BinaryExpression": {
-      const left = reduceExpr(node.left as StepNode);
+      const left = await reduceExpr(node.left as StepNode, evaluator);
       if (left) return rebuild(node, "left", left);
-      const right = reduceExpr(node.right as StepNode);
+      const right = await reduceExpr(node.right as StepNode, evaluator);
       if (right) return rebuild(node, "right", right);
       return contractBinary(node);
     }
     case "LogicalExpression": {
-      const left = reduceExpr(node.left as StepNode);
+      const left = await reduceExpr(node.left as StepNode, evaluator);
       if (left) return rebuild(node, "left", left);
       return contractLogical(node);
     }
     case "UnaryExpression": {
-      const arg = reduceExpr(node.argument as StepNode);
+      const arg = await reduceExpr(node.argument as StepNode, evaluator);
       if (arg) return rebuild(node, "argument", arg);
       return contractUnary(node);
     }
     case "ConditionalExpression": {
-      const test = reduceExpr(node.test as StepNode);
+      const test = await reduceExpr(node.test as StepNode, evaluator);
       if (test) return rebuild(node, "test", test);
       return contractConditional(node);
     }
     case "CallExpression": {
-      const callee = reduceExpr(node.callee as StepNode);
+      const callee = await reduceExpr(node.callee as StepNode, evaluator);
       if (callee) return rebuild(node, "callee", callee);
       const args = node.arguments as StepNode[];
       for (let i = 0; i < args.length; i++) {
-        const reduced = reduceExpr(args[i]);
+        const reduced = await reduceExpr(args[i], evaluator);
         if (reduced) return rebuildIndex(node, "arguments", i, reduced);
       }
-      return contractCall(node);
+      return contractCall(node, evaluator);
     }
     case "ArrayExpression": {
       const elements = node.elements as StepNode[];
       for (let i = 0; i < elements.length; i++) {
-        const reduced = reduceExpr(elements[i]);
+        const reduced = await reduceExpr(elements[i], evaluator);
         if (reduced) return rebuildIndex(node, "elements", i, reduced);
       }
       return null;
     }
     case "BlockStatement":
       // A function body in expression position (produced by applying a multi-statement `def`).
-      return reduceBlock(node);
+      return reduceBlock(node, evaluator);
     default:
       return null;
   }
@@ -808,7 +846,11 @@ type HeadOutcome =
  * branch; a `pass` is dropped. Boundary cases (`finished-expression`/`return`/`irreducible`) are
  * reported back for the caller to resolve.
  */
-function stepHead(head: StepNode, rest: StepNode[]): HeadOutcome {
+async function stepHead(
+  head: StepNode,
+  rest: StepNode[],
+  evaluator: IDataHandler | undefined,
+): Promise<HeadOutcome> {
   switch (head.type) {
     case "ExpressionStatement": {
       const expr = head.expression as StepNode;
@@ -844,7 +886,7 @@ function stepHead(head: StepNode, rest: StepNode[]): HeadOutcome {
           isBreakpoint: true,
         };
       }
-      const reduced = reduceExpr(expr);
+      const reduced = await reduceExpr(expr, evaluator);
       if (reduced) {
         // `hasBreakpoint: false` on the carried-forward copy: `head` still has one more expression
         // step to take, so it stays the head on the next call to this function with the *same*
@@ -874,7 +916,7 @@ function stepHead(head: StepNode, rest: StepNode[]): HeadOutcome {
       const decl = declaratorOf(head);
       const init = decl.init as StepNode;
       if (!isValue(init)) {
-        const reduced = reduceExpr(init);
+        const reduced = await reduceExpr(init, evaluator);
         if (reduced) {
           // See the identical `hasBreakpoint: false` note in the `ExpressionStatement` case above.
           return {
@@ -955,8 +997,22 @@ function stepHead(head: StepNode, rest: StepNode[]): HeadOutcome {
         explanation: "Evaluated pass statement",
         beforeExplanation: "Evaluating pass statement",
       };
+    case "ImportStatement":
+      // A no-op, like `PassStatement` above: imported names are resolved and bound before stepping
+      // begins (see `../getSteps`), mirroring the CSE machine's own `FromImport` evaluator, which is a
+      // no-op for the identical reason (its own `evaluateImports` pass already ran). By the time this
+      // statement is reached there is nothing left to do.
+      return {
+        kind: "step",
+        newBody: rest,
+        preRedex: head,
+        postRedex: head,
+        postNewBody: [head, ...rest],
+        explanation: "Evaluated import statement",
+        beforeExplanation: "Evaluating import statement",
+      };
     case "IfStatement": {
-      const reduced = reduceExpr(head.test as StepNode);
+      const reduced = await reduceExpr(head.test as StepNode, evaluator);
       if (reduced) {
         // See the identical `hasBreakpoint: false` note in the `ExpressionStatement` case above.
         return {
@@ -999,13 +1055,16 @@ function stepHead(head: StepNode, rest: StepNode[]): HeadOutcome {
  * leading statement is a finished value statement that is last (the program's value), or nothing is
  * left to reduce.
  */
-export function reduceProgram(prog: StepNode): ReduceResult | null {
+export async function reduceProgram(
+  prog: StepNode,
+  evaluator?: IDataHandler,
+): Promise<ReduceResult | null> {
   const body = prog.body as StepNode[];
   if (body.length === 0) return null;
 
   const head = body[0];
   const rest = body.slice(1);
-  const outcome = stepHead(head, rest);
+  const outcome = await stepHead(head, rest, evaluator);
   // A statement flagged by `markBreakpoints` (a gutter click resolved to its closest enclosing
   // statement — see `../../breakpoints.ts`, propagated onto the `StepNode` by `translate.ts`) is
   // treated exactly like an explicit `breakpoint()` call: computed once here, where `head` is in
@@ -1058,7 +1117,10 @@ export function reduceProgram(prog: StepNode): ReduceResult | null {
  * argument expression (which then reduces in place) — and falling off the end yields Python `None`.
  * Mirrors Source's `StepperBlockExpression`.
  */
-function reduceBlock(node: StepNode): ReduceResult | null {
+async function reduceBlock(
+  node: StepNode,
+  evaluator: IDataHandler | undefined,
+): Promise<ReduceResult | null> {
   const none = (): StepNode => literal(null, "None");
   const fallOff = (preRedex: StepNode, isBreakpoint = false): ReduceResult => {
     const result = none();
@@ -1077,7 +1139,7 @@ function reduceBlock(node: StepNode): ReduceResult | null {
 
   const head = body[0];
   const rest = body.slice(1);
-  const outcome = stepHead(head, rest);
+  const outcome = await stepHead(head, rest, evaluator);
   // See the identical `headBreakpoint` note in `reduceProgram`.
   const headBreakpoint = !!head.hasBreakpoint;
 

--- a/src/conductor/stepper/syntaxProfile.ts
+++ b/src/conductor/stepper/syntaxProfile.ts
@@ -41,12 +41,19 @@ export const pythonSyntaxProfile: SyntaxProfile = {
       { when: "alternate", parts: [{ token: "else:", cls: "identifier" }, { child: "alternate" }] },
     ],
     PassStatement: [{ token: "pass", cls: "identifier" }],
+    // Never reduces (see reduce.ts's "ImportStatement" case) — `raw` is display text reconstructed
+    // by translate.ts's `importText`, not something the host interprets structurally.
+    ImportStatement: [{ prop: "raw", cls: "identifier" }],
 
     // Atoms
     Literal: [{ prop: "raw", cls: "literal" }],
     // Plain names are uncoloured (white), like Source — only keywords/operators are coloured. A
     // function name shown as a value collapses to a bold mu-term (see `functionValues` below).
     Identifier: [{ prop: "name" }],
+    // A callable imported from a module (see ast.ts's `moduleFunction`) — always just its name, like
+    // Identifier; there's no inline/expanded form to collapse from (unlike a bound def/lambda — see
+    // `functionValues` below), since it has no Python body.
+    ModuleFunction: [{ prop: "name" }],
 
     // Expressions
     BinaryExpression: [
@@ -80,6 +87,10 @@ export const pythonSyntaxProfile: SyntaxProfile = {
       { child: "body" },
     ],
     ArrayExpression: ["[", { list: "elements", sep: ", " }, "]"],
+    // An opaque module value (e.g. a `rune` Rune) — no structure to render, just its label. See
+    // `ast.ts`'s `opaqueValue`; `dataUrl` (a rendered thumbnail, source-academy/modules#879) isn't
+    // rendered by the host yet.
+    Opaque: [{ token: "<", cls: "identifier" }, { prop: "label", cls: "identifier" }, ">"],
   },
 
   // Parenthesisation precedence (higher binds tighter). Mirrors Python's grammar; the host wraps a
@@ -104,6 +115,8 @@ export const pythonSyntaxProfile: SyntaxProfile = {
   expressionPrecedence: {
     Identifier: 20,
     ArrayExpression: 20,
+    Opaque: 20,
+    ModuleFunction: 20,
     Literal: 18,
     CallExpression: 18,
     UnaryExpression: 15,

--- a/src/conductor/stepper/translate.ts
+++ b/src/conductor/stepper/translate.ts
@@ -195,9 +195,25 @@ function translateStmtInner(stmt: StmtNS.Stmt): StepNode {
     }
     case "Pass":
       return { type: "PassStatement" };
+    case "FromImport":
+      return { type: "ImportStatement", raw: importText(stmt as StmtNS.FromImport) };
     default:
       return { type: "ExpressionStatement", expression: identifier(`<${stmt.kind}>`) };
   }
+}
+
+/** Reconstructs `from X import Y [as Z], ...` (or its relative `from .X import ...` form) as display
+ * text for {@link translateStmtInner}'s `"FromImport"` case. The statement itself never reduces (see
+ * `reduce.ts`'s `"ImportStatement"` case) — imported names are resolved and bound before stepping
+ * begins (see `../getSteps`), mirroring how the CSE machine's own `FromImport` evaluator is a no-op
+ * once its own upfront `evaluateImports` pass has run — so this text is purely what the student's
+ * source reads like on this step, not something the reducer interprets. */
+function importText(stmt: StmtNS.FromImport): string {
+  const module = ".".repeat(stmt.level) + stmt.module.lexeme;
+  const names = stmt.names
+    .map(({ name, alias }) => (alias ? `${name.lexeme} as ${alias.lexeme}` : name.lexeme))
+    .join(", ");
+  return `from ${module} import ${names}`;
 }
 
 /** Translates a parsed Python file into the estree-shaped {@link program} root the stepper reduces. */

--- a/src/tests/operator-conformance-stepper.test.ts
+++ b/src/tests/operator-conformance-stepper.test.ts
@@ -113,7 +113,7 @@ type StepperOutcome = { kind: "value"; text: string } | { kind: "error" } | { ki
  * "Evaluation stuck" — distinguishing "error" from a genuine "stuck" (no preceding error-shaped
  * explanation) this way.
  */
-function stepperOutcome(code: string, chapter: number): StepperOutcome {
+async function stepperOutcome(code: string, chapter: number): Promise<StepperOutcome> {
   const script = code + "\n";
   let ast: StmtNS.FileInput;
   try {
@@ -125,10 +125,10 @@ function stepperOutcome(code: string, chapter: number): StepperOutcome {
     return { kind: "error" };
   }
 
-  const steps = getPythonSteps(ast);
+  const steps = await getPythonSteps(ast);
   const last = steps[steps.length - 1];
   if (last.markers?.[0]?.explanation === "Evaluation complete") {
-    return { kind: "value", text: evaluatePython(ast) };
+    return { kind: "value", text: await evaluatePython(ast) };
   }
   const secondLast = steps[steps.length - 2];
   const secondLastExplanation = secondLast?.markers?.[0]?.explanation;
@@ -180,7 +180,7 @@ for (const chapter of [1, 2]) {
             const code = `${literalFor(left, chapter)} ${op} ${literalFor(right, chapter)}`;
             testOrSkip(code)(code, async () => {
               const wanted = await cseOutcome(code, chapter, groups);
-              const actual = stepperOutcome(code, chapter);
+              const actual = await stepperOutcome(code, chapter);
               expectMatch(wanted, actual);
             });
           }
@@ -193,7 +193,7 @@ for (const chapter of [1, 2]) {
         const code = `-${literalFor(operand, chapter)}`;
         testOrSkip(code)(code, async () => {
           const wanted = await cseOutcome(code, chapter, groups);
-          const actual = stepperOutcome(code, chapter);
+          const actual = await stepperOutcome(code, chapter);
           expectMatch(wanted, actual);
         });
       }
@@ -208,7 +208,7 @@ for (const chapter of [1, 2]) {
         const code = `not ${literalFor(operand, chapter)}`;
         testOrSkip(code)(code, async () => {
           const wanted = await cseOutcome(code, chapter, groups);
-          const actual = stepperOutcome(code, chapter);
+          const actual = await stepperOutcome(code, chapter);
           if (wanted.kind === "value") {
             expect(actual.kind).toBe("value");
           } else {
@@ -225,7 +225,7 @@ for (const chapter of [1, 2]) {
             const code = `${literalFor(left, chapter)} ${op} ${literalFor(right, chapter)}`;
             testOrSkip(code)(code, async () => {
               const wanted = await cseOutcome(code, chapter, groups);
-              const actual = stepperOutcome(code, chapter);
+              const actual = await stepperOutcome(code, chapter);
               if (wanted.kind === "value") {
                 expect(actual.kind).toBe("value");
               } else {


### PR DESCRIPTION
## Summary

Closes #385. `from X import Y` used to make the stepper report "Evaluation stuck" the instant it saw the import line, regardless of whether the imported name was ever used. This wires up real module resolution for the substitution stepper, mirroring the CSE machine's own two-phase (load-then-run) model — for a deliberately scoped subset of modules (see below).

- `FromImport` now translates to a no-op statement instead of an inert placeholder identifier, and renders the student's actual import text (`from rune import circle`, not `pass`).
- New `OpaqueValue`/`ModuleFunction` `StepNode` kinds represent opaque module handles (e.g. a `rune` `Rune`) and imported callables as legitimate, substitutable stepper values.
- `ModuleLoaderRunnerPlugin` is registered on `PyStepperEvaluatorBase`, exactly mirroring how `PyCseEvaluatorBase`/`Py2JsEvaluatorBase`/`PyPvmlEvaluatorBase` already do it.
- New `moduleInterop.ts` resolves and substitutes a program's imports before stepping begins (`resolveImports`), and calls imported functions (`callModuleFunction`) — trying the synchronous `closure_call_sync` fast path first, falling back to draining the mandatory async `closure_call_unchecked` generator.
- **Scope**: a Python closure (a `lambda`/`def`, or a bare reference to a static built-in) passed as an *argument* into a module call is declined — the call simply stays irreducible ("Evaluation stuck"), the same honest degrade `input()`/`time_time()` already get. Supporting that direction would mean the module calling back into Python mid-call, which needs the reducer to re-enter its own step machinery — out of scope for this pass. This covers modules like `rune` (pure data/opaque handles in, opaque handles out) but not ones like `sound` that take a Python function as an argument.
- A relative import (`from .foo import x`) is now a clear, student-actionable error (mirroring the CSE machine's `RelativeImportNotSupportedError`) rather than silently rendering as inert text.
- `reduce.ts`/`getSteps.ts` are now `async` end-to-end to support this — the biggest mechanical part of the diff, since it also required migrating the existing (large) stepper test suite off synchronous helper calls.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on all touched files
- [x] `npx prettier --list-different` clean
- [x] Full test suite green (`npx jest`): 19565 passed, 0 failed
- [x] New unit tests for the `FromImport` → no-op translation, the relative-import error, and aliased-import display text
- [x] New integration tests against a fake module (the same `GenericDataHandler` + `ModuleLoaderRunnerPlugin` harness `py2js-from-import.test.ts` uses), not just the no-evaluator-wired degrade path: a constant export substituted as a literal, a function export actually called, an opaque return value (both created-and-discarded and used/rendered), a declined Python-closure argument staying stuck, a missing module, and a name a module doesn't export

https://claude.ai/code/session_017w4FqCep4j8XyFpF4kpVue