### PR TITLE
Stepper imports: pin down CodeRabbit's ModuleFunction/Opaque substitution concern

### DIFF
--- a/src/conductor/stepper/__tests__/getSteps.test.ts
+++ b/src/conductor/stepper/__tests__/getSteps.test.ts
@@ -1963,6 +1963,19 @@ describe("Python stepper — real module resolution (py-slang#385)", () => {
       "from visualmod import make_thing, is_same_thing\nis_same_thing(make_thing())\n",
     );
     expect(await evaluatePython(ast, dh)).toBe("True");
+
+    // Bound to a name first, not nested directly as a call argument: `x`'s value substitutes into
+    // `is_same_thing(x)` via `substitute`'s Identifier case, which — unlike the direct-nesting form
+    // above (plain object-spread rebuilding, no `substitute` involved) — `clone()`s the Opaque node
+    // being substituted in. `clone` deep-copies `handle`'s wrapper object, so this only round-trips
+    // correctly because `TypedValue<DataType.OPAQUE>.value` (`OpaqueIdentifier`, an `Identifier &
+    // {...}` brand — see conductor's own types) is a plain `number` at runtime: the clone is a new
+    // object with the same primitive id, and `GenericDataHandler.opaqueMap` looks values up by that
+    // id, not by object reference — so a structurally-cloned handle still resolves to the original.
+    const boundAst = parse(
+      "from visualmod import make_thing, is_same_thing\nx = make_thing()\nis_same_thing(x)\n",
+    );
+    expect(await evaluatePython(boundAst, dh)).toBe("True");
   });
 
   test("arity() reports an imported function's real parameter count", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #386 (merged before its second CodeRabbit review landed). That review flagged a plausible-sounding concern on `ast.ts`:

> `substitute` clones substitution targets and descends under `ModuleFunction` via `mapChildren`. Because `mapChildren` calls `mapValue` for every property, the evaluator-owned `TypedValue<DataType.CLOSURE>` at `ModuleFunction.closure` is not treated as an AST child.

Investigated and confirmed this is a **false positive**, not a bug:

- `mapValue` (used when *walking* a node) only recurses into a field whose own `.type` is a *string*. `TypedValue<DataType.CLOSURE>.type` is `DataType.CLOSURE`, a plain number — already skipped, passed through by reference unchanged.
- `clone()` (used when a value is *substituted in*, i.e. bound to a name) does deep-copy `closure`/`handle`, producing a new wrapper object. But `ClosureIdentifier`/`OpaqueIdentifier` are `Identifier & {__brand: ...}`, and conductor's own types define `Identifier = number` — the brand is compile-time only, so at runtime `.value` is a plain number. `GenericDataHandler`'s `closureMap`/`opaqueMap` key their lookups by that primitive number, not object identity, so a structurally-cloned wrapper still resolves to the original entry correctly.

Rather than just asserting this in a review reply, this PR adds a regression test that specifically exercises the path CodeRabbit was worried about: an opaque value bound to a variable *first* (forcing it through `substitute`'s `clone()`), not just nested directly as a call argument (which bypasses `substitute` entirely via plain object-spread rebuilding in `reduce.ts`'s `rebuildIndex`).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint`/`npx prettier --list-different` clean
- [x] New test passes, exercising the exact substitution path in question
- [x] Full stepper suite green