### PR TITLE
Fix lexer: triple-quoted strings confuse line/col tracking for later tokens

### DIFF
--- a/src/parser/lexer.ts
+++ b/src/parser/lexer.ts
@@ -63,8 +63,12 @@ const mooLexer = moo.compile({
   number_bin: /0[bB][01]+/,
   number_int: /\d+/,
 
-  string_triple_double: /"""(?:[^\\]|\\.)*?"""/,
-  string_triple_single: /'''(?:[^\\]|\\.)*?'''/,
+  // `lineBreaks: true` is required so moo's own line/col counters advance
+  // across embedded newlines in the matched text (py-slang#394) — without
+  // it, moo silently under-counts, and every token after a multi-line
+  // triple-quoted string reports the wrong line/column.
+  string_triple_double: { match: /"""(?:[^\\]|\\.)*?"""/, lineBreaks: true },
+  string_triple_single: { match: /'''(?:[^\\]|\\.)*?'''/, lineBreaks: true },
   string_double: /"(?:[^"\\]|\\.)*"/,
   string_single: /'(?:[^'\\]|\\.)*'/,
 

--- a/src/tests/nearley-parser.test.ts
+++ b/src/tests/nearley-parser.test.ts
@@ -861,6 +861,23 @@ describe("Token tracking", () => {
     const expr = parseExpr("1 + 2") as ExprNS.Binary;
     expect(expr.startToken.lexeme).toBe("1");
   });
+
+  // py-slang#394: the triple-quoted string tokens were missing moo's
+  // `lineBreaks: true`, so moo's own line/col counters silently stopped
+  // advancing across the string's embedded newlines — every token after a
+  // multi-line triple-quoted string reported the wrong line/column.
+  test("line tracking survives a multi-line triple-quoted string", () => {
+    const stmts = parseStmts("x = '''\nline2\nline3\n'''\ny = 1");
+    expect(stmts[0].startToken.line).toBe(1);
+    expect(stmts[1].startToken.line).toBe(5);
+  });
+
+  test("a syntax error after a multi-line triple-quoted string reports the right line (py-slang#394 repro)", () => {
+    // Mirrors the issue's exact repro: an invalid `&` token six lines below
+    // a multi-line triple-quoted string used to be reported against a line
+    // inside the string instead of its own line.
+    expect(() => parseStmts("1 + 2\n'''\na\nb\n'''\n&\n4 + 5")).toThrow(/line 6 col 1/);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `string_triple_double` and `string_triple_single` in `src/parser/lexer.ts` were plain regexes with no `lineBreaks: true`, unlike `newline` and `continuation` which correctly set it.
- moo requires `lineBreaks: true` on any token whose matched text can itself contain embedded newlines, so it knows to advance its internal line/col counters accordingly. Without it, moo silently keeps counting as if the matched text were a single line.
- Since a triple-quoted string can span multiple physical lines, every token *after* one had a wrong (too-small) line number and a column computed from the wrong starting point — reproduced exactly from the issue: a syntax error six lines below a 4-line triple-quoted string was reported against a line *inside* the string instead of its own line.
- Fix: mark both triple-quote token regexes `lineBreaks: true`.

## Test plan
- [x] `npx tsc --noEmit -p .`
- [x] `npx eslint` (no new warnings/errors)
- [x] `npx prettier --list-different` (clean)
- [x] `npx jest src/tests/nearley-parser.test.ts src/tests/lexer.test.ts` (207/207, including 2 new regression tests: line tracking directly, and the issue's exact repro asserting the correct `line 6 col 1` error)
- [x] Full suite: `npx jest` (19,586 passed, 0 failed)

Fixes #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)