### PR TITLE
Fix parser: leading blank line/comment before a from-import causes a parse error

### DIFF
--- a/src/parser/python-grammar.ts
+++ b/src/parser/python-grammar.ts
@@ -106,7 +106,22 @@ const tokList = ([first, rest]: [moo.Token, [unknown, moo.Token][]]) => [
 const Lexer = pythonLexer;
 const ParserRules = [
   { name: "program$ebnf$1", symbols: [] },
-  { name: "program$ebnf$1$subexpression$1", symbols: ["import_stmt", { type: "newline" }] },
+  { name: "program$ebnf$1$subexpression$1$ebnf$1", symbols: [] },
+  { name: "program$ebnf$1$subexpression$1$ebnf$1$subexpression$1", symbols: [{ type: "newline" }] },
+  {
+    name: "program$ebnf$1$subexpression$1$ebnf$1",
+    symbols: [
+      "program$ebnf$1$subexpression$1$ebnf$1",
+      "program$ebnf$1$subexpression$1$ebnf$1$subexpression$1",
+    ],
+    postprocess: function arrpush<T>(d: [T[], T]) {
+      return d[0].concat([d[1]]);
+    },
+  },
+  {
+    name: "program$ebnf$1$subexpression$1",
+    symbols: ["program$ebnf$1$subexpression$1$ebnf$1", "import_stmt", { type: "newline" }],
+  },
   {
     name: "program$ebnf$1",
     symbols: ["program$ebnf$1", "program$ebnf$1$subexpression$1"],
@@ -128,10 +143,10 @@ const ParserRules = [
     name: "program",
     symbols: ["program$ebnf$1", "program$ebnf$2"],
     postprocess: ([imports, stmts]: [
-      [StmtNS.FromImport, moo.Token][],
+      [moo.Token[], StmtNS.FromImport, moo.Token][],
       ([StmtNS.Stmt] | [moo.Token])[],
     ]) => {
-      const importNodes = imports.map(d => d[0]);
+      const importNodes = imports.map(d => d[1]);
       const stmtNodes = stmts.map(d => d[0]).filter(s => "startToken" in s);
       const filtered = [...importNodes, ...stmtNodes];
       const start = filtered[0]

--- a/src/parser/python.ne
+++ b/src/parser/python.ne
@@ -79,12 +79,21 @@ const tokList       = ([first, rest]: [moo.Token, [unknown, moo.Token][]]) => [t
 # program ::= import-stmt ... block              [python_1_bnf.tex line 18]
 #
 # Enforces: imports come before statements.  An import after a statement
-# is a parse error.
+# is a parse error. A leading run of blank lines/comments before an import
+# is not a statement and must not count as one (py-slang#393) — the lexer
+# already collapses any blank lines/comments between two real tokens into
+# a single `newline` token (see lexer.ts's processTokens), so each import
+# only ever needs at most one such leading token. The optional leading
+# `(%newline):*` is tied to (i.e. inside the same repetition as) its own
+# import_stmt, rather than factored out as a separate top-level group,
+# specifically so a bare leading newline with no import to follow can only
+# ever be matched by the trailing `(statement | %newline):*` group — a
+# factored-out version is ambiguous about which group consumes it.
 # ============================================================================
 
-program -> (import_stmt %newline):* (statement | %newline):*
-  {% ([imports, stmts]: [[StmtNS.FromImport, moo.Token][], ([StmtNS.Stmt] | [moo.Token])[]]) => {
-       const importNodes = imports.map(d => d[0]);
+program -> ((%newline):* import_stmt %newline):* (statement | %newline):*
+  {% ([imports, stmts]: [[moo.Token[], StmtNS.FromImport, moo.Token][], ([StmtNS.Stmt] | [moo.Token])[]]) => {
+       const importNodes = imports.map(d => d[1]);
        const stmtNodes = stmts.map(d => d[0]).filter(s => 'startToken' in s);
        const filtered = [...importNodes, ...stmtNodes];
        const start = filtered[0]

--- a/src/tests/nearley-parser.test.ts
+++ b/src/tests/nearley-parser.test.ts
@@ -827,6 +827,28 @@ describe("Import statement", () => {
     expect(imp.module.lexeme).toBe("foo.bar");
     expect(imp.names).toHaveLength(2);
   });
+
+  // py-slang#393: a leading blank line or comment isn't a statement, and
+  // must not count as one — it shouldn't be able to knock a `from` import
+  // out of the program's import-prefix section. Blank lines/comments
+  // *between* imports already worked (the lexer collapses each into a
+  // single `newline` token that already pairs with the previous import),
+  // so those aren't regression-tested here, only the previously-broken
+  // leading case.
+  test("a leading blank line before the first import still parses it as an import", () => {
+    const stmts = parseStmts("\nfrom math import sqrt");
+    expect(stmts[0]).toBeInstanceOf(StmtNS.FromImport);
+  });
+
+  test("a leading comment before the first import still parses it as an import", () => {
+    const stmts = parseStmts("# a comment\nfrom math import sqrt");
+    expect(stmts[0]).toBeInstanceOf(StmtNS.FromImport);
+  });
+
+  test("several leading blank/comment lines before the first import still parse it as an import", () => {
+    const stmts = parseStmts("# one\n\n# two\n\nfrom math import sqrt");
+    expect(stmts[0]).toBeInstanceOf(StmtNS.FromImport);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The `program` grammar rule required import statements to form a strict, uninterrupted prefix block at the very start of the file (`(import_stmt %newline):*`), with no tolerance for anything preceding them.
- The lexer collapses any run of blank lines and comments between two real tokens into a single `newline` token (see `lexer.ts`'s `processTokens`). A leading blank line or comment before the first `from` import therefore produced exactly one leading `newline` token with no `import_stmt` yet to pair with — and since the grammar has no way to "go back" to the import-prefix section once any token is consumed by the trailing statement-body section, that lone token permanently disqualified every subsequent `from` import in the file.
- Fix: tie an optional leading `(%newline):*` to each import's own repetition (`((%newline):* import_stmt %newline):*`) instead of factoring it out as a separate top-level group. A factored-out version reintroduces ambiguity (a bare leading newline with zero imports in the file could be assigned to either group); tying it to the import repetition avoids that while still accepting the leading blank line/comment.
- The existing rule that a real statement (not blank lines/comments) before an import is a parse error is unchanged and still tested (`Negative cases — spec restrictions`).

## Test plan
- [x] `npx tsc --noEmit -p .`
- [x] `npx eslint` (no new warnings/errors)
- [x] `npx prettier --list-different` on changed files (clean)
- [x] `npx jest src/tests/nearley-parser.test.ts` (191/191, including 3 new regression tests for leading blank line, leading comment, and several combined leading blank/comment lines before an import)
- [x] Full suite: `npx jest` (19,584 passed, 0 failed)

Fixes #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)