### PR TITLE
py2js: stop showing a fabricated line number, name the enclosing predefined function

### DIFF
--- a/src/engines/py2js/README.md
+++ b/src/engines/py2js/README.md
@@ -308,8 +308,14 @@ boundary (matching the CSE converter's identical restrictions).
 
 - **Error source locations are not attached yet.** Errors carry the
   correct Python error-class name (matching the CSE machine) but not a
-  source position; the stdlib bridge's synthetic `command` nodes point at
-  the program start.
+  source position; the stdlib bridge's synthetic `command` nodes carry no
+  real position at all (py-slang#397: errors.ts skips the location header
+  entirely for a synthetic token, rather than printing a misleading one).
+  Where the failing builtin was called from inside a predefined (prelude)
+  function like `map`, the message names that function instead (e.g.
+  `unsupported argument type for tail: integer (in predefined function
+'map')` — see `Py2JsRuntime.enclosingPreludeFunction`), which is the
+  closest substitute for a real position until one exists.
 - **Negative list indexing (`xs[-1]`) is unsupported**, matching a gap in
   the CSE reference itself (`LIST_ACCESS` has no negative-index handling;
   `LIST_ASSIGNMENT`'s attempt is a JS `%`, not Python's modulo, and

--- a/src/engines/py2js/index.ts
+++ b/src/engines/py2js/index.ts
@@ -254,10 +254,7 @@ function setupRuntime(
     try {
       new Function("__py", preludeJs)(rt);
     } catch (e: unknown) {
-      throw new Py2JsRunError(
-        "runtime",
-        formatCaughtError(e),
-      );
+      throw new Py2JsRunError("runtime", formatCaughtError(e));
     } finally {
       rt.compilingPrelude = false;
     }

--- a/src/engines/py2js/index.ts
+++ b/src/engines/py2js/index.ts
@@ -122,6 +122,18 @@ function hasLocalImports(statements: StmtNS.Stmt[]): boolean {
   return statements.some(s => s.kind === "FromImport" && (s as StmtNS.FromImport).level > 0);
 }
 
+/** Formats a caught error for Py2JsRunError's message: `${e.name}: ${e.message}`, except
+ * a Py2JsRuntimeError's own .message already starts with its own kind as a literal string
+ * (stdlibBridge.ts's error-kind prefixing, py-slang#397) — re-adding e.name in front of an
+ * already-prefixed message would double it ("TypeError: TypeError: ..."). Detected from the
+ * message's own text (any leading "Word: "), not by comparing against e.name — e.name is
+ * ultimately sourced from e.constructor.name (stdlibBridge.ts), which a minified production
+ * build mangles, while the literal "TypeError: " etc. baked into the message text survives. */
+function formatCaughtError(e: unknown): string {
+  if (!(e instanceof Error)) return String(e);
+  return /^[A-Za-z]+: /.test(e.message) ? e.message : `${e.name}: ${e.message}`;
+}
+
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
   ...args: string[]
 ) => (rt: Py2JsRuntime) => Promise<void>;
@@ -244,7 +256,7 @@ function setupRuntime(
     } catch (e: unknown) {
       throw new Py2JsRunError(
         "runtime",
-        e instanceof Error ? `${e.name}: ${e.message}` : String(e),
+        formatCaughtError(e),
       );
     } finally {
       rt.compilingPrelude = false;
@@ -359,7 +371,7 @@ export function runCodePy2Js(
       "runtime",
       // Keep the Python error kind (Py2JsRuntimeError sets name = pyKind), so
       // callers can still tell ZeroDivisionError from TypeError etc.
-      e instanceof Error ? `${e.name}: ${e.message}` : String(e),
+      formatCaughtError(e),
     );
   }
   return { output: rt.output.join("") };
@@ -383,7 +395,7 @@ export async function runCodePy2JsDual(
       "runtime",
       // Keep the Python error kind (Py2JsRuntimeError sets name = pyKind), so
       // callers can still tell ZeroDivisionError from TypeError etc.
-      e instanceof Error ? `${e.name}: ${e.message}` : String(e),
+      formatCaughtError(e),
     );
   }
   return { output: rt.output.join("") };

--- a/src/engines/py2js/index.ts
+++ b/src/engines/py2js/index.ts
@@ -536,7 +536,19 @@ export class Py2JsSession {
         .map(g => g.prelude ?? "")
         .filter(p => p.trim())
         .join("\n");
-      if (preludeText.trim()) await this.runChunkInternal(preludeText);
+      if (preludeText.trim()) {
+        // Marks every function this defines pyPrelude: true (see Py2JsRuntime.def) — the
+        // Py2JsSession analogue of setupRuntime's identical wrapping around its own,
+        // separate prelude-loading call above. Without this, a bridged builtin's error
+        // can never name the predefined function it happened inside of (py-slang#397)
+        // for any conductor-evaluator session, since that's the only path they use.
+        this.rt.compilingPrelude = true;
+        try {
+          await this.runChunkInternal(preludeText);
+        } finally {
+          this.rt.compilingPrelude = false;
+        }
+      }
     }
     await this.runChunkInternal(code);
   }

--- a/src/engines/py2js/index.ts
+++ b/src/engines/py2js/index.ts
@@ -235,6 +235,10 @@ function setupRuntime(
     .join("\n");
   if (preludeText.trim()) {
     const preludeJs = compileScript(rt, preludeText + "\n", variant, "sync");
+    // Marks every function this defines pyPrelude: true (see Py2JsRuntime.def) — lets a
+    // bridged builtin's error name the predefined function it happened inside of
+    // (py-slang#397), e.g. tail() failing inside map()'s own _map helper.
+    rt.compilingPrelude = true;
     try {
       new Function("__py", preludeJs)(rt);
     } catch (e: unknown) {
@@ -242,6 +246,8 @@ function setupRuntime(
         "runtime",
         e instanceof Error ? `${e.name}: ${e.message}` : String(e),
       );
+    } finally {
+      rt.compilingPrelude = false;
     }
   }
 

--- a/src/engines/py2js/runtime.ts
+++ b/src/engines/py2js/runtime.ts
@@ -97,6 +97,23 @@ export interface PyFunction {
   pyArity: number;
   pyBuiltin?: boolean;
   /**
+   * True for a function compiled from a stdlib group's own SICPy prelude
+   * source (e.g. linked-list.prelude.ts's map/filter/reduce), set by `def`
+   * while `compilingPrelude` is on — see that field and
+   * `enclosingPreludeFunction` (py-slang#397). Unset for both native/bridged
+   * builtins and the user's own compiled functions.
+   */
+  pyPrelude?: boolean;
+  /**
+   * True for a native/bridged builtin (set by `builtin()` and
+   * `bridgeBuiltin`) — a leaf operation that is never itself "user code" or
+   * "library code" and so, unlike pyPrelude/plain user functions, must not
+   * become its own boundary when computing `enclosingPreludeFunction`
+   * (py-slang#397): it transparently passes its caller's origin through
+   * rather than resetting or claiming it.
+   */
+  pyNative?: boolean;
+  /**
    * For bridged stdlib builtins: the CSE-side minArgs, reported by the
    * native arity() builtin so both engines answer arity questions
    * identically (bridged functions run with pyArity -1, leaving argument
@@ -494,6 +511,63 @@ export class Py2JsRuntime {
    * sites are unaffected; index.ts passes `variant >= 3` explicitly.
    */
   constructor(public readonly universalEquality: boolean = false) {}
+
+  /**
+   * True while `setupRuntime` (index.ts) is executing a stdlib group's
+   * compiled prelude script — `def`/`def2` tag every function created during
+   * that window `pyPrelude: true` (py-slang#397). Never true for anything
+   * else: native/bridged builtins are `def`'d directly from TS, and the
+   * user's own script always compiles and runs in a separate call, outside
+   * this window.
+   */
+  compilingPrelude = false;
+
+  /**
+   * Parallel to the call stack, one entry per currently-executing frame: the name of
+   * the outermost predefined (prelude) function that frame is logically running
+   * inside of, or undefined if it isn't (and isn't nested within one). Lets
+   * `enclosingPreludeFunction` (py-slang#397) find which predefined function, if any,
+   * a bridged builtin's error occurred inside of — e.g. `tail()` failing partway
+   * through `map()`'s own `_map` helper should name `map`, the function the user
+   * actually called, not `_map`, an implementation detail they never wrote.
+   *
+   * Set once by `call`/`acall` when a frame is genuinely pushed, and deliberately
+   * left untouched across a tail-call bounce: TCO means "the same logical frame, a
+   * different function now running in it" (map tail-calling into _map is exactly
+   * this), so the frame's already-resolved origin must survive the bounce rather
+   * than being recomputed from whatever function it bounces into.
+   */
+  private readonly preludeOrigin: (string | undefined)[] = [];
+
+  /**
+   * The origin a *new* frame for `fn` should record when genuinely pushed (not
+   * bounced into):
+   *  - prelude code: its own name if entered fresh, or the caller's inherited
+   *    origin if already nested inside prelude code (a deeper prelude helper
+   *    doesn't override the outer one the user actually called).
+   *  - a native/bridged builtin: transparently passes the caller's origin
+   *    through unchanged — it's a leaf operation, never itself a boundary,
+   *    so it inherits "still inside map" from a prelude caller just as much
+   *    as it inherits "not inside anything" from a top-level one.
+   *  - anything else (a genuine user-defined function): always undefined,
+   *    a hard boundary — an error inside code the user actually wrote must
+   *    never be attributed to a predefined function, even if that function
+   *    was itself invoked as a callback passed into one (e.g. map(f, xs)).
+   */
+  private originForNewFrame(fn: PyFunction): string | undefined {
+    const callerOrigin = this.preludeOrigin[this.preludeOrigin.length - 1];
+    if (fn.pyPrelude) return callerOrigin ?? fn.pyName;
+    if (fn.pyNative) return callerOrigin;
+    return undefined;
+  }
+
+  /** The predefined function, if any, the currently executing frame is running
+   * inside of — undefined when it isn't nested within prelude code at all (e.g. a
+   * builtin called directly at the top level, or from inside a user-defined
+   * function that was itself called from prelude code). */
+  enclosingPreludeFunction(): string | undefined {
+    return this.preludeOrigin[this.preludeOrigin.length - 1];
+  }
 
   output: string[] = [];
 
@@ -912,12 +986,25 @@ export class Py2JsRuntime {
 
   /** Non-tail call: run the trampoline until a real value comes back. */
   call(f: PyValue, args: PyValue[]): PyValue {
-    let result = this.checkCallable(f, args.length, true)(...args);
-    while (result !== null && typeof result === "object" && (result as TailCall).__tail === true) {
-      const t = result as TailCall;
-      result = this.checkCallable(t.f, t.args.length, true)(...t.args);
+    let fn = this.checkCallable(f, args.length, true);
+    this.preludeOrigin.push(this.originForNewFrame(fn));
+    try {
+      let result = fn(...args);
+      while (
+        result !== null &&
+        typeof result === "object" &&
+        (result as TailCall).__tail === true
+      ) {
+        const t = result as TailCall;
+        fn = this.checkCallable(t.f, t.args.length, true);
+        // A tail call bounces on the *same* logical frame — preludeOrigin is
+        // deliberately not touched here; see its own doc comment for why.
+        result = fn(...t.args);
+      }
+      return result === undefined ? null : (result as PyValue);
+    } finally {
+      this.preludeOrigin.pop();
     }
-    return result === undefined ? null : (result as PyValue);
   }
 
   /**
@@ -928,13 +1015,22 @@ export class Py2JsRuntime {
    */
   async acall(f: PyValue, args: PyValue[]): Promise<PyValue> {
     let fn = this.checkCallable(f, args.length, false);
-    let result = await (fn.asyncBody ?? fn)(...args);
-    while (result !== null && typeof result === "object" && (result as TailCall).__tail === true) {
-      const t = result as TailCall;
-      fn = this.checkCallable(t.f, t.args.length, false);
-      result = await (fn.asyncBody ?? fn)(...t.args);
+    this.preludeOrigin.push(this.originForNewFrame(fn));
+    try {
+      let result = await (fn.asyncBody ?? fn)(...args);
+      while (
+        result !== null &&
+        typeof result === "object" &&
+        (result as TailCall).__tail === true
+      ) {
+        const t = result as TailCall;
+        fn = this.checkCallable(t.f, t.args.length, false);
+        result = await (fn.asyncBody ?? fn)(...t.args);
+      }
+      return result === undefined ? null : (result as PyValue);
+    } finally {
+      this.preludeOrigin.pop();
     }
-    return result === undefined ? null : (result as PyValue);
   }
 
   /** Tail call marker: bounced on the caller's trampoline instead of growing the stack. */
@@ -947,6 +1043,7 @@ export class Py2JsRuntime {
     const f = fn as PyFunction;
     f.pyName = name;
     f.pyArity = arity;
+    if (this.compilingPrelude) f.pyPrelude = true;
     return f;
   }
 
@@ -983,6 +1080,7 @@ export class Py2JsRuntime {
   private builtin(name: string, arity: number, fn: (...args: PyValue[]) => PyValue): PyFunction {
     const f = this.def(name, arity, fn);
     f.pyBuiltin = true;
+    f.pyNative = true;
     return f;
   }
 
@@ -1060,6 +1158,7 @@ export class Py2JsRuntime {
         },
       );
       f.pyBuiltin = true;
+      f.pyNative = true;
       f.asyncOnly = true;
       return f;
     })(),

--- a/src/engines/py2js/runtime.ts
+++ b/src/engines/py2js/runtime.ts
@@ -200,11 +200,33 @@ export function pyTypeName(v: PyValue, sayPair = false): string {
   }
 }
 
-function unsupported(op: string, l: PyValue, r?: PyValue, sayPair = false): never {
+/**
+ * Prefixes `detail` with "in predefined function 'X': " when `enclosing` is set — the
+ * predefined (prelude) function whose own code is what tripped over a bad argument
+ * (py-slang#397), e.g. llist_ref(xs, False) fails because llist_ref's own `n == 0`
+ * comparison rejects a bool, not because of anything in a callback the student wrote.
+ * A free function, not a Py2JsRuntime method, since operator-error call sites like
+ * pyEquals/pyOrder/complexBinop below have no `this` to call enclosingPreludeFunction
+ * on themselves — their caller (binop, a method) computes it once and passes it down.
+ */
+function withEnclosingPredefinedFunction(detail: string, enclosing: string | undefined): string {
+  return enclosing ? `in predefined function '${enclosing}': ${detail}` : detail;
+}
+
+function unsupported(
+  op: string,
+  l: PyValue,
+  r?: PyValue,
+  sayPair = false,
+  enclosing?: string,
+): never {
   const rhs = r === undefined ? "" : ` and '${pyTypeName(r, sayPair)}'`;
   throw new Py2JsRuntimeError(
     "UnsupportedOperandTypeError",
-    `unsupported operand type(s) for ${op}: '${pyTypeName(l, sayPair)}'${rhs}`,
+    withEnclosingPredefinedFunction(
+      `unsupported operand type(s) for ${op}: '${pyTypeName(l, sayPair)}'${rhs}`,
+      enclosing,
+    ),
   );
 }
 
@@ -370,12 +392,12 @@ function isNaNValue(v: PyValue): boolean {
  * threading in src/engines/cse/operators.ts, re-checked at every level of
  * list/pair recursion, not just the top level.
  */
-function pyEquals(l: PyValue, r: PyValue, restrict: boolean): boolean {
+function pyEquals(l: PyValue, r: PyValue, restrict: boolean, enclosing?: string): boolean {
   if (restrict && (typeof l === "boolean" || typeof l === "function")) {
-    unsupported("==", l, r, restrict);
+    unsupported("==", l, r, restrict, enclosing);
   }
   if (restrict && (typeof r === "boolean" || typeof r === "function")) {
-    unsupported("==", l, r, restrict);
+    unsupported("==", l, r, restrict, enclosing);
   }
   // At chapter 3+, booleans compare as the ints they are (True == 1, False ==
   // 0.0) — mirrors asIntIfBool's use in CSE's structuralEquals. At chapter
@@ -432,7 +454,13 @@ function pyIdentical(l: PyValue, r: PyValue): boolean {
  * asIntIfBool's use in evaluateBinaryExpression). NaN is unordered: every
  * comparison is False.
  */
-function pyOrder(op: string, l: PyValue, r: PyValue, universal: boolean): boolean {
+function pyOrder(
+  op: string,
+  l: PyValue,
+  r: PyValue,
+  universal: boolean,
+  enclosing?: string,
+): boolean {
   // Gated on both operands already being bool-or-numeric — as in CSE — so an
   // unsupported comparison against some other type (e.g. `True < 'abc'`)
   // still reports 'bool', not 'int', in its error message below.
@@ -453,7 +481,7 @@ function pyOrder(op: string, l: PyValue, r: PyValue, universal: boolean): boolea
         return l >= r;
     }
   }
-  if (!isNum(l) || !isNum(r)) unsupported(op, l, r, !universal);
+  if (!isNum(l) || !isNum(r)) unsupported(op, l, r, !universal, enclosing);
   if ((typeof l === "number" && Number.isNaN(l)) || (typeof r === "number" && Number.isNaN(r))) {
     return false;
   }
@@ -470,8 +498,15 @@ function pyOrder(op: string, l: PyValue, r: PyValue, universal: boolean): boolea
   }
 }
 
-function complexBinop(op: string, l: PyValue, r: PyValue, sayPair: boolean): PyComplexNumber {
-  if (!isCoercibleToComplex(l) || !isCoercibleToComplex(r)) unsupported(op, l, r, sayPair);
+function complexBinop(
+  op: string,
+  l: PyValue,
+  r: PyValue,
+  sayPair: boolean,
+  enclosing?: string,
+): PyComplexNumber {
+  if (!isCoercibleToComplex(l) || !isCoercibleToComplex(r))
+    unsupported(op, l, r, sayPair, enclosing);
   const a = toComplex(l);
   const b = toComplex(r);
   switch (op) {
@@ -498,7 +533,7 @@ function complexBinop(op: string, l: PyValue, r: PyValue, sayPair: boolean): PyC
       }
     default:
       // %, // and every ordering operator are unsupported on complex operands
-      unsupported(op, l, r, sayPair);
+      unsupported(op, l, r, sayPair, enclosing);
   }
 }
 
@@ -713,25 +748,30 @@ export class Py2JsRuntime {
       }
     }
 
+    // Computed once, up front — passed down through every unsupported()-reaching
+    // path below (see that function's doc comment for why the free helpers it
+    // calls need this threaded in rather than looked up via `this`).
+    const enclosing = this.enclosingPreludeFunction();
+
     // Same dispatch order as evaluateBinaryExpression (cse/operators.ts):
     // equality first (it is total over the non-excluded §1 universe), then
     // ordering, then the complex branch, then None/string, then numerics.
     switch (op) {
       case "==":
-        return pyEquals(l, r, !this.universalEquality);
+        return pyEquals(l, r, !this.universalEquality, enclosing);
       case "!=":
-        return !pyEquals(l, r, !this.universalEquality);
+        return !pyEquals(l, r, !this.universalEquality, enclosing);
       case "<":
       case "<=":
       case ">":
       case ">=":
-        return pyOrder(op, l, r, this.universalEquality);
+        return pyOrder(op, l, r, this.universalEquality, enclosing);
       case "is":
       case "is not":
         // NoIsOperatorValidator (the resolver) already rejects this operator
         // at chapter 1-2; universalEquality false here is an independent
         // runtime backstop, matching the CSE machine's own variant gate.
-        if (!this.universalEquality) unsupported(op, l, r, !this.universalEquality);
+        if (!this.universalEquality) unsupported(op, l, r, !this.universalEquality, enclosing);
         return (op === "is not") !== pyIdentical(l, r);
     }
 
@@ -759,16 +799,16 @@ export class Py2JsRuntime {
     }
 
     if (isComplex(l) || isComplex(r)) {
-      return complexBinop(op, l, r, !this.universalEquality);
+      return complexBinop(op, l, r, !this.universalEquality, enclosing);
     }
 
     // String concatenation: str + str only.
     if (typeof l === "string" || typeof r === "string") {
       if (op === "+" && typeof l === "string" && typeof r === "string") return l + r;
-      unsupported(op, l, r, !this.universalEquality);
+      unsupported(op, l, r, !this.universalEquality, enclosing);
     }
 
-    if (!isNum(l) || !isNum(r)) unsupported(op, l, r, !this.universalEquality);
+    if (!isNum(l) || !isNum(r)) unsupported(op, l, r, !this.universalEquality, enclosing);
 
     // Mixed int/float (or float/float) arithmetic: coerce to float, as the CSE
     // machine does (with the same potential precision loss on huge ints).
@@ -799,25 +839,26 @@ export class Py2JsRuntime {
           );
         return a ** b;
       default:
-        unsupported(op, l, r, !this.universalEquality);
+        unsupported(op, l, r, !this.universalEquality, enclosing);
     }
   }
 
   unop(op: string, v: PyValue): PyValue {
     const sayPair = !this.universalEquality;
+    const enclosing = this.enclosingPreludeFunction();
     switch (op) {
       case "not":
-        if (typeof v !== "boolean") unsupported("not", v, undefined, sayPair);
+        if (typeof v !== "boolean") unsupported("not", v, undefined, sayPair, enclosing);
         return !v;
       case "-":
         if (typeof v === "bigint") return -v;
         if (typeof v === "number") return -v;
         if (isComplex(v)) return new PyComplexNumber(-v.real, -v.imag);
-        unsupported("-", v, undefined, sayPair);
+        unsupported("-", v, undefined, sayPair, enclosing);
         break;
       case "+":
         if (isNum(v) || isComplex(v)) return v;
-        unsupported("+", v, undefined, sayPair);
+        unsupported("+", v, undefined, sayPair, enclosing);
     }
     throw new Py2JsRuntimeError("UnsupportedOperandTypeError", `bad unary operator ${op}`);
   }
@@ -922,7 +963,8 @@ export class Py2JsRuntime {
 
   /** Left operand of and/or must be bool (mirrors the CSE BOOL_OP instruction). */
   boolLeft(v: PyValue, op: string): boolean {
-    if (typeof v !== "boolean") unsupported(op, v, undefined, !this.universalEquality);
+    if (typeof v !== "boolean")
+      unsupported(op, v, undefined, !this.universalEquality, this.enclosingPreludeFunction());
     return v;
   }
 
@@ -962,47 +1004,44 @@ export class Py2JsRuntime {
     }
   }
 
+  /**
+   * The enclosing-function naming below (py-slang#397) is called before the attempted
+   * call's own frame is pushed, so the current top of preludeOrigin is already the
+   * caller's — e.g. reduce(1, 2, xs) fails because reduce itself tries to call its
+   * non-callable first argument; the student never called anything literally named
+   * "reduce" wrongly, reduce did. Unlike stdlibBridge.ts's equivalent (which reads one
+   * frame later, from inside the already-pushed, already-failing call itself).
+   */
   private checkCallable(f: PyValue, nArgs: number, sync: boolean): PyFunction {
+    const enclosing = this.enclosingPreludeFunction();
     if (typeof f !== "function") {
       throw new Py2JsRuntimeError(
         "TypeError",
-        this.withEnclosingPredefinedFunction(
+        withEnclosingPredefinedFunction(
           `'${pyTypeName(f, !this.universalEquality)}' object is not callable`,
+          enclosing,
         ),
       );
     }
     if (f.pyArity >= 0 && f.pyArity !== nArgs) {
       throw new Py2JsRuntimeError(
         "TypeError",
-        this.withEnclosingPredefinedFunction(
+        withEnclosingPredefinedFunction(
           `${f.pyName}() takes ${f.pyArity} argument${f.pyArity === 1 ? "" : "s"} but ${nArgs} ${nArgs === 1 ? "was" : "were"} given`,
+          enclosing,
         ),
       );
     }
     if (sync && f.asyncOnly) {
       throw new Py2JsRuntimeError(
         "TypeError",
-        this.withEnclosingPredefinedFunction(
+        withEnclosingPredefinedFunction(
           `${f.pyName}() needs a frontend round-trip and cannot be called from a synchronous module callback`,
+          enclosing,
         ),
       );
     }
     return f;
-  }
-
-  /**
-   * Prefixes `detail` with "in predefined function 'X': " when the call currently being
-   * checked (about to run, not yet pushed onto preludeOrigin) was made from inside a
-   * predefined (prelude) function — e.g. reduce(1, 2, xs) fails because reduce itself
-   * tries to call its non-callable first argument; the student never called anything
-   * literally named "reduce" wrongly, reduce did (py-slang#397). Called before the
-   * attempted call's own frame is pushed, so the current top of preludeOrigin is
-   * already the caller's, unlike stdlibBridge.ts's equivalent (which reads one frame
-   * later, from inside the already-pushed, already-failing call itself).
-   */
-  private withEnclosingPredefinedFunction(detail: string): string {
-    const enclosing = this.enclosingPreludeFunction();
-    return enclosing ? `in predefined function '${enclosing}': ${detail}` : detail;
   }
 
   /** Non-tail call: run the trampoline until a real value comes back. */

--- a/src/engines/py2js/runtime.ts
+++ b/src/engines/py2js/runtime.ts
@@ -966,22 +966,43 @@ export class Py2JsRuntime {
     if (typeof f !== "function") {
       throw new Py2JsRuntimeError(
         "TypeError",
-        `'${pyTypeName(f, !this.universalEquality)}' object is not callable`,
+        this.withEnclosingPredefinedFunction(
+          `'${pyTypeName(f, !this.universalEquality)}' object is not callable`,
+        ),
       );
     }
     if (f.pyArity >= 0 && f.pyArity !== nArgs) {
       throw new Py2JsRuntimeError(
         "TypeError",
-        `${f.pyName}() takes ${f.pyArity} argument${f.pyArity === 1 ? "" : "s"} but ${nArgs} ${nArgs === 1 ? "was" : "were"} given`,
+        this.withEnclosingPredefinedFunction(
+          `${f.pyName}() takes ${f.pyArity} argument${f.pyArity === 1 ? "" : "s"} but ${nArgs} ${nArgs === 1 ? "was" : "were"} given`,
+        ),
       );
     }
     if (sync && f.asyncOnly) {
       throw new Py2JsRuntimeError(
         "TypeError",
-        `${f.pyName}() needs a frontend round-trip and cannot be called from a synchronous module callback`,
+        this.withEnclosingPredefinedFunction(
+          `${f.pyName}() needs a frontend round-trip and cannot be called from a synchronous module callback`,
+        ),
       );
     }
     return f;
+  }
+
+  /**
+   * Prefixes `detail` with "in predefined function 'X': " when the call currently being
+   * checked (about to run, not yet pushed onto preludeOrigin) was made from inside a
+   * predefined (prelude) function — e.g. reduce(1, 2, xs) fails because reduce itself
+   * tries to call its non-callable first argument; the student never called anything
+   * literally named "reduce" wrongly, reduce did (py-slang#397). Called before the
+   * attempted call's own frame is pushed, so the current top of preludeOrigin is
+   * already the caller's, unlike stdlibBridge.ts's equivalent (which reads one frame
+   * later, from inside the already-pushed, already-failing call itself).
+   */
+  private withEnclosingPredefinedFunction(detail: string): string {
+    const enclosing = this.enclosingPreludeFunction();
+    return enclosing ? `in predefined function '${enclosing}': ${detail}` : detail;
   }
 
   /** Non-tail call: run the trampoline until a real value comes back. */

--- a/src/engines/py2js/stdlibBridge.ts
+++ b/src/engines/py2js/stdlibBridge.ts
@@ -299,7 +299,15 @@ function bridgeBuiltin(
       // displayError falls back to a generic "Error" name for the same
       // reason), so the constructor is the only reliable source for it.
       if (e instanceof RuntimeSourceError) {
-        throw new Py2JsRuntimeError(e.constructor.name, e.message);
+        // The builtin itself is named in e.message already ("...for tail: ...");
+        // this instead names the *enclosing* predefined function, if any — e.g. a
+        // student calling map() never wrote or sees _map, the internal helper that
+        // actually calls tail() (py-slang#397).
+        const enclosing = rt.enclosingPreludeFunction();
+        const message = enclosing
+          ? `${e.message} (in predefined function '${enclosing}')`
+          : e.message;
+        throw new Py2JsRuntimeError(e.constructor.name, message);
       }
       throw e;
     }
@@ -312,6 +320,7 @@ function bridgeBuiltin(
     return result === undefined ? null : fromTagged(name, result);
   });
   f.pyBuiltin = true;
+  f.pyNative = true;
   f.pyMinArgs = builtin.minArgs;
   return f;
 }
@@ -341,6 +350,7 @@ function nativeSetPairSlot(name: string, index: 0 | 1, sayPair: boolean): PyFunc
   f.pyName = name;
   f.pyArity = 2;
   f.pyBuiltin = true;
+  f.pyNative = true;
   f.pyMinArgs = 2;
   return f;
 }
@@ -366,12 +376,14 @@ function nativeStream(rt: Py2JsRuntime): PyFunction {
     if (index >= args.length) return null;
     const tail = rt.def("anonymous stream", 0, () => build(args, index + 1));
     tail.pyBuiltin = true;
+    tail.pyNative = true;
     return [args[index], tail];
   };
   const f = ((...args: PyValue[]) => build(args, 0)) as PyFunction;
   f.pyName = "stream";
   f.pyArity = -1;
   f.pyBuiltin = true;
+  f.pyNative = true;
   f.pyMinArgs = 0;
   return f;
 }
@@ -424,6 +436,7 @@ function nativeApplyInUnderlyingPython(rt: Py2JsRuntime): PyFunction {
   f.pyName = "apply_in_underlying_python";
   f.pyArity = 2;
   f.pyBuiltin = true;
+  f.pyNative = true;
   f.pyMinArgs = 2;
   return f;
 }
@@ -463,6 +476,7 @@ function nativeDrawData(plugin: BaseDataVisualizerRunnerPlugin<PyValue> | undefi
   f.pyName = "draw_data";
   f.pyArity = -1;
   f.pyBuiltin = true;
+  f.pyNative = true;
   f.pyMinArgs = 1;
   return f;
 }

--- a/src/engines/py2js/stdlibBridge.ts
+++ b/src/engines/py2js/stdlibBridge.ts
@@ -306,7 +306,11 @@ function bridgeBuiltin(
         // prefix ("TypeError: ") rather than appended, so the most actionable fact —
         // *which* call the student actually wrote led here — reads first, matching
         // how a Python traceback lists the outer frame before the innermost error.
-        const enclosing = rt.enclosingPreludeFunction();
+        //
+        // Except error(): that's how a prelude author writes a fully custom message —
+        // llist_ref's own error("llist_ref: index out of bounds") already names itself,
+        // so attributing it too would say "llist_ref" twice.
+        const enclosing = name === "error" ? undefined : rt.enclosingPreludeFunction();
         let message = e.message;
         if (enclosing) {
           // Detected from the message's own text ("TypeError: ...", "ValueError: ..."),

--- a/src/engines/py2js/stdlibBridge.ts
+++ b/src/engines/py2js/stdlibBridge.ts
@@ -302,11 +302,22 @@ function bridgeBuiltin(
         // The builtin itself is named in e.message already ("...for tail: ...");
         // this instead names the *enclosing* predefined function, if any — e.g. a
         // student calling map() never wrote or sees _map, the internal helper that
-        // actually calls tail() (py-slang#397).
+        // actually calls tail() (py-slang#397). Inserted right after the error-name
+        // prefix ("TypeError: ") rather than appended, so the most actionable fact —
+        // *which* call the student actually wrote led here — reads first, matching
+        // how a Python traceback lists the outer frame before the innermost error.
         const enclosing = rt.enclosingPreludeFunction();
-        const message = enclosing
-          ? `${e.message} (in predefined function '${enclosing}')`
-          : e.message;
+        let message = e.message;
+        if (enclosing) {
+          // Detected from the message's own text ("TypeError: ...", "ValueError: ..."),
+          // not e.constructor.name — a minified production build mangles class names,
+          // but every RuntimeSourceError subclass bakes its own error-kind word as a
+          // literal string into the message itself, so this survives minification.
+          const match = message.match(/^([A-Za-z]+): /);
+          message = match
+            ? `${match[0]}in predefined function '${enclosing}': ${message.slice(match[0].length)}`
+            : `in predefined function '${enclosing}': ${message}`;
+        }
         throw new Py2JsRuntimeError(e.constructor.name, message);
       }
       throw e;

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -453,18 +453,28 @@ export class ValueError extends RuntimeSourceError {
   constructor(source: string, node: ExprNS.Expr, context: Context, functionName: string) {
     super(node);
     this.type = ErrorType.TYPE;
+    const hint = "ValueError: math domain error. ";
+    const suggestion = `Ensure that the input value(s) passed to '${functionName}' satisfy the mathematical requirements`;
+
+    // py-slang#397: a synthetic token (e.g. py2js's bridged-builtin call site — see
+    // stdlibBridge.ts's syntheticCallNode) carries no real position, only a hardcoded
+    // placeholder — showing "at line 1" would be actively misleading, so skip the
+    // location header/snippet entirely when the position isn't real.
+    if (node.startToken.synthetic) {
+      this.message = hint + suggestion;
+      return;
+    }
+
     const index = node.startToken.indexInSource;
     const { lineIndex, fullLine } = getFullLine(source, index);
     const snippet = source.substring(
       node.startToken.indexInSource,
       node.endToken.indexInSource + node.endToken.lexeme.length,
     );
-    const hint = "ValueError: math domain error. ";
     const offset = fullLine.indexOf(snippet);
     const errorPos = 0;
     const indicator = createErrorIndicator(snippet, errorPos);
     const name = "ValueError";
-    const suggestion = `Ensure that the input value(s) passed to '${functionName}' satisfy the mathematical requirements`;
     const msg =
       name +
       " at line " +
@@ -491,12 +501,6 @@ export class TypeError extends RuntimeSourceError {
     super(node);
     const typeStr = friendlyTypeName(typeTranslator(originalType), context.variant);
     this.type = ErrorType.TYPE;
-    const index = node.startToken.indexInSource;
-    const { lineIndex, fullLine } = getFullLine(source, index);
-    const snippet = source.substring(
-      node.startToken.indexInSource,
-      node.endToken.indexInSource + node.endToken.lexeme.length,
-    );
     // Almost every call site is a builtin call (math_sin(x), tail(xs), ...) —
     // name it after the callee the user actually wrote, matching
     // UnsupportedOperandTypeError's "unsupported operand type(s) for +: ..."
@@ -522,6 +526,22 @@ export class TypeError extends RuntimeSourceError {
         ? (callNode.callee.name?.lexeme ?? "subscript assignment")
         : "subscript assignment";
     const hint = `TypeError: unsupported argument type for ${subject}: ${typeStr}`;
+
+    // py-slang#397: a synthetic token (e.g. py2js's bridged-builtin call site — see
+    // stdlibBridge.ts's syntheticCallNode) carries no real position, only a hardcoded
+    // placeholder — showing "at line 1" would be actively misleading, so skip the
+    // location header/snippet entirely when the position isn't real.
+    if (node.startToken.synthetic) {
+      this.message = hint;
+      return;
+    }
+
+    const index = node.startToken.indexInSource;
+    const { lineIndex, fullLine } = getFullLine(source, index);
+    const snippet = source.substring(
+      node.startToken.indexInSource,
+      node.endToken.indexInSource + node.endToken.lexeme.length,
+    );
     const offset = fullLine.indexOf(snippet);
     const adjustedOffset = offset >= 0 ? offset : 0;
     const errorPos = 0;

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -245,19 +245,14 @@ export class MissingRequiredPositionalError extends RuntimeSourceError {
     if (variadic) {
       adverb = "at least";
     }
-    const index = node.startToken.indexInSource;
-    const { lineIndex, fullLine } = getFullLine(source, index);
-    this.message = "TypeError at line " + lineIndex + "\n\n    " + fullLine + "\n";
 
+    let detail: string;
     if (typeof params === "number") {
       this.missingParamCnt = params;
       this.missingParamName = "";
       const givenParamCnt = args.length;
-      if (this.missingParamCnt === 1 || this.missingParamCnt === 0) {
-      }
-      const msg = `TypeError: ${this.functionName}() takes ${adverb} ${this.missingParamCnt} argument (${givenParamCnt} given)
+      detail = `TypeError: ${this.functionName}() takes ${adverb} ${this.missingParamCnt} argument (${givenParamCnt} given)
 Check the function definition of '${this.functionName}' and make sure to provide all required positional arguments in the correct order.`;
-      this.message += msg;
     } else {
       this.missingParamCnt = params.length - args.length;
       const missingNames: string[] = [];
@@ -266,10 +261,20 @@ Check the function definition of '${this.functionName}' and make sure to provide
         missingNames.push("\'" + param + "\'");
       }
       this.missingParamName = this.joinWithCommasAndAnd(missingNames);
-      const msg = `TypeError: ${this.functionName}() missing ${this.missingParamCnt} required positional argument(s): ${this.missingParamName}
+      detail = `TypeError: ${this.functionName}() missing ${this.missingParamCnt} required positional argument(s): ${this.missingParamName}
 You called ${this.functionName}() without providing the required positional argument ${this.missingParamName}. Make sure to pass all required arguments when calling ${this.functionName}.`;
-      this.message += msg;
     }
+
+    // py-slang#397: skip the fabricated "at line 1" header for a synthetic (no real
+    // position) token — see TypeError/ValueError's identical check above.
+    if (node.startToken.synthetic) {
+      this.message = detail;
+      return;
+    }
+
+    const index = node.startToken.indexInSource;
+    const { lineIndex, fullLine } = getFullLine(source, index);
+    this.message = "TypeError at line " + lineIndex + "\n\n    " + fullLine + "\n" + detail;
   }
 
   private joinWithCommasAndAnd(names: string[]): string {
@@ -307,29 +312,34 @@ export class TooManyPositionalArgumentsError extends RuntimeSourceError {
       adverb = "at most";
     }
 
-    const index = node.startToken.indexInSource;
-    const { lineIndex, fullLine } = getFullLine(source, index);
-    this.message = "TypeError at line " + lineIndex + "\n\n    " + fullLine + "\n";
-
+    let detail: string;
     if (typeof params === "number") {
       this.expectedCount = params;
       this.givenCount = args.length;
-      if (this.expectedCount === 1 || this.expectedCount === 0) {
-        this.message += `TypeError: ${this.functionName}() takes ${adverb} ${this.expectedCount} argument (${this.givenCount} given)`;
-      } else {
-        this.message += `TypeError: ${this.functionName}() takes ${adverb} ${this.expectedCount} arguments (${this.givenCount} given)`;
-      }
+      detail =
+        this.expectedCount === 1 || this.expectedCount === 0
+          ? `TypeError: ${this.functionName}() takes ${adverb} ${this.expectedCount} argument (${this.givenCount} given)`
+          : `TypeError: ${this.functionName}() takes ${adverb} ${this.expectedCount} arguments (${this.givenCount} given)`;
     } else {
       this.expectedCount = params.length;
       this.givenCount = args.length;
-      if (this.expectedCount === 1 || this.expectedCount === 0) {
-        this.message += `TypeError: ${this.functionName}() takes ${this.expectedCount} positional argument but ${this.givenCount} were given`;
-      } else {
-        this.message += `TypeError: ${this.functionName}() takes ${this.expectedCount} positional arguments but ${this.givenCount} were given`;
-      }
+      detail =
+        this.expectedCount === 1 || this.expectedCount === 0
+          ? `TypeError: ${this.functionName}() takes ${this.expectedCount} positional argument but ${this.givenCount} were given`
+          : `TypeError: ${this.functionName}() takes ${this.expectedCount} positional arguments but ${this.givenCount} were given`;
+    }
+    detail += `\nRemove the extra argument(s) when calling '${this.functionName}', or check if the function definition accepts more arguments.`;
+
+    // py-slang#397: skip the fabricated "at line 1" header for a synthetic (no real
+    // position) token — see TypeError/ValueError's identical check above.
+    if (node.startToken.synthetic) {
+      this.message = detail;
+      return;
     }
 
-    this.message += `\nRemove the extra argument(s) when calling '${this.functionName}', or check if the function definition accepts more arguments.`;
+    const index = node.startToken.indexInSource;
+    const { lineIndex, fullLine } = getFullLine(source, index);
+    this.message = "TypeError at line " + lineIndex + "\n\n    " + fullLine + "\n" + detail;
   }
 }
 

--- a/src/tests/py2js-stdlib-error-bridge.test.ts
+++ b/src/tests/py2js-stdlib-error-bridge.test.ts
@@ -7,7 +7,7 @@
  * Error` check up the call chain unless bridgeBuiltin converts them at the
  * boundary where they actually originate.
  */
-import { runCodePy2Js } from "../engines/py2js";
+import { runCodePy2Js, Py2JsSession } from "../engines/py2js";
 
 test("tail() on a non-pair surfaces a real TypeError, not [object Object]", () => {
   expect(() => runCodePy2Js("print(tail(5))", 2)).toThrow(
@@ -114,5 +114,21 @@ describe("py-slang#397: no fabricated line number, name the enclosing predefined
       message = (e as Error).message;
     }
     expect(message).not.toMatch(/predefined function/);
+  });
+
+  // Py2JsSession (what the conductor evaluator actually uses for the Playground)
+  // loads the stdlib prelude through its own runChunk, a separate code path from
+  // setupRuntime's one-shot prelude load that runCodePy2Js/runCodePy2JsDual use —
+  // each needs its own compilingPrelude wrapping, or prelude functions loaded via
+  // a session never get tagged pyPrelude and this attribution silently never fires.
+  test("Py2JsSession also names the enclosing predefined function", async () => {
+    const session = new Py2JsSession(2);
+    let message = "";
+    try {
+      await session.runChunk("map(1, 2)");
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toMatch(/in predefined function 'map'/);
   });
 });

--- a/src/tests/py2js-stdlib-error-bridge.test.ts
+++ b/src/tests/py2js-stdlib-error-bridge.test.ts
@@ -180,4 +180,33 @@ describe("py-slang#397: no fabricated line number, name the enclosing predefined
       "TypeError: math_acos() takes exactly 1 argument (0 given)\nCheck the function definition of 'math_acos' and make sure to provide all required positional arguments in the correct order.",
     );
   });
+
+  // A third distinct error path: llist_ref's own `n == 0` comparison (a binary
+  // operator, evaluated inline in compiled code — not a builtin call, not
+  // checkCallable) rejects a bool argument the student passed in. binop/unop and
+  // the free helpers they delegate to (pyEquals/pyOrder/complexBinop) didn't carry
+  // enclosing-function context at all until this was added.
+  test("llist_ref(xs, False) names llist_ref — the bug is in llist_ref's own comparison", () => {
+    let message = "";
+    try {
+      runCodePy2Js("print(llist_ref(llist(1, 2, 3), False))", 2);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toBe(
+      "UnsupportedOperandTypeError: in predefined function 'llist_ref': unsupported operand type(s) for ==: 'bool' and 'int'",
+    );
+  });
+
+  test("an operator error inside the student's own callback is still never blamed on filter", () => {
+    let message = "";
+    try {
+      runCodePy2Js("filter(lambda x: 1 * True, llist(1, 2, 3))", 2);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toBe(
+      "UnsupportedOperandTypeError: unsupported operand type(s) for *: 'int' and 'bool'",
+    );
+  });
 });

--- a/src/tests/py2js-stdlib-error-bridge.test.ts
+++ b/src/tests/py2js-stdlib-error-bridge.test.ts
@@ -150,4 +150,34 @@ describe("py-slang#397: no fabricated line number, name the enclosing predefined
       "TypeError: in predefined function 'reduce': 'int' object is not callable",
     );
   });
+
+  // MissingRequiredPositionalError/TooManyPositionalArgumentsError (the Validate
+  // decorator's arity checks — src/stdlib/utils.ts, shared by every @Validate-annotated
+  // stdlib builtin) were missed by the original synthetic-token fix above: they build
+  // their own "TypeError at line X" header independently of TypeError/ValueError, so
+  // an arity mismatch calling *any* stdlib builtin via py2js — math_acos(2, 3, 4),
+  // tail(1, 2), etc. — still showed the fabricated line number until this was added.
+  test("too many arguments to a stdlib builtin has no fabricated line number", () => {
+    let message = "";
+    try {
+      runCodePy2Js("\n\nmath_acos(2, 3, 4)", 2);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toBe(
+      "TypeError: math_acos() takes exactly 1 argument (3 given)\nRemove the extra argument(s) when calling 'math_acos', or check if the function definition accepts more arguments.",
+    );
+  });
+
+  test("a missing argument to a stdlib builtin has no fabricated line number", () => {
+    let message = "";
+    try {
+      runCodePy2Js("\n\nmath_acos()", 2);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toBe(
+      "TypeError: math_acos() takes exactly 1 argument (0 given)\nCheck the function definition of 'math_acos' and make sure to provide all required positional arguments in the correct order.",
+    );
+  });
 });

--- a/src/tests/py2js-stdlib-error-bridge.test.ts
+++ b/src/tests/py2js-stdlib-error-bridge.test.ts
@@ -209,4 +209,17 @@ describe("py-slang#397: no fabricated line number, name the enclosing predefined
       "UnsupportedOperandTypeError: unsupported operand type(s) for *: 'int' and 'bool'",
     );
   });
+
+  // error() is how a prelude author writes a fully custom, already-self-naming message
+  // (llist_ref's own error("llist_ref: index out of bounds")) — attributing it too would
+  // say "llist_ref" twice ("in predefined function 'llist_ref': llist_ref: ...").
+  test("error() calls are exempt from attribution — the message already names itself", () => {
+    let message = "";
+    try {
+      runCodePy2Js("print(llist_ref(llist(1, 2), 5))", 2);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toBe("Error: llist_ref: index out of bounds\n");
+  });
 });

--- a/src/tests/py2js-stdlib-error-bridge.test.ts
+++ b/src/tests/py2js-stdlib-error-bridge.test.ts
@@ -31,3 +31,69 @@ test("the thrown error's message is never the literal string [object Object]", (
   expect(caught).toBeInstanceOf(Error);
   expect((caught as Error).message).not.toBe("[object Object]");
 });
+
+/**
+ * py-slang#397: bridged builtins raise using a synthetic call-site token (see
+ * stdlibBridge.ts's syntheticCallNode) with no real source position, so the
+ * TypeError/ValueError location header ("at line 1\n\n...") errors.ts would
+ * otherwise print is not just imprecise, it's actively wrong — always
+ * reporting a placeholder near the top of the file regardless of where the
+ * call actually happened. Two independent lines of defense here: never print
+ * a fabricated location at all, and where possible name the enclosing
+ * predefined (prelude) function instead, so "unsupported argument type for
+ * tail" at least says *which* library call the student wrote led there.
+ */
+describe("py-slang#397: no fabricated line number, name the enclosing predefined function", () => {
+  test("a leading blank line before the call does not produce a wrong line number", () => {
+    let message = "";
+    try {
+      runCodePy2Js("\n\n\ntail(0)", 2);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).not.toMatch(/at line/);
+    expect(message).toMatch(/unsupported argument type for tail/);
+  });
+
+  test("a ValueError also has no fabricated line number", () => {
+    let message = "";
+    try {
+      runCodePy2Js("\n\nmath_sqrt(-1)", 2);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).not.toMatch(/at line/);
+    expect(message).toMatch(/math domain error/);
+  });
+
+  test("tail() failing inside map()'s own internal helper names map, not the helper", () => {
+    let message = "";
+    try {
+      runCodePy2Js("map(print, 0)", 2);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toMatch(/in predefined function 'map'/);
+    expect(message).not.toMatch(/_map/);
+  });
+
+  test("a builtin called directly at the top level names no enclosing function", () => {
+    let message = "";
+    try {
+      runCodePy2Js("tail(0)", 2);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).not.toMatch(/predefined function/);
+  });
+
+  test("an error inside the student's own callback is never blamed on map", () => {
+    let message = "";
+    try {
+      runCodePy2Js("def bad(x):\n    return tail(x)\nmap(bad, pair(1, None))", 2);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).not.toMatch(/predefined function/);
+  });
+});

--- a/src/tests/py2js-stdlib-error-bridge.test.ts
+++ b/src/tests/py2js-stdlib-error-bridge.test.ts
@@ -92,8 +92,11 @@ describe("py-slang#397: no fabricated line number, name the enclosing predefined
     } catch (e) {
       message = (e as Error).message;
     }
-    expect(message).toMatch(/in predefined function 'map'/);
-    expect(message).not.toMatch(/_map/);
+    // Right after the error-name prefix, not appended — the most actionable fact
+    // (which call the student wrote led here) reads first, Python-traceback-style.
+    expect(message).toBe(
+      "TypeError: in predefined function 'map': unsupported argument type for tail: integer",
+    );
   });
 
   test("a builtin called directly at the top level names no enclosing function", () => {
@@ -130,5 +133,21 @@ describe("py-slang#397: no fabricated line number, name the enclosing predefined
       message = (e as Error).message;
     }
     expect(message).toMatch(/in predefined function 'map'/);
+  });
+
+  // A different code path entirely: reduce(f, ...) calling its own non-callable f
+  // argument raises through Py2JsRuntime.checkCallable directly (runtime.ts), not
+  // through the CSE-bridged stdlib errors.ts covers above. Same underlying fix
+  // (enclosingPreludeFunction), applied at the other place py2js raises errors.
+  test("reduce() calling a non-callable f names reduce, not a bare 'not callable'", () => {
+    let message = "";
+    try {
+      runCodePy2Js("print(reduce(1, 2, llist(12, 2, 3)))", 2);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toBe(
+      "TypeError: in predefined function 'reduce': 'int' object is not callable",
+    );
   });
 });

--- a/src/tests/py2js-stdlib-error-bridge.test.ts
+++ b/src/tests/py2js-stdlib-error-bridge.test.ts
@@ -66,6 +66,25 @@ describe("py-slang#397: no fabricated line number, name the enclosing predefined
     expect(message).toMatch(/math domain error/);
   });
 
+  // Pre-existing crash on main, incidentally fixed by the same synthetic-token check:
+  // ValueError's location header did `" ".repeat(offset)`, and offset is -1 whenever
+  // fullLine.indexOf(snippet) can't find the (synthetic, not-really-there) snippet in
+  // the line it's pointing at — String#repeat throws RangeError on a negative count,
+  // so a ValueError-raising builtin like math_sqrt crashed with a raw JS RangeError
+  // instead of ever producing a Python-style error at all.
+  test("math_sqrt(-1) raises a real ValueError, not a raw JS RangeError", () => {
+    let caught: unknown;
+    try {
+      runCodePy2Js("math_sqrt(-1)", 2);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).name).not.toBe("RangeError");
+    expect((caught as Error).message).not.toMatch(/Invalid count value/);
+    expect((caught as Error).message).toMatch(/math domain error/);
+  });
+
   test("tail() failing inside map()'s own internal helper names map, not the helper", () => {
     let message = "";
     try {


### PR DESCRIPTION
## Summary

py2js only (per discussion on #397 — CSE's error location has a different, separate root cause and is out of scope here).

- **Stop printing a fabricated line number.** py2js's bridged stdlib builtins (`tail`, `head`, `math_sqrt`, ...) raise using a synthetic call-site token with no real source position (`stdlibBridge.ts`'s `syntheticCallNode` is hardcoded to line 1, index 0). `errors.ts`'s `TypeError`/`ValueError` unconditionally printed `"<Name> at line X"` plus a code-frame snippet computed from that fake position — actively misleading (the reported line depended on unrelated things, like how many blank lines happened to precede the call), not just imprecise. Both classes now check the token's existing `synthetic` flag (already used elsewhere to mean "this position is fabricated, don't trust it") and skip the location header entirely when set, leaving just the plain hint message.
- **Name the enclosing predefined function instead.** Since a real position isn't available, the next best thing: which predefined (prelude) function was the failing builtin called from? `tail()` failing partway through `map()`'s own internal `_map` helper now says `TypeError: in predefined function 'map': unsupported argument type for tail: integer` — the attribution leads, Python-traceback-style (outer frame first, innermost error last), rather than trailing as a parenthetical.

  Implementation, in `Py2JsRuntime`:
  - Every function is tagged `pyPrelude` (compiled from a stdlib group's own prelude source, e.g. `linked-list.prelude.ts`) or `pyNative` (a bridged/native builtin) at creation.
  - `call()`/`acall()` maintain, per currently-executing frame, which predefined function (if any) it's logically nested inside of. This is deliberately **not** recomputed on a tail-call bounce — TCO means "the same logical frame, a different function now running in it" (`map` tail-calling into `_map` is exactly this), so the frame's already-resolved origin must survive the bounce.
  - A native builtin transparently passes its caller's origin through (it's a leaf operation, never itself a boundary). A genuine user-defined function is always a hard boundary and resets it to nothing — so an error inside a student's *own* callback passed to `map()` is never misattributed to `map` itself.
  - Extended to `Py2JsRuntime.checkCallable` too — a separate error path from the CSE-bridged stdlib: `reduce(1, 2, xs)` fails because `reduce` itself tries to call its own non-callable first argument, raised directly with no `errors.ts` involved at all. Same underlying fix, applied at the other place py2js raises errors.
  - `Py2JsSession` — what the conductor evaluator actually uses for the browser Playground — loads the stdlib prelude through its own `runChunk`, a separate code path from the one-shot prelude load `runCodePy2Js`/`runCodePy2JsDual` use. Needed its own `compilingPrelude` wrapping; without it the attribution silently never fired for any real browser session (caught by demoing the fix live against sourceacademy.org).

- **Bonus fix, found while comparing against #398**: `math_sqrt(-1)` (and any other `ValueError`-raising builtin called via py2js) used to crash with a raw JS `RangeError: Invalid count value: -1` instead of ever producing a Python-style error — `ValueError`'s location header did `" ".repeat(offset)`, and `offset` is `-1` whenever `fullLine.indexOf(snippet)` can't find the synthetic, not-really-there snippet. Pre-existing on `main`, unrelated to #398; the same synthetic-token early return above fixes it as a side effect.

- **Minification fragility, also found by demoing live**: the prefix-detection above initially compared against `e.constructor.name` to find the existing "TypeError: " etc. prefix — which a minified production build mangles (unlike dev/test builds), so it silently never matched in the real deployed bundle, producing `"in predefined function 'map': TypeError: ..."` (wrong order) instead of `"TypeError: in predefined function 'map': ..."`. Fixed by detecting the prefix from the message's own literal text instead of the (possibly-mangled) class name. `index.ts`'s separate `Py2JsRunError` wrapping (`${e.name}: ${e.message}`) had the same fragility and, pre-existing, doubled the prefix (`"TypeError: TypeError: ..."`) for any already-prefixed message — extracted into a shared `formatCaughtError()` with the same content-based detection.

- **Two more errors.ts classes missed by the original fix, also found live**: `MissingRequiredPositionalError`/`TooManyPositionalArgumentsError` — the `Validate` decorator's arity checks (`src/stdlib/utils.ts`, shared by every `@Validate`-annotated stdlib builtin) — build their own `"TypeError at line X"` header independently of `TypeError`/`ValueError`, so they weren't covered by the original synthetic-token check. An arity mismatch calling *any* stdlib builtin via py2js (`math_acos(2, 3, 4)`, `tail(1, 2)`, a missing argument, ...) still showed the fabricated line number. Same fix applied: skip the header when the token is synthetic.

- **Extended to operator errors (`binop`/`unop`)**: `llist_ref(xs, False)` fails because `llist_ref`'s own `n == 0` comparison rejects a bool — a third distinct error path (not a bridged stdlib call, not `checkCallable`, a binary operator evaluated inline in compiled code). `binop`/`unop` now compute `enclosingPreludeFunction()` once and thread it as an explicit parameter through `unsupported()` and the free helpers it delegates to (`pyEquals`/`pyOrder`/`complexBinop`, which have no `this` to call it on themselves). Audited every other `Py2JsRuntimeError` throw site in `runtime.ts` (subscripting, `range()`, `assert`, name-resolution errors) — none of the rest are reachable from any prelude function's own source, so extending them further wouldn't fire in practice.

- **`error()` is exempt from the attribution**: it's how a prelude author writes a fully custom, already-self-naming message (`llist_ref`'s own `error("llist_ref: index out of bounds")`) — attributing it too said the function's name twice.

## Test plan
- [x] `npx tsc --noEmit -p .`
- [x] `npx eslint` (no new warnings/errors)
- [x] `npx prettier --list-different` (clean)
- [x] `npx jest src/tests/py2js-stdlib-error-bridge.test.ts` — 16/16
- [x] Full py2js suite: `npx jest --testPathPattern="py2js"` — 5053/5053 (includes the exhaustive operator × type conformance sweep, given this touches `binop`/`unop`)
- [x] Full suite: `npx jest` — 19599/19599
- [x] Verified live against `sourceacademy.org` with a locally-built, locally-served evaluator bundle (via a local `language-directory` override) — confirmed `map(1, 2)`, `reduce(1, 2, llist(12, 2, 3))`, `math_acos(2, 3, 4)`, and `llist_ref(llist(1, 2), 5)` all produce correct, non-fabricated, non-redundant messages through the actual conductor evaluator path, not just the standalone test helpers

Fixes #397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

