### PR TITLE
Match CPython's wording for unresolvable nonlocal declarations

### DIFF
--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -876,14 +876,20 @@ export class Resolver implements StmtNS.Visitor<void>, ExprNS.Visitor<void> {
     // skipping the current function itself (nonlocal can never bind to it).
     const found = this.hasEnclosingFunctionBinding(name, this.functionDefStack.length - 2);
     if (!found) {
+      // A dedicated message matching CPython's own wording for this exact diagnostic (#187) —
+      // not the generic NameNotFoundError, whose "Perhaps you meant to type 'x'?" suggestion is
+      // actively misleading here: the closest Levenshtein match is often `name` itself (e.g. the
+      // very binding an intermediate `global name` is blocking resolution past), since a name
+      // reaching this point is, by definition, spelled correctly and simply unresolvable as
+      // nonlocal — there is nothing sensible to suggest instead.
       this.errors.push(
-        new ResolverErrors.NameNotFoundError(
+        new ResolverErrors.ScopeConflictError(
           stmt.name.line,
           stmt.name.col,
           this.source,
           stmt.name.indexInSource,
-          stmt.name.indexInSource + stmt.name.lexeme.length,
-          this.environment?.suggestName(stmt.name) ?? null,
+          stmt.name.indexInSource + name.length,
+          `no binding for nonlocal '${name}' found`,
         ),
       );
     }

--- a/src/tests/nonlocal.test.ts
+++ b/src/tests/nonlocal.test.ts
@@ -835,9 +835,16 @@ grandouter()
     // resolve to as nonlocal), no "Perhaps you meant to type 'x'?" suggestion should appear
     // either, even though `x` genuinely exists in scope here (the very global-shadowed binding
     // blocking resolution) and would otherwise be the Levenshtein-closest — and thus most
-    // confusing possible — suggestion.
-    expect(() => toPythonAstAndResolve(code, 3)).toThrow(/no binding for nonlocal 'x' found/);
-    expect(() => toPythonAstAndResolve(code, 3)).not.toThrow(/Perhaps you meant/);
+    // confusing possible — suggestion. Resolved once, not twice: both checks read the same
+    // thrown error's message.
+    let error: Error | undefined;
+    try {
+      toPythonAstAndResolve(code, 3);
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error?.message).toMatch(/no binding for nonlocal 'x' found/);
+    expect(error?.message).not.toMatch(/Perhaps you meant/);
   });
 
   test("nonlocal with no binding construct anywhere in any enclosing function is still rejected", () => {
@@ -849,7 +856,13 @@ def outer():
     inner()
 outer()
 `;
-    expect(() => toPythonAstAndResolve(code, 3)).toThrow(/no binding for nonlocal 'x' found/);
-    expect(() => toPythonAstAndResolve(code, 3)).not.toThrow(/Perhaps you meant/);
+    let error: Error | undefined;
+    try {
+      toPythonAstAndResolve(code, 3);
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error?.message).toMatch(/no binding for nonlocal 'x' found/);
+    expect(error?.message).not.toMatch(/Perhaps you meant/);
   });
 });

--- a/src/tests/nonlocal.test.ts
+++ b/src/tests/nonlocal.test.ts
@@ -830,7 +830,14 @@ def grandouter():
     outer()
 grandouter()
 `;
-    expect(() => toPythonAstAndResolve(code, 3)).toThrow(SyntaxError);
+    // Matches CPython's own wording for this diagnostic (#187) — and, since the name reaching
+    // this point is by definition already spelled correctly (there's simply no binding it can
+    // resolve to as nonlocal), no "Perhaps you meant to type 'x'?" suggestion should appear
+    // either, even though `x` genuinely exists in scope here (the very global-shadowed binding
+    // blocking resolution) and would otherwise be the Levenshtein-closest — and thus most
+    // confusing possible — suggestion.
+    expect(() => toPythonAstAndResolve(code, 3)).toThrow(/no binding for nonlocal 'x' found/);
+    expect(() => toPythonAstAndResolve(code, 3)).not.toThrow(/Perhaps you meant/);
   });
 
   test("nonlocal with no binding construct anywhere in any enclosing function is still rejected", () => {
@@ -842,6 +849,7 @@ def outer():
     inner()
 outer()
 `;
-    expect(() => toPythonAstAndResolve(code, 3)).toThrow(SyntaxError);
+    expect(() => toPythonAstAndResolve(code, 3)).toThrow(/no binding for nonlocal 'x' found/);
+    expect(() => toPythonAstAndResolve(code, 3)).not.toThrow(/Perhaps you meant/);
   });
 });

--- a/src/tests/wasm/wasm-functions.spec.ts
+++ b/src/tests/wasm/wasm-functions.spec.ts
@@ -111,8 +111,13 @@ def f(x):
     return x
 f(5)
 `;
+    // The parameter/nonlocal conflict (#179) — this was incidentally also collecting a
+    // NameNotFoundError before #187's fix, since `x` (already invalid as a parameter declared
+    // nonlocal) also has no enclosing-scope binding to resolve to; that fallback is now the more
+    // specific ScopeConflictError ("no binding for nonlocal 'x' found", matching CPython's own
+    // wording), not a NameNotFoundError.
     expect((await compileToWasmAndRun(pythonCode, true)).errors).toContainEqual(
-      expect.any(ResolverErrors.NameNotFoundError),
+      expect.any(ResolverErrors.ScopeConflictError),
     );
   });
 


### PR DESCRIPTION
## Summary

Closes #187.

`visitNonLocalStmt` fell back to the generic `NameNotFoundError` when a `nonlocal x` declaration has no binding in any enclosing function scope. CPython raises a specific `SyntaxError` for this exact diagnostic:

```
SyntaxError: no binding for nonlocal 'x' found
```

The generic fallback also produced a misleading `Perhaps you meant to type 'x'?` suggestion in the issue's second repro case — where a same-named binding exists in scope but is unreachable (an intermediate function declares `global x`, correctly blocking `nonlocal` from skipping past it). The Levenshtein-closest match ends up being the identifier itself, since a name reaching this point is by definition already spelled correctly — there's simply no binding it can resolve to as `nonlocal`.

## Fix

- Reuse `ScopeConflictError` (`src/resolver/errors.ts`) — already used for the sibling #178-#181 nonlocal/global scope-conflict diagnostics, and whose reported error name is literally `"SyntaxError"`, matching CPython's own exception class here — instead of introducing a new error class.
- Never call `suggestName` for this case, since CPython never offers a "did you mean" for it either.
- `visitGlobalStmt` was checked and doesn't have the analogous bug — `global x` is unconditionally accepted by the resolver (real Python only raises at runtime if `x` is never actually assigned, which py-slang already defers to) — so it's untouched.

## Test plan

- [x] Tightened the two existing repro-case tests in `src/tests/nonlocal.test.ts` (previously only asserted `.toThrow(SyntaxError)`) to assert the exact CPython-matching message and the absence of the misleading suggestion.
- [x] Updated `src/tests/wasm/wasm-functions.spec.ts`'s "cannot declare parameter as nonlocal" test: it was incidentally also asserting a `NameNotFoundError` was present, since the same name failed both the #179 parameter/nonlocal conflict and (as an unrelated side effect) the "no binding" check; now asserts the more accurate `ScopeConflictError`.
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint`/`npx prettier --list-different` clean
- [x] Full suite green: 19568 passed, 0 failed

https://claude.ai/code/session_017w4FqCep4j8XyFpF4kpVue